### PR TITLE
Fix emit_mov_to_preg always emitting NOP (issue #30)

### DIFF
--- a/llvm-target-x86/src/encode.rs
+++ b/llvm-target-x86/src/encode.rs
@@ -133,6 +133,21 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             }
         }
 
+        // ── MOV fixed_preg, src_preg (REX.W 0x89 /r) ────────────────────
+        // operands[0] = PReg destination (ABI-fixed, not in `dst`),
+        // operands[1] = PReg source (VReg resolved by regalloc).
+        MOV_PR => {
+            if let (Some(MOperand::PReg(dst)), Some(MOperand::PReg(src))) =
+                (instr.operands.first(), instr.operands.get(1))
+            {
+                maybe_rex(ctx, true, *src, *dst);
+                ctx.emit(0x89);
+                ctx.emit(modrm_rr(*src, *dst));
+            } else {
+                ctx.emit(0x90); // fallback NOP (pre-allocation, should not reach encoder)
+            }
+        }
+
         // ── MOV reg, imm64 (REX.W 0xB8+rd) ───────────────────────────────
         MOV_RI => {
             if let (Some(dst), Some(val)) = (instr.dst, instr.operands.first().and_then(imm)) {
@@ -506,6 +521,47 @@ mod tests {
         // REX.W=0x48, MOV r/m64,r64=0x89, ModRM(11 110 000)=0xF0
         assert_eq!(&sec.data[0..3], &[0x48, 0x89, 0xF0]);
         let _ = mi;
+    }
+
+    #[test]
+    fn mov_pr_rax_rsi_encodes_correctly() {
+        // MOV_PR: mov rax, rsi
+        // operands[0] = PReg(RAX=0), operands[1] = PReg(RSI=6)
+        // Expected: REX.W(0x48) + MOV r/m64,r64(0x89) + ModRM(11_110_000=0xF0)
+        use llvm_codegen::isel::MOperand;
+        let mi = MInstr {
+            opcode: MOV_PR,
+            dst: None,
+            operands: vec![MOperand::PReg(RAX), MOperand::PReg(RSI)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("mov_pr_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        assert_eq!(&sec.data[0..3], &[0x48, 0x89, 0xF0],
+            "mov rax, rsi should be REX.W + 0x89 + ModRM(11 110 000)");
+    }
+
+    #[test]
+    fn mov_pr_emits_non_nop_for_extended_reg() {
+        // MOV_PR: mov r8, rdi (R8 is an extended register, needs REX.B)
+        // Expected: REX.WB(0x49) + 0x89 + ModRM(11_111_000=0xF8)
+        use llvm_codegen::isel::MOperand;
+        use crate::regs::{R8, RDI};
+        let mi = MInstr {
+            opcode: MOV_PR,
+            dst: None,
+            operands: vec![MOperand::PReg(R8), MOperand::PReg(RDI)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("mov_pr_ext_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        // REX.W + REX.B = 0x49, opcode = 0x89, ModRM(11 111 000) = 0xF8
+        assert_eq!(&sec.data[0..3], &[0x49, 0x89, 0xF8],
+            "mov r8, rdi should use REX.WB");
     }
 
     #[test]

--- a/llvm-target-x86/src/instructions.rs
+++ b/llvm-target-x86/src/instructions.rs
@@ -13,6 +13,11 @@ pub const MOVSX_32:  MOpcode = MOpcode(0x02);
 pub const MOVSX_8:   MOpcode = MOpcode(0x03);
 /// Zero-extend 8-bit source to 64-bit destination (`movzx`)
 pub const MOVZX_8:   MOpcode = MOpcode(0x04);
+/// Move VReg source into a fixed physical register destination.
+/// Layout: `operands[0]` = `PReg` (destination, ABI-fixed), `operands[1]` = `VReg`/`PReg` (source).
+/// Used by `emit_mov_to_preg`; unlike `MOV_RR` there is no `dst` field so the
+/// physical register in `operands[0]` survives register allocation unchanged.
+pub const MOV_PR:    MOpcode = MOpcode(0x05);
 
 // ── integer arithmetic ─────────────────────────────────────────────────────
 pub const ADD_RR:    MOpcode = MOpcode(0x10);

--- a/llvm-target-x86/src/lower.rs
+++ b/llvm-target-x86/src/lower.rs
@@ -443,9 +443,11 @@ fn emit_phi_copies(
 // ── ABI register helpers ──────────────────────────────────────────────────
 
 fn emit_mov_to_preg(mf: &mut MachineFunction, mblock: usize, preg: PReg, src: VReg) {
-    let mut mi = MInstr::new(MOV_RR).with_vreg(src).with_preg(preg);
-    mi.phys_uses = vec![preg];
-    mf.push(mblock, mi);
+    // MOV_PR: operands[0] = fixed PReg destination, operands[1] = VReg source.
+    // dst is intentionally None so apply_allocation does not reassign preg.
+    // After regalloc operands[1] becomes PReg(src_allocated) and the encoder
+    // generates `mov preg, src_allocated`.
+    mf.push(mblock, MInstr::new(MOV_PR).with_preg(preg).with_vreg(src));
 }
 
 fn emit_mov_from_preg(mf: &mut MachineFunction, mblock: usize, dst: VReg, preg: PReg) {
@@ -552,6 +554,28 @@ mod tests {
         });
         assert!(has_cmp,   "should emit CMP");
         assert!(has_setcc, "should emit SETCC");
+    }
+
+    #[test]
+    fn emit_mov_to_preg_uses_mov_pr_opcode() {
+        // emit_mov_to_preg must use MOV_PR (not MOV_RR) so that the fixed
+        // physical register destination survives register allocation.
+        // Verify: the instruction has dst=None, opcode=MOV_PR,
+        //         operands[0]=PReg(preg), operands[1]=VReg(src).
+        use llvm_codegen::isel::{MachineFunction, MOperand};
+        use crate::regs::RAX;
+
+        let mut mf = MachineFunction::new("f".into());
+        let b = mf.add_block("entry");
+        let src = mf.fresh_vreg();
+        super::emit_mov_to_preg(&mut mf, b, RAX, src);
+
+        let instr = &mf.blocks[b].instrs[0];
+        assert_eq!(instr.opcode, MOV_PR, "emit_mov_to_preg must use MOV_PR opcode");
+        assert!(instr.dst.is_none(), "dst must be None (destination is a fixed PReg)");
+        assert_eq!(instr.operands.len(), 2);
+        assert_eq!(instr.operands[0], MOperand::PReg(RAX), "operands[0] must be the fixed PReg");
+        assert_eq!(instr.operands[1], MOperand::VReg(src), "operands[1] must be the source VReg");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `MOV_PR` opcode (`0x05`) whose destination is a **fixed physical register** stored in `operands[0]` rather than `instr.dst`, so `apply_allocation` leaves it unchanged while still rewriting the source VReg.
- Updates `emit_mov_to_preg` in `lower.rs` to use `MOV_PR` instead of `MOV_RR` with `dst=None`.
- Adds `MOV_PR` encoding in `encode.rs`: emits `REX.W + 0x89 + ModRM(src, dst)`, same bytes as `MOV_RR` but reading both registers from `operands`.

## Root cause

`emit_mov_to_preg` built `MInstr::new(MOV_RR).with_vreg(src).with_preg(preg)` with `dst=None`.  The `MOV_RR` encoder guard `if let (Some(dst), Some(src)) = (instr.dst, ...)` always failed on `None`, falling through to `ctx.emit(0x90)` (NOP).  This silently discarded every argument-setup move before calls, the `mov rax, lhs` before `idiv`, and the return-value move before `ret`.

## Test plan

- [x] `lower::tests::emit_mov_to_preg_uses_mov_pr_opcode` — verifies opcode, `dst=None`, and operand layout
- [x] `encode::tests::mov_pr_rax_rsi_encodes_correctly` — verifies byte output for `mov rax, rsi`
- [x] `encode::tests::mov_pr_emits_non_nop_for_extended_reg` — verifies REX.WB for `mov r8, rdi`
- [x] All 148 existing tests continue to pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)