### PR TITLE
Fix SETCC REX, Mach-O strtab null, linear-scan sort (issues #35, #37, #38)

### DIFF
--- a/llvm-codegen/src/emit.rs
+++ b/llvm-codegen/src/emit.rs
@@ -282,8 +282,8 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     let reloc_off     = text_off + text_size;
     let reloc_size    = text_relocs.len() as u32 * 8;
 
-    // String table: index 0 = space (Mach-O convention)
-    let mut strtab: Vec<u8> = vec![b' '];
+    // String table: index 0 = \0 (null, required by Mach-O spec — empty string).
+    let mut strtab: Vec<u8> = vec![0u8];
     let sym_name_offs: Vec<u32> = obj.symbols.iter().map(|s| {
         let off = strtab.len() as u32;
         strtab.push(b'_'); // C symbol underscore prefix
@@ -454,6 +454,19 @@ mod tests {
         let bytes = make_obj(ObjectFormat::MachO, vec![0xc3]).to_bytes();
         let filetype = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
         assert_eq!(filetype, 1, "MH_OBJECT = 1");
+    }
+
+    #[test]
+    fn macho_strtab_first_byte_is_null() {
+        // Issue #37: Mach-O string table byte 0 must be \0 (null), not ' ' (space).
+        // The string table is the last thing written in the object file.
+        // For symbol "f", strtab = [\0, '_', 'f', \0] (4 bytes, aligned).
+        // We verify the first byte of strtab (= last 4 bytes of the file) is \0.
+        let bytes = make_obj(ObjectFormat::MachO, vec![0xc3]).to_bytes();
+        // strtab is padded to 4 bytes: [\0, '_', 'f', \0] = 4 bytes.
+        let strtab_first = bytes[bytes.len() - 4];
+        assert_eq!(strtab_first, 0x00,
+            "Mach-O strtab[0] must be null (\\0), was 0x{:02x}", strtab_first);
     }
 
     #[test]

--- a/llvm-codegen/src/regalloc.rs
+++ b/llvm-codegen/src/regalloc.rs
@@ -116,13 +116,9 @@ pub fn linear_scan(
         free.extend(returned);
 
         if free.is_empty() {
-            // Spill: choose the active interval with the largest end point,
-            // because that frees the register for the most future instructions.
-            let spill_idx = active
-                .iter()
-                .enumerate()
-                .max_by_key(|(_, (end, _, _))| end)
-                .map(|(i, _)| i);
+            // Spill: the active set is kept sorted by end, so the interval with
+            // the largest end is always at the back — O(1) lookup instead of O(n).
+            let spill_idx = if active.is_empty() { None } else { Some(active.len() - 1) };
 
             if let Some(idx) = spill_idx {
                 let (spill_end, spill_vr, spill_pr) = active[idx];
@@ -131,8 +127,9 @@ pub fn linear_scan(
                     active.remove(idx);
                     result.vreg_to_preg.remove(&spill_vr); // revoke previous assignment
                     result.vreg_to_preg.insert(interval.vreg, spill_pr);
-                    active.push((interval.end, interval.vreg, spill_pr));
-                    active.sort_unstable_by_key(|(e, _, _)| *e);
+                    // Insert in sorted position to maintain invariant.
+                    let pos = active.partition_point(|&(e, _, _)| e <= interval.end);
+                    active.insert(pos, (interval.end, interval.vreg, spill_pr));
                     result.spilled.push(spill_vr);
                 } else {
                     // Current interval has the largest end — spill it.
@@ -144,8 +141,10 @@ pub fn linear_scan(
         } else {
             let pr = free.remove(0);
             result.vreg_to_preg.insert(interval.vreg, pr);
-            active.push((interval.end, interval.vreg, pr));
-            active.sort_unstable_by_key(|(e, _, _)| *e);
+            // Insert in sorted position to maintain the end-sorted invariant without
+            // a full O(n log n) sort on every push.
+            let pos = active.partition_point(|&(e, _, _)| e <= interval.end);
+            active.insert(pos, (interval.end, interval.vreg, pr));
         }
     }
 
@@ -277,6 +276,20 @@ mod tests {
 
         // dst should now contain VReg(2) so that PReg(dst.0 as u8) == PReg(2)
         assert_eq!(mf.blocks[0].instrs[0].dst, Some(VReg(2)));
+    }
+
+    #[test]
+    fn many_overlapping_intervals_all_assigned() {
+        // Issue #38: stress test with many intervals to verify that the
+        // partition_point insertion correctly maintains the sorted invariant.
+        // 5 intervals all starting at 0 with different ends — need 5 registers.
+        let intervals = vec![
+            iv(0, 0, 10), iv(1, 0, 8), iv(2, 0, 6), iv(3, 0, 4), iv(4, 0, 2),
+        ];
+        let alloc: Vec<PReg> = (0u8..5).map(PReg).collect();
+        let result = linear_scan(&intervals, &alloc);
+        assert!(result.spilled.is_empty(), "no spills: 5 regs for 5 simultaneous live ranges");
+        assert_eq!(result.vreg_to_preg.len(), 5);
     }
 
     #[test]

--- a/llvm-target-x86/src/encode.rs
+++ b/llvm-target-x86/src/encode.rs
@@ -275,16 +275,23 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             }
         }
 
-        // ── SETcc dst (0x0F 0x9x /0) ─────────────────────────────────────
+        // ── SETcc dst (REX? 0x0F 0x9x /0) ────────────────────────────────
         SETCC => {
             if let (Some(dst), Some(cc)) = (instr.dst, instr.operands.first().and_then(imm)) {
                 let r = PReg(dst.0 as u8);
-                // REX needed only for spl/bpl/sil/dil (r4-r7 in 8-bit) or R8-R15.
-                if is_extended(r) { ctx.emit(0x41); }
+                // Without a REX prefix, 8-bit encodings 4-7 alias the high bytes
+                // AH/CH/DH/BH rather than SPL/BPL/SIL/DIL.  A bare REX (0x40)
+                // selects the low-byte form even when no register field extension
+                // is needed; REX.B (0x41) selects R8-R15.
+                if is_extended(r) {
+                    ctx.emit(0x41); // REX.B for R8–R15
+                } else if r.0 >= 4 {
+                    ctx.emit(0x40); // bare REX for SIL/DIL (enc 6/7) and SPL/BPL (enc 4/5)
+                }
                 ctx.emit(0x0F);
                 ctx.emit(setcc_opcode(cc));
                 ctx.emit(0xC0 | reg_enc(r));
-                // Zero-extend to 64 bits via movzx.
+                // Zero-extend the 8-bit result to 64 bits via MOVZX r64, r8.
                 maybe_rex(ctx, true, r, r);
                 ctx.emit(0x0F); ctx.emit(0xB6);
                 ctx.emit(modrm_rr(r, r));
@@ -532,6 +539,48 @@ mod tests {
         // REX.W=0x48, MOV r/m64,r64=0x89, ModRM(11 110 000)=0xF0
         assert_eq!(&sec.data[0..3], &[0x48, 0x89, 0xF0]);
         let _ = mi;
+    }
+
+    #[test]
+    fn setcc_rsi_emits_bare_rex() {
+        // Issue #35: SETCC into RSI (encoding 6) must emit a bare REX (0x40) before
+        // the 0x0F opcode so that encoding 6 selects SIL (not DH which lacks REX).
+        // Instruction: SETCC with dst=RSI, condition=CC_EQ (0x94).
+        // Expected prefix: 0x40 (bare REX), then 0x0F 0x94 0xC6 (SETE sil).
+        use crate::regs::RSI;
+        let mi = MInstr {
+            opcode: SETCC,
+            dst: Some(VReg(RSI.0 as u32)),
+            operands: vec![MOperand::Imm(CC_EQ)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("setcc_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        // First 4 bytes: bare REX(0x40), 0x0F, SETE(0x94), ModRM(0xC6 = 11_000_110 for RSI)
+        assert_eq!(sec.data[0], 0x40, "bare REX must be emitted for SETCC into RSI");
+        assert_eq!(sec.data[1], 0x0F, "escape prefix");
+        assert_eq!(sec.data[2], 0x94, "SETE opcode byte");
+        assert_eq!(sec.data[3], 0xC6, "ModRM(11 000 110) for RSI");
+    }
+
+    #[test]
+    fn setcc_rax_no_extra_rex() {
+        // RAX (encoding 0) does not need a REX prefix for 8-bit access — AL is
+        // directly addressable. Verify no spurious REX appears before 0x0F.
+        let mi = MInstr {
+            opcode: SETCC,
+            dst: Some(VReg(RAX.0 as u32)),
+            operands: vec![MOperand::Imm(CC_EQ)],
+            phys_uses: vec![],
+            clobbers: vec![],
+        };
+        let mf = single_block_mf("setcc_rax_fn", vec![mi]);
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+        // First byte must be 0x0F (no REX prefix for RAX).
+        assert_eq!(sec.data[0], 0x0F, "no REX prefix should be emitted for SETCC into RAX");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three independent fixes bundled together since they touch different subsystems.

### Issue #35 — SETCC missing REX prefix for RSI/RDI

Without a REX prefix, 8-bit encodings 4-7 alias the **high bytes** AH/CH/DH/BH instead of SPL/BPL/SIL/DIL. The previous code emitted REX.B (`0x41`) only for R8–R15 registers. For RSI (enc=6) and RDI (enc=7) — which are in `ALLOCATABLE` — no REX was emitted, so `setl rsi/rdi` wrote to DH/BH while the following `movzx rsi/rdi, sil/dil` read from a different register.

**Fix:** Emit bare REX (`0x40`) when `r.0 >= 4` (SPL/BPL/SIL/DIL), and REX.B (`0x41`) for R8–R15.

### Issue #37 — Mach-O strtab\[0\] = space instead of null

The Mach-O string table must begin with a null byte (the empty string at index 0). The previous initializer used `b' '` (space). This could confuse linkers that read `strtab[0]` as the start of the empty symbol name.

**Fix:** Change `vec![b' ']` to `vec![0u8]` in `serialize_macho`.

### Issue #38 — Linear scan O(n² log n) active-set sorting

`sort_unstable_by_key` was called after every `push` to the active set, making each iteration O(n log n). Since the set is always kept sorted, we instead:
- Use `partition_point` + `insert` for O(n) ordered insertion.
- Use `active.last()` (O(1)) to find the maximum-end spill candidate instead of O(n) `max_by_key`.

## Test plan

- [x] `encode::tests::setcc_rsi_emits_bare_rex` — verifies 0x40 prefix before SETCC into RSI
- [x] `encode::tests::setcc_rax_no_extra_rex` — regression: no spurious REX for RAX
- [x] `emit::tests::macho_strtab_first_byte_is_null` — strtab\[0\] = `\0`
- [x] `regalloc::tests::many_overlapping_intervals_all_assigned` — 5 simultaneous intervals, no spills
- [x] All 157 existing tests continue to pass

Closes #35, #37, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)