### PR TITLE
Fix apply_allocation dst rewrite and emit_binop self-reference

### DIFF
--- a/llvm-codegen/src/regalloc.rs
+++ b/llvm-codegen/src/regalloc.rs
@@ -155,10 +155,21 @@ pub fn linear_scan(
 // ── apply allocation ───────────────────────────────────────────────────────
 
 /// Replace `MOperand::VReg` with `MOperand::PReg` in `mf` according to
-/// `result`.  Spilled VRegs are left unchanged (the caller must handle them).
+/// `result`.  Also rewrites `instr.dst` so that the destination register
+/// number reflects the assigned physical register rather than the raw VReg
+/// counter.  Spilled VRegs are left unchanged (the caller must handle them).
 pub fn apply_allocation(mf: &mut MachineFunction, result: &RegAllocResult) {
     for block in &mut mf.blocks {
         for instr in &mut block.instrs {
+            // Rewrite destination VReg.
+            if let Some(ref mut vr) = instr.dst {
+                if let Some(&pr) = result.vreg_to_preg.get(vr) {
+                    // Store the physical register number in the VReg wrapper
+                    // so encoder casts `PReg(dst.0 as u8)` yield the correct reg.
+                    *vr = VReg(pr.0 as u32);
+                }
+            }
+            // Rewrite source operands.
             for op in &mut instr.operands {
                 if let MOperand::VReg(vr) = op {
                     if let Some(&pr) = result.vreg_to_preg.get(vr) {
@@ -243,8 +254,29 @@ mod tests {
 
         apply_allocation(&mut mf, &result);
 
+        // instr 0: dst=v0→PReg(3), src operand v1→PReg(7)
+        assert_eq!(mf.blocks[0].instrs[0].dst, Some(VReg(3)));  // physical reg 3
         assert_eq!(mf.blocks[0].instrs[0].operands[0], MOperand::PReg(PReg(7)));
+        // instr 1: src operand v0→PReg(3)
         assert_eq!(mf.blocks[0].instrs[1].operands[0], MOperand::PReg(PReg(3)));
+    }
+
+    #[test]
+    fn apply_allocation_rewrites_dst_register() {
+        use crate::isel::{MachineFunction, MInstr, MOpcode};
+        let mut mf = MachineFunction::new("f".into());
+        let b = mf.add_block("entry");
+        let v5 = VReg(5); // VReg 5 allocated to PReg 2
+        mf.next_vreg = 6;
+        mf.push(b, MInstr::new(MOpcode(0)).with_dst(v5));
+
+        let mut result = RegAllocResult::default();
+        result.vreg_to_preg.insert(v5, PReg(2));
+
+        apply_allocation(&mut mf, &result);
+
+        // dst should now contain VReg(2) so that PReg(dst.0 as u8) == PReg(2)
+        assert_eq!(mf.blocks[0].instrs[0].dst, Some(VReg(2)));
     }
 
     #[test]

--- a/llvm-target-x86/src/lower.rs
+++ b/llvm-target-x86/src/lower.rs
@@ -172,13 +172,15 @@ fn lower_instr(
         };
     }
     // Helper: emit a two-input binary op as: dst=mov(lhs); op(dst,rhs).
+    // The binary op instruction carries only the RHS in operands (not dst
+    // itself) so that `get_dst_src` in the encoder sees the correct source.
     macro_rules! emit_binop {
         ($op:expr, $lhs:expr, $rhs:expr) => {{
             let dst = new_dst!();
             let l = res!($lhs);
             let r = res!($rhs);
             mf.push(mblock, MInstr::new(MOV_RR).with_dst(dst).with_vreg(l));
-            mf.push(mblock, MInstr::new($op).with_dst(dst).with_vreg(dst).with_vreg(r));
+            mf.push(mblock, MInstr::new($op).with_dst(dst).with_vreg(r));
         }};
     }
 
@@ -550,5 +552,25 @@ mod tests {
         });
         assert!(has_cmp,   "should emit CMP");
         assert!(has_setcc, "should emit SETCC");
+    }
+
+    #[test]
+    fn add_binop_instr_has_single_rhs_operand() {
+        // After fix for issue #34: the ADD_RR instruction must have exactly
+        // one operand (the RHS vreg), not two (self-reference + rhs).
+        let (ctx, module) = make_add_fn();
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+
+        // Find the ADD_RR instruction.
+        let add_instr = mf.blocks.iter()
+            .flat_map(|b| b.instrs.iter())
+            .find(|i| i.opcode == ADD_RR);
+        let add_instr = add_instr.expect("should have an ADD_RR instruction");
+
+        assert_eq!(
+            add_instr.operands.len(), 1,
+            "ADD_RR must carry only the RHS operand, not a self-reference (issue #34)"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- **Issue #29**: `apply_allocation` never rewrote `instr.dst` — only `instr.operands` were updated. Encoder casts `PReg(dst.0 as u8)`, so an unmodified VReg counter produced a wrong physical register for every instruction with a destination.
- **Issue #34**: `emit_binop!` included `VReg(dst)` as `operands[0]` alongside the RHS in `operands[1]`. After allocation, `get_dst_src` picked the first PReg in operands (the destination itself), emitting `OP dst, dst` instead of `OP dst, rhs` for all binary operations (ADD, SUB, IMUL, AND, OR, XOR).

## Changes
- `llvm-codegen/src/regalloc.rs`: `apply_allocation` now rewrites `instr.dst` to `VReg(pr.0)` so the encoder gets the assigned physical register number
- `llvm-target-x86/src/lower.rs`: `emit_binop!` no longer appends `VReg(dst)` to operands; only the RHS operand is stored
- Added tests: `apply_allocation_rewrites_dst_register`, `add_binop_instr_has_single_rhs_operand`

## Test plan
- [x] `cargo test -p llvm-codegen -p llvm-target-x86` — 23 tests pass
- [x] `cargo test` — all 143 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)