### PR TITLE
Document reducibility requirement for natural loop detection

### DIFF
--- a/llvm-analysis/src/loops.rs
+++ b/llvm-analysis/src/loops.rs
@@ -7,6 +7,22 @@
 //!    from the tail up to (and including) the header.
 //! 3. Assign loop nesting: a loop is a child of the smallest loop whose body
 //!    contains the child's header.
+//!
+//! # Reducibility requirement
+//!
+//! This algorithm detects **natural loops** only, which requires the CFG to be
+//! **reducible**.  A CFG is reducible when every strongly-connected component
+//! has a single entry node that dominates all other nodes in the component.
+//! Irreducible CFGs — those containing a
+//! strongly-connected component with two or more entry edges that do not
+//! dominate each other — are not handled correctly: the multi-entry cycle will
+//! not be detected, and `LoopInfo` will report zero loops for it.
+//!
+//! Irreducible CFGs are uncommon in practice (most front-ends and optimisers
+//! avoid them), but the LLVM IR format permits them.  Callers that need
+//! correct results on irreducible graphs should either:
+//! * structurise the CFG before calling `LoopInfo::compute`, or
+//! * use a full SCC-based (Havlak/Sreedhar) algorithm instead.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use llvm_ir::{BlockId, Function};
@@ -33,6 +49,12 @@ pub struct LoopInfo {
 
 impl LoopInfo {
     /// Detect all natural loops in `func`.
+    ///
+    /// Uses the standard back-edge + reverse-CFG-BFS algorithm, which is
+    /// correct only for **reducible** CFGs.  On an irreducible CFG, cycles
+    /// whose strongly-connected component has no single dominating header will
+    /// not be reported.  See the [module-level documentation](self) for
+    /// details and mitigation options.
     pub fn compute(func: &Function, cfg: &Cfg, dom: &DomTree) -> Self {
         if func.num_blocks() == 0 {
             return LoopInfo { loops: vec![], block_loop: HashMap::new() };
@@ -79,7 +101,11 @@ impl LoopInfo {
     }
 
     /// Find all back-edges (tail, header) using iterative DFS on the CFG.
-    /// An edge (n → h) is a back-edge when h dominates n.
+    ///
+    /// An edge `(n → h)` is classified as a back-edge when `h` dominates `n`.
+    /// This definition is equivalent to natural-loop back-edges **only for
+    /// reducible CFGs**.  In an irreducible CFG, cross-edges inside a
+    /// multi-entry SCC are not dominance back-edges and will be missed.
     fn find_back_edges(cfg: &Cfg, dom: &DomTree) -> Vec<(BlockId, BlockId)> {
         let mut back_edges = Vec::new();
         let mut visited = HashSet::new();
@@ -251,5 +277,29 @@ mod tests {
         assert_eq!(li.depth(BlockId(3)), 2); // in both
         assert_eq!(li.depth(BlockId(0)), 0);
         assert_eq!(li.depth(BlockId(4)), 0);
+    }
+
+    #[test]
+    fn irreducible_cfg_not_detected() {
+        // Irreducible CFG: 0 → 1, 0 → 2, 1 → 2, 2 → 1
+        //
+        // Blocks 1 and 2 form a cycle but neither dominates the other, so no
+        // back-edge is detected by the dominance-based algorithm.  This test
+        // documents the known limitation described in issue #9: natural loop
+        // detection silently under-reports loops in irreducible CFGs.
+        let (_ctx, func) = build_func(3, &[
+            (0, vec![1, 2]),
+            (1, vec![2]),
+            (2, vec![1]),
+        ]);
+        let cfg = Cfg::compute(&func);
+        let dom = DomTree::compute(&func, &cfg);
+        let li = LoopInfo::compute(&func, &cfg, &dom);
+
+        // The cycle 1 ↔ 2 is NOT reported because neither block dominates the
+        // other (irreducible CFG).  Zero loops is the known, documented
+        // behaviour for this input; a correct SCC-based detector would find 1.
+        assert_eq!(li.loops().len(), 0,
+            "dominance-based algorithm does not detect irreducible cycle (known limitation, see issue #9)");
     }
 }


### PR DESCRIPTION
Fixes #9.

## Problem

`LoopInfo::compute` uses the standard natural-loop algorithm (dominance back-edge + reverse-CFG BFS). This algorithm is only correct for **reducible CFGs**. Irreducible CFGs — those with multi-entry strongly-connected components — are silently under-reported: the cycle is simply not detected. This limitation was nowhere documented.

## Changes

**Documentation** (`llvm-analysis/src/loops.rs`):

- New module-level doc section **"Reducibility requirement"** explains:
  - What reducibility means and why the algorithm depends on it
  - What happens on irreducible input (silent under-reporting)
  - Two mitigation paths for callers who need correct results on irreducible graphs (CFG structurisation, or a full SCC-based / Havlak algorithm)
- `LoopInfo::compute` doc comment notes the reducibility precondition and links to the module docs
- `find_back_edges` doc comment explains why dominance back-edges miss cross-edges in irreducible SCCs

**Test** (`irreducible_cfg_not_detected`):

Documents the canonical irreducible CFG from the issue (`0→1`, `0→2`, `1→2`, `2→1`). The test asserts that zero loops are reported and explains in its comment that this is the *known, documented* behaviour — not a silent regression. A future SCC-based implementation can change the assertion when it is ready.

## What is NOT changed

No algorithmic changes. The algorithm remains natural-loop / dominance back-edge because irreducible CFGs are rare in practice and a full SCC-based implementation is out of scope for this issue.

## Code review findings (self-review, applied before merge)

Three issues found and fixed in the same commit:

| # | Issue | Fix |
|---|-------|-----|
| 1 | Assert message `"irreducible cycle should not be detected..."` read like a desired contract rather than a known limitation | Changed to `"dominance-based algorithm does not detect irreducible cycle (known limitation, see issue #9)"` |
| 2 | Test function used `///` Rustdoc comments instead of `//` — unconventional for `#[test]` functions; inconsistent with the rest of the test suite | Changed to `//` |
| 3 | Reducibility definition was circular: defined using "back-edge" which itself depends on reducibility | Replaced with the standard SCC-entry definition: "every SCC has a single entry node that dominates all other nodes in the component" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)