### PR TITLE
Fix code review issues from Phase 1 IR Foundation

### DIFF
--- a/llvm-ir-parser/src/parser.rs
+++ b/llvm-ir-parser/src/parser.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use llvm_ir::{
     Context, Module, Function, BasicBlock, Instruction, InstrKind,
-    TypeId, BlockId, ArgId, ConstId, ValueRef,
+    TypeId, BlockId, ArgId, ConstId, GlobalId, ValueRef,
     FloatKind,
     ConstantData,
     Argument, GlobalVariable, Linkage,
@@ -214,7 +214,7 @@ impl<'src> Parser<'src> {
             Token::Kw(Keyword::Double) => { self.lex.next()?; self.ctx.f64_ty }
             Token::Kw(Keyword::Fp128)  => { self.lex.next()?; self.ctx.mk_float(FloatKind::Fp128) }
             Token::Kw(Keyword::X86Fp80)=> { self.lex.next()?; self.ctx.mk_float(FloatKind::X86Fp80) }
-            Token::Kw(Keyword::Label)  => { self.lex.next()?; self.ctx.mk_int(0) /* placeholder */ }
+            Token::Kw(Keyword::Label)  => { self.lex.next()?; self.ctx.label_ty }
             Token::Kw(Keyword::Ptr)    => { self.lex.next()?; self.ctx.ptr_ty }
             Token::IntType(bits) => {
                 let b = *bits;
@@ -285,6 +285,7 @@ impl<'src> Parser<'src> {
         Ok((fields, packed))
     }
 
+    #[allow(dead_code)]
     fn parse_function_type(&mut self, ret: TypeId) -> Result<TypeId, ParseError> {
         self.lex.expect(&Token::LParen)?;
         let mut params = Vec::new();
@@ -428,7 +429,7 @@ impl<'src> Parser<'src> {
             _ => "entry".to_string(),
         };
 
-        let fid = self.current_func.expect("no current function");
+        let fid = self.current_func.ok_or_else(|| self.err("block outside function"))?;
         let func = &mut self.module.functions[fid];
 
         // Reuse pre-allocated BlockId if this block was forward-referenced.
@@ -476,7 +477,8 @@ impl<'src> Parser<'src> {
     // -----------------------------------------------------------------------
 
     fn parse_instruction(&mut self, bid: BlockId) -> Result<(), ParseError> {
-        let fid = self.current_func.expect("no current function");
+        let fid = self.current_func
+            .ok_or_else(|| self.err("instruction outside function"))?;
 
         // Parse optional result assignment: `%name = ` or `%N = `.
         let (result_name, result_slot) = match self.lex.peek()? {
@@ -1117,27 +1119,40 @@ impl<'src> Parser<'src> {
                 return Ok(v);
             }
         }
-        Err(ParseError { line: 0, col: 0, message: format!("undefined local value '%{}'", name) })
+        Err(ParseError {
+            line: self.lex.current_line(),
+            col:  self.lex.current_col(),
+            message: format!("undefined local value '%{}'", name),
+        })
     }
 
     fn resolve_global_ref(&mut self, name: &str) -> Result<ValueRef, ParseError> {
-        // Look up in module globals and functions.
-        if let Some(gid) = self.module.get_global_id(name) {
-            let ptr_ty = self.ctx.ptr_ty;
-            let c = self.ctx.push_const(ConstantData::GlobalRef { ty: ptr_ty, id: gid });
-            return Ok(ValueRef::Constant(c));
-        }
-        if let Some(_fid) = self.module.get_function_id(name) {
-            // Return a function pointer constant.
-            let ptr_ty = self.ctx.ptr_ty;
-            // We don't have a dedicated function-pointer variant; use GlobalRef with GlobalId(fid.0).
-            // For now, just produce a pointer constant.
-            let c = self.ctx.const_null(ptr_ty);
-            return Ok(ValueRef::Constant(c));
-        }
-        // Unknown global — create a null constant as a placeholder.
         let ptr_ty = self.ctx.ptr_ty;
-        let c = self.ctx.const_null(ptr_ty);
+        // Look up in module globals first.
+        if let Some(gid) = self.module.get_global_id(name) {
+            let c = self.ctx.push_const(ConstantData::GlobalRef {
+                ty: ptr_ty,
+                id: gid,
+                name: name.to_string(),
+            });
+            return Ok(ValueRef::Constant(c));
+        }
+        // Functions are also referenced by @name (as function pointers / callees).
+        // Use GlobalId::MAX as a sentinel meaning "function reference".
+        if self.module.get_function_id(name).is_some() {
+            let c = self.ctx.push_const(ConstantData::GlobalRef {
+                ty: ptr_ty,
+                id: GlobalId(u32::MAX),
+                name: name.to_string(),
+            });
+            return Ok(ValueRef::Constant(c));
+        }
+        // Forward/unknown reference — record name for future resolution.
+        let c = self.ctx.push_const(ConstantData::GlobalRef {
+            ty: ptr_ty,
+            id: GlobalId(u32::MAX),
+            name: name.to_string(),
+        });
         Ok(ValueRef::Constant(c))
     }
 
@@ -1162,7 +1177,7 @@ impl<'src> Parser<'src> {
     }
 
     fn get_or_create_block(&mut self, name: &str) -> Result<BlockId, ParseError> {
-        let fid = self.current_func.expect("no current function");
+        let fid = self.current_func.ok_or_else(|| self.err("block reference outside function"))?;
         if let Some(&bid) = self.pending_blocks.get(name) {
             return Ok(bid);
         }
@@ -1371,7 +1386,7 @@ entry:
   ret void
 }
 "#;
-        let (ctx, module) = parse(src).expect("parse failed");
+        let (_ctx, module) = parse(src).expect("parse failed");
         assert_eq!(module.functions.len(), 1);
         let f = &module.functions[0];
         assert_eq!(f.name, "empty");
@@ -1389,7 +1404,7 @@ entry:
   ret i32 %result
 }
 "#;
-        let (ctx, module) = parse(src).expect("parse failed");
+        let (_ctx, module) = parse(src).expect("parse failed");
         let f = &module.functions[0];
         assert_eq!(f.name, "add");
         assert_eq!(f.args.len(), 2);
@@ -1401,7 +1416,7 @@ entry:
     #[test]
     fn parse_declaration() {
         let src = "declare i32 @printf(ptr, ...)";
-        let (ctx, module) = parse(src).expect("parse failed");
+        let (_ctx, module) = parse(src).expect("parse failed");
         assert_eq!(module.functions.len(), 1);
         assert!(module.functions[0].is_declaration);
     }
@@ -1438,7 +1453,7 @@ else:
   ret void
 }
 "#;
-        let (ctx, module) = parse(src).expect("parse failed");
+        let (_ctx, module) = parse(src).expect("parse failed");
         let f = &module.functions[0];
         assert_eq!(f.blocks.len(), 3);
     }

--- a/llvm-ir-parser/tests/parse_basic.rs
+++ b/llvm-ir-parser/tests/parse_basic.rs
@@ -158,7 +158,7 @@ fn parse_named_struct() {
     let src = r#"
 %Point = type { i32, i32 }
 "#;
-    let (ctx, module) = parse(src).expect("parse failed");
+    let (_ctx, module) = parse(src).expect("parse failed");
     assert_eq!(module.named_types.len(), 1);
     assert_eq!(module.named_types[0].0, "Point");
 }

--- a/llvm-ir/src/builder.rs
+++ b/llvm-ir/src/builder.rs
@@ -496,7 +496,7 @@ mod tests {
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
 
-        let fid = b.add_function(
+        let _fid = b.add_function(
             "foo",
             b.ctx.i32_ty,
             vec![b.ctx.i32_ty],
@@ -525,7 +525,7 @@ mod tests {
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
 
-        let fid = b.add_function(
+        let _fid = b.add_function(
             "check",
             b.ctx.void_ty,
             vec![b.ctx.i1_ty],

--- a/llvm-ir/src/context.rs
+++ b/llvm-ir/src/context.rs
@@ -80,6 +80,7 @@ pub struct Context {
     pub f32_ty: TypeId,
     pub f64_ty: TypeId,
     pub ptr_ty: TypeId,
+    pub label_ty: TypeId,
 }
 
 impl Context {
@@ -99,6 +100,7 @@ impl Context {
             f32_ty: TypeId(0),
             f64_ty: TypeId(0),
             ptr_ty: TypeId(0),
+            label_ty: TypeId(0),
         };
         ctx.void_ty = ctx.intern_anon(TypeData::Void);
         ctx.i1_ty = ctx.intern_anon(TypeData::Integer(1));
@@ -109,6 +111,7 @@ impl Context {
         ctx.f32_ty = ctx.intern_anon(TypeData::Float(FloatKind::Single));
         ctx.f64_ty = ctx.intern_anon(TypeData::Float(FloatKind::Double));
         ctx.ptr_ty = ctx.intern_anon(TypeData::Pointer);
+        ctx.label_ty = ctx.intern_anon(TypeData::Label);
         ctx
     }
 
@@ -137,6 +140,10 @@ impl Context {
 
     pub fn mk_ptr(&mut self) -> TypeId {
         self.ptr_ty
+    }
+
+    pub fn mk_label(&mut self) -> TypeId {
+        self.label_ty
     }
 
     pub fn mk_array(&mut self, element: TypeId, len: u64) -> TypeId {
@@ -305,7 +312,7 @@ impl Context {
             ConstantData::Array { ty, .. } => *ty,
             ConstantData::Struct { ty, .. } => *ty,
             ConstantData::Vector { ty, .. } => *ty,
-            ConstantData::GlobalRef { ty, .. } => *ty,
+            ConstantData::GlobalRef { ty, .. } => *ty, // name field ignored here
         }
     }
 }

--- a/llvm-ir/src/function.rs
+++ b/llvm-ir/src/function.rs
@@ -177,7 +177,6 @@ impl Function {
 mod tests {
     use super::*;
     use crate::context::Context;
-    use crate::instruction::{Instruction, InstrKind};
 
     #[test]
     fn function_fresh_names() {

--- a/llvm-ir/src/instruction.rs
+++ b/llvm-ir/src/instruction.rs
@@ -406,11 +406,11 @@ impl Instruction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{Context, InstrId};
+    use crate::context::Context;
 
     #[test]
     fn terminator_check() {
-        let ctx = Context::new();
+        let _ctx = Context::new();
         let ret = InstrKind::Ret { val: None };
         assert!(ret.is_terminator());
         let add = InstrKind::Add {

--- a/llvm-ir/src/module.rs
+++ b/llvm-ir/src/module.rs
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn module_globals() {
-        let mut ctx = Context::new();
+        let ctx = Context::new();
         let gv = GlobalVariable {
             name: "x".to_string(),
             ty: ctx.i32_ty,

--- a/llvm-ir/src/printer.rs
+++ b/llvm-ir/src/printer.rs
@@ -212,9 +212,8 @@ impl<'a> Printer<'a> {
                 }
                 out.push('>');
             }
-            ConstantData::GlobalRef { id: gid, .. } => {
-                // We don't have the module here; just emit placeholder.
-                write!(out, "@g{}", gid.0).unwrap();
+            ConstantData::GlobalRef { name, .. } => {
+                write!(out, "@{}", name).unwrap();
             }
         }
     }

--- a/llvm-ir/src/types.rs
+++ b/llvm-ir/src/types.rs
@@ -43,7 +43,7 @@ pub struct FunctionType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{Context, TypeId};
+    use crate::context::Context;
 
     #[test]
     fn type_data_eq() {

--- a/llvm-ir/src/value.rs
+++ b/llvm-ir/src/value.rs
@@ -25,8 +25,9 @@ pub enum ConstantData {
     Struct { ty: TypeId, fields: Vec<ConstId> },
     /// Constant vector.
     Vector { ty: TypeId, elements: Vec<ConstId> },
-    /// Reference to a global symbol.
-    GlobalRef { ty: TypeId, id: GlobalId },
+    /// Reference to a global symbol (global variable or function).
+    /// `name` is the LLVM IR name (without `@`), used for printing.
+    GlobalRef { ty: TypeId, id: GlobalId, name: String },
 }
 
 /// A function argument (SSA value produced by function entry).

--- a/llvm-ir/tests/roundtrip.rs
+++ b/llvm-ir/tests/roundtrip.rs
@@ -1,9 +1,8 @@
 //! Round-trip test: build IR → print → parse → print → assert text equality.
 
 use llvm_ir::{
-    Context, Module, Function, BasicBlock, Instruction, InstrKind,
-    Builder, Printer, Linkage, IntArithFlags, IntPredicate,
-    ValueRef,
+    Context, Module,
+    Builder, Printer, Linkage, IntPredicate,
 };
 
 /// Build a simple add function and check that the printer emits expected text.
@@ -121,7 +120,7 @@ fn roundtrip_global() {
     let mut b = Builder::new(&mut ctx, &mut module);
 
     let init = b.ctx.const_int(b.ctx.i32_ty, 100);
-    let gid = b.add_global("LIMIT", b.ctx.i32_ty, Some(init), true, Linkage::Internal);
+    let _gid = b.add_global("LIMIT", b.ctx.i32_ty, Some(init), true, Linkage::Internal);
 
     let p = Printer::new(b.ctx);
     let ir = p.print_module(b.module);


### PR DESCRIPTION
## Summary

Code review of the Phase 1 IR Foundation implementation surfaced several correctness and quality issues. This PR fixes them all.

### Bug Fixes
- **Missing `label_ty` type**: `Context` lacked a pre-interned `label_ty` singleton and `mk_label()` constructor. The parser was using `mk_int(0)` as a stand-in for the `label` type, producing incorrect IR type metadata for branch targets.
- **`GlobalRef` missing name field**: `ConstantData::GlobalRef` stored only a `GlobalId`, so the printer was emitting `@g{id}` placeholders instead of real symbol names like `@printf`. Added a `name: String` field and updated printer and parser accordingly.
- **Parser panics instead of errors**: Three sites in the parser used `.expect()` which would panic on malformed input rather than returning a `ParseError`. Converted to `.ok_or_else(|| self.err(...))` with accurate line/column positions from `lex.current_line()/col()`.
  - `parse_instruction`: "no current function"
  - `parse_block`: "no current function"
  - `get_or_create_block`: "block reference outside function"

### Warnings Cleaned Up
- Removed unused imports (`Instruction`, `InstrKind`, `InstrId`, `TypeId`, `IntArithFlags`, `ValueRef`, `Function`, `BasicBlock`) from test modules
- Prefixed intentionally unused variables with `_` (`fid`, `gid`, `ctx`) in tests
- Fixed `let mut ctx` → `let ctx` in module test where mutability wasn't needed
- Added `#[allow(dead_code)]` to `parse_function_type` helper (useful for future function-pointer parsing)
- Added missing `GlobalId` import in parser

## Test Plan

- [x] `cargo check` — zero warnings
- [x] `cargo test` — all 45 tests pass (18 unit + 4 roundtrip + 13 parser unit + 10 parser integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)