### PR TITLE
Fix UDiv/URem using signed IDIV instead of unsigned DIV (issue #31)

### DIFF
--- a/llvm-target-x86/src/encode.rs
+++ b/llvm-target-x86/src/encode.rs
@@ -194,6 +194,17 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             }
         }
 
+        // ── DIV src (REX.W 0xF7 /6) — unsigned ───────────────────────────
+        DIV_R => {
+            if let Some(src) = instr.operands.first().and_then(preg) {
+                maybe_rex(ctx, true, PReg(0), src);
+                ctx.emit(0xF7);
+                ctx.emit(0xC0 | (6 << 3) | reg_enc(src)); // ModRM /6
+            } else {
+                ctx.emit(0x90);
+            }
+        }
+
         // ── CQO (REX.W 0x99) ─────────────────────────────────────────────
         CQO => {
             ctx.emit(0x48); // REX.W
@@ -521,6 +532,44 @@ mod tests {
         // REX.W=0x48, MOV r/m64,r64=0x89, ModRM(11 110 000)=0xF0
         assert_eq!(&sec.data[0..3], &[0x48, 0x89, 0xF0]);
         let _ = mi;
+    }
+
+    #[test]
+    fn div_r_encodes_correctly() {
+        // div rcx → REX.W(0x48) + 0xF7 + ModRM(/6, rcx=1) = 0xF1
+        use crate::regs::RCX;
+        let mi = MInstr {
+            opcode: DIV_R,
+            dst: None,
+            operands: vec![MOperand::PReg(RCX)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("div_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        // REX.W=0x48, F7, ModRM(11 110 001) = 0xF1 (digit /6 = 110b, rcx=001b)
+        assert_eq!(&sec.data[0..3], &[0x48, 0xF7, 0xF1],
+            "div rcx should encode as REX.W + 0xF7 + ModRM(/6)");
+    }
+
+    #[test]
+    fn idiv_r_encodes_correctly() {
+        // idiv rcx → REX.W(0x48) + 0xF7 + ModRM(/7, rcx=1) = 0xF9
+        use crate::regs::RCX;
+        let mi = MInstr {
+            opcode: IDIV_R,
+            dst: None,
+            operands: vec![MOperand::PReg(RCX)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("idiv_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        // REX.W=0x48, F7, ModRM(11 111 001) = 0xF9 (digit /7 = 111b, rcx=001b)
+        assert_eq!(&sec.data[0..3], &[0x48, 0xF7, 0xF9],
+            "idiv rcx should encode as REX.W + 0xF7 + ModRM(/7)");
     }
 
     #[test]

--- a/llvm-target-x86/src/instructions.rs
+++ b/llvm-target-x86/src/instructions.rs
@@ -28,12 +28,14 @@ pub const SUB_RI:    MOpcode = MOpcode(0x13);
 pub const IMUL_RR:   MOpcode = MOpcode(0x14);
 /// `imul dst, src, imm`  (3-operand)
 pub const IMUL_RRI:  MOpcode = MOpcode(0x15);
-/// `idiv src`  (rax,rdx:rax ÷ src → rax=quot, rdx=rem)
+/// `idiv src`  (signed: rdx:rax ÷ src → rax=quot, rdx=rem; requires CQO first)
 pub const IDIV_R:    MOpcode = MOpcode(0x16);
 /// `neg dst`
 pub const NEG_R:     MOpcode = MOpcode(0x17);
 /// `cqo` — sign-extend rax into rdx:rax before idiv
 pub const CQO:       MOpcode = MOpcode(0x18);
+/// `div src`  (unsigned: rdx:rax ÷ src → rax=quot, rdx=rem; requires `xor rdx, rdx` first)
+pub const DIV_R:     MOpcode = MOpcode(0x19);
 
 // ── bitwise ────────────────────────────────────────────────────────────────
 pub const AND_RR:    MOpcode = MOpcode(0x20);

--- a/llvm-target-x86/src/lower.rs
+++ b/llvm-target-x86/src/lower.rs
@@ -190,11 +190,11 @@ fn lower_instr(
         Sub { lhs, rhs, .. }  => { emit_binop!(SUB_RR, *lhs, *rhs); }
         Mul { lhs, rhs, .. }  => { emit_binop!(IMUL_RR, *lhs, *rhs); }
 
-        SDiv { lhs, rhs, .. } | UDiv { lhs, rhs, .. } => {
+        SDiv { lhs, rhs, .. } => {
             let dst = new_dst!();
             let l = res!(*lhs);
             let r = res!(*rhs);
-            // mov rax, lhs; cqo; idiv rhs → rax = quotient
+            // mov rax, lhs; cqo; idiv rhs → rax = quotient (signed)
             emit_mov_to_preg(mf, mblock, SYSV_INT_RET, l);
             mf.push(mblock, MInstr::new(CQO));
             let mut div_mi = MInstr::new(IDIV_R).with_vreg(r);
@@ -203,14 +203,44 @@ fn lower_instr(
             emit_mov_from_preg(mf, mblock, dst, SYSV_INT_RET);
         }
 
-        SRem { lhs, rhs, .. } | URem { lhs, rhs, .. } => {
+        UDiv { lhs, rhs, .. } => {
             let dst = new_dst!();
             let l = res!(*lhs);
             let r = res!(*rhs);
-            // mov rax, lhs; cqo; idiv rhs → rdx = remainder
+            // mov rax, lhs; xor rdx, rdx; div rhs → rax = quotient (unsigned)
+            emit_mov_to_preg(mf, mblock, SYSV_INT_RET, l);
+            let zero = mf.fresh_vreg();
+            mf.push(mblock, MInstr::new(MOV_RI).with_dst(zero).with_imm(0));
+            emit_mov_to_preg(mf, mblock, RDX, zero);
+            let mut div_mi = MInstr::new(DIV_R).with_vreg(r);
+            div_mi.clobbers = vec![SYSV_INT_RET, RDX];
+            mf.push(mblock, div_mi);
+            emit_mov_from_preg(mf, mblock, dst, SYSV_INT_RET);
+        }
+
+        SRem { lhs, rhs, .. } => {
+            let dst = new_dst!();
+            let l = res!(*lhs);
+            let r = res!(*rhs);
+            // mov rax, lhs; cqo; idiv rhs → rdx = remainder (signed)
             emit_mov_to_preg(mf, mblock, SYSV_INT_RET, l);
             mf.push(mblock, MInstr::new(CQO));
             let mut div_mi = MInstr::new(IDIV_R).with_vreg(r);
+            div_mi.clobbers = vec![SYSV_INT_RET, RDX];
+            mf.push(mblock, div_mi);
+            emit_mov_from_preg(mf, mblock, dst, RDX);
+        }
+
+        URem { lhs, rhs, .. } => {
+            let dst = new_dst!();
+            let l = res!(*lhs);
+            let r = res!(*rhs);
+            // mov rax, lhs; xor rdx, rdx; div rhs → rdx = remainder (unsigned)
+            emit_mov_to_preg(mf, mblock, SYSV_INT_RET, l);
+            let zero = mf.fresh_vreg();
+            mf.push(mblock, MInstr::new(MOV_RI).with_dst(zero).with_imm(0));
+            emit_mov_to_preg(mf, mblock, RDX, zero);
+            let mut div_mi = MInstr::new(DIV_R).with_vreg(r);
             div_mi.clobbers = vec![SYSV_INT_RET, RDX];
             mf.push(mblock, div_mi);
             emit_mov_from_preg(mf, mblock, dst, RDX);
@@ -554,6 +584,55 @@ mod tests {
         });
         assert!(has_cmp,   "should emit CMP");
         assert!(has_setcc, "should emit SETCC");
+    }
+
+    fn make_div_fn(unsigned: bool) -> (Context, Module) {
+        let mut ctx = Context::new();
+        let mut module = Module::new("test");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "div_fn",
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty, b.ctx.i64_ty],
+            vec!["a".into(), "b".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let a = b.get_arg(0);
+        let bv = b.get_arg(1);
+        let result = if unsigned {
+            b.build_udiv("q", a, bv)
+        } else {
+            b.build_sdiv("q", a, bv)
+        };
+        b.build_ret(result);
+        (ctx, module)
+    }
+
+    #[test]
+    fn udiv_uses_div_r_not_idiv_r() {
+        // Issue #31: UDiv must emit DIV_R (unsigned) not IDIV_R (signed).
+        let (ctx, module) = make_div_fn(true);
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+        let has_div_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
+        let has_idiv_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
+        assert!(has_div_r,  "UDiv must emit DIV_R (unsigned div)");
+        assert!(!has_idiv_r, "UDiv must NOT emit IDIV_R (signed div)");
+    }
+
+    #[test]
+    fn sdiv_uses_idiv_r() {
+        // Regression: SDiv must still emit IDIV_R (signed).
+        let (ctx, module) = make_div_fn(false);
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+        let has_idiv_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
+        let has_div_r  = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
+        assert!(has_idiv_r, "SDiv must emit IDIV_R (signed div)");
+        assert!(!has_div_r,  "SDiv must NOT emit DIV_R (unsigned div)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `DIV_R` opcode (`0x19`) for the unsigned `div` instruction.
- Splits the combined `SDiv|UDiv` and `SRem|URem` lowering arms into separate arms, using the correct sequence for each:
  - **SDiv/SRem** (unchanged): `CQO` (sign-extend RAX into RDX:RAX) + `IDIV_R`
  - **UDiv/URem** (fixed): materialize zero → `MOV_PR(RDX, 0)` (zero-extend) + `DIV_R`
- Adds `DIV_R` encoding: `REX.W + 0xF7 + ModRM(/6)` (same byte, digit 6 instead of 7 for IDIV).

## Root cause

The previous code used `CQO + IDIV_R` for both signed and unsigned division. `CQO` sign-extends RAX into RDX:RAX, which is correct for signed but wrong for unsigned — for unsigned the high-half must be zero. Using IDIV on unsigned values also interprets the dividend as a signed quantity, producing wrong quotients/remainders for values with the high bit set.

## Test plan

- [x] `lower::tests::udiv_uses_div_r_not_idiv_r` — UDiv emits DIV_R, not IDIV_R
- [x] `lower::tests::sdiv_uses_idiv_r` — SDiv regression guard: still uses IDIV_R
- [x] `encode::tests::div_r_encodes_correctly` — byte output for `div rcx`
- [x] `encode::tests::idiv_r_encodes_correctly` — byte output regression guard for `idiv rcx`
- [x] All 152 existing tests continue to pass

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)