### PR TITLE
Add AGENTS.md and Claude Code skills for autonomous development (closes #44)

### DIFF
--- a/.claude/skills/fix-issue.md
+++ b/.claude/skills/fix-issue.md
@@ -1,0 +1,103 @@
+Fix a specific GitHub issue with a dedicated branch, commit, PR, and squash-merge.
+
+## Usage
+```
+/fix-issue <issue-number>
+```
+
+## What this skill does
+Reads the GitHub issue, traces the root cause in the codebase, implements the
+minimal correct fix, adds a regression test, and merges a PR — fully autonomously.
+
+## Execution steps
+
+### 1. Read the issue
+```bash
+gh issue view <N>
+```
+Understand: what is wrong, which files are involved, and what the correct
+behaviour should be.
+
+### 2. Read the relevant source files
+Use Read/Grep/Glob to locate and read every file mentioned in the issue before
+writing a single line of code. Never edit code you haven't read.
+
+### 3. Branch from latest main
+```bash
+git fetch origin
+git checkout -b fix/issue-<N>-<slug> origin/main
+```
+`<slug>` is a 2–4 word kebab-case summary of the fix (e.g. `udiv-unsigned-div`).
+Always branch from `origin/main`, not a local tracking branch.
+
+### 4. Implement the fix
+- Make the **minimum change** that correctly addresses the root cause.
+- Do not refactor unrelated code, add comments to unchanged functions, or
+  introduce new abstractions unless they are strictly required by the fix.
+- If a new opcode or helper is needed, add it in the natural place following
+  the existing file's style and conventions.
+
+### 5. Add a regression test
+Add at least one test in the existing `#[cfg(test)] mod tests` block that:
+- Would have **failed** with the old code.
+- **Passes** with the fix.
+- Is named descriptively (e.g. `udiv_uses_div_r_not_idiv_r`).
+
+If relevant, also add a regression guard test that verifies the complementary
+case still works (e.g. `sdiv_uses_idiv_r` alongside the unsigned fix).
+
+### 6. Verify
+```bash
+cargo test -p <affected-crate>   # fast feedback on the changed crate
+cargo test                        # full workspace — must be all green
+```
+Never commit if any test fails.
+
+### 7. Commit
+```bash
+git add <specific files only — never "git add -A">
+git commit -m "$(cat <<'EOF'
+Fix <short description of what was wrong and what the fix does> (closes #<N>)
+
+<1–3 sentence explanation of root cause and approach.>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 8. Push, open PR, and merge
+```bash
+git push -u origin fix/issue-<N>-<slug>
+
+gh pr create \
+  --title "Fix <description> (issue #<N>)" \
+  --body "$(cat <<'EOF'
+## Summary
+<bullet points of what changed>
+
+## Root cause
+<one paragraph>
+
+## Test plan
+- [ ] <new test name> — <what it verifies>
+- [ ] All <X> existing tests continue to pass
+
+Closes #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr merge <PR-N> --squash
+```
+Do NOT pass `--delete-branch` — `main` may be checked out in another worktree.
+
+## Pitfalls to avoid
+- **Branch from `origin/main`**, not `main` — the latter may be another worktree.
+- **Stage specific files** — `git add -A` can accidentally include `target/` or
+  `.env` files.
+- **`--no-verify` is forbidden** — if a pre-commit hook fails, fix the underlying
+  issue and create a fresh commit.
+- **Scope creep** — if you discover a second bug while fixing the first, open a new
+  issue and handle it in a separate PR.

--- a/.claude/skills/implement-phase.md
+++ b/.claude/skills/implement-phase.md
@@ -1,0 +1,71 @@
+Implement the next incomplete phase of the LLVM-in-Rust compiler project.
+
+## What this skill does
+Reads the project plan, implements all files for the next outstanding phase,
+runs tests, commits to a feature branch, creates a PR, and merges it — with
+no user interaction required beyond invoking this skill.
+
+## Execution steps
+
+### 1. Determine the phase to implement
+- Read `CLAUDE.md` — the "Implementation Phases" section lists phases and their completion status.
+- Read `/Users/yudong/.claude/projects/-Users-yudong-work-claude-LLVM-in-Rust/memory/MEMORY.md`
+  to understand what has already been completed.
+- If a plan file exists at `/Users/yudong/.claude/plans/`, load it; otherwise use the
+  Plan agent to produce a detailed step-by-step implementation plan before writing any code.
+
+### 2. Create a feature branch
+```bash
+git fetch origin
+git checkout -b feature/phase<N>-<short-description> origin/main
+```
+Always branch from `origin/main`, never from a local tracking branch, because
+`main` may be checked out in another worktree.
+
+### 3. Implement each file
+- Read every existing stub file before editing it.
+- Follow the architecture and naming conventions already established in the codebase.
+- Add `#[cfg(test)] mod tests { … }` blocks at the bottom of each new source file.
+- Run `cargo check` after each file to catch type errors early.
+- Run `cargo test -p <crate>` once the crate is complete before moving on.
+
+### 4. Full test run
+```bash
+cargo test
+```
+All tests must pass before committing. If any test fails, diagnose and fix it —
+do not skip or comment out failing tests.
+
+### 5. Commit
+Stage only the files changed for this phase (not `target/` or `*.local.*`).
+```bash
+git add <specific files>
+git commit -m "Phase <N>: <description> (closes #<issue>)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+### 6. Push and open PR
+```bash
+git push -u origin <branch>
+gh pr create --title "Phase <N>: <description>" --body "…"
+```
+The PR body must include: what was implemented, key design decisions, and a
+test plan checklist.
+
+### 7. Merge
+```bash
+gh pr merge <N> --squash
+```
+Do NOT use `--delete-branch` because `main` may live in another git worktree.
+
+### 8. Update memory
+Edit `MEMORY.md` in the auto-memory directory to record the new phase status,
+key file paths, and any design decisions made during implementation.
+
+## Constraints
+- No new Cargo dependencies unless explicitly called for in `CLAUDE.md`.
+- Keep each crate's public API minimal — only expose what downstream crates need.
+- Never commit generated files (`target/`, `*.lock` changes from dependency adds).
+- If `cargo test` output shows a pre-commit hook failure, fix the underlying issue
+  and create a new commit (never use `--no-verify`).

--- a/.claude/skills/review-and-fix.md
+++ b/.claude/skills/review-and-fix.md
@@ -1,0 +1,94 @@
+Review the most recently merged PR for correctness issues, open a GitHub issue for
+each problem found, then fix every issue in its own dedicated PR.
+
+## Usage
+```
+/review-and-fix
+/review-and-fix <PR-number>
+```
+If a PR number is supplied, review that PR; otherwise review the most recently merged PR.
+
+## What this skill does
+Runs a thorough code review, catalogs all bugs as GitHub issues, then autonomously
+fixes them one by one — each fix on its own branch with its own PR — without
+requiring the user to prompt for each individual fix.
+
+## Execution steps
+
+### Phase A — Code review
+
+1. **Fetch the PR diff**
+   ```bash
+   gh pr view <N> --json files,additions,deletions
+   gh pr diff <N>
+   ```
+
+2. **Deep analysis** — Use the Plan agent to review every changed file for:
+   - **Critical bugs**: wrong output (incorrect encodings, wrong opcodes, sign errors)
+   - **Logic errors**: conditions always true/false, operands in wrong order
+   - **Missing cases**: enum variants not handled, edge cases silently ignored
+   - **ABI/calling-convention violations**: wrong registers, missing clobbers
+   - **Performance regressions**: unnecessary O(n log n) ops inside loops
+   - **Minor issues**: null vs sentinel byte, off-by-one in struct layouts
+
+3. **Categorise** each finding as Critical / Moderate / Minor.
+
+### Phase B — Open GitHub issues
+
+For each distinct problem, open **one issue** with:
+```bash
+gh issue create \
+  --title "<short imperative title>" \
+  --body "## Root cause\n…\n## Affected file(s)\n…\n## Expected behaviour\n…\n## Actual behaviour\n…"
+```
+Use a clear, searchable title (e.g. "emit_mov_to_preg always emits NOP").
+Record every issue number for Phase C.
+
+### Phase C — Fix each issue
+
+Repeat the following for every issue, starting with Critical, then Moderate, then Minor:
+
+1. **Branch from latest main**
+   ```bash
+   git fetch origin
+   git checkout -b fix/issue-<N>-<slug> origin/main
+   ```
+
+2. **Understand the code** — read the relevant source files before editing.
+
+3. **Implement the minimal fix** — change only what is necessary to correct the bug.
+   Do not refactor surrounding code or add unrelated improvements.
+
+4. **Add targeted tests** that would have caught the bug. Place them in the existing
+   `#[cfg(test)] mod tests` block of the affected file.
+
+5. **Verify**
+   ```bash
+   cargo test -p <affected-crate>
+   cargo test   # full suite — must be all green
+   ```
+
+6. **Commit**
+   ```bash
+   git add <specific files>
+   git commit -m "Fix <short description> (closes #<issue-N>)
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   ```
+
+7. **PR and merge**
+   ```bash
+   git push -u origin fix/issue-<N>-<slug>
+   gh pr create --title "Fix <description> (issue #<N>)" \
+     --body "## Summary\n…\n## Root cause\n…\n## Test plan\n- [ ] …"
+   gh pr merge <PR-N> --squash
+   ```
+   Do NOT use `--delete-branch`.
+
+8. **Fetch main** before starting the next fix so each branch is current.
+
+## Constraints
+- One GitHub issue per distinct problem (do not bundle unrelated bugs).
+- One PR per issue (or tightly coupled pair), so git history stays bisectable.
+- Never mark an issue as fixed until `cargo test` is fully green.
+- If a fix reveals a secondary bug, open a new issue rather than expanding scope.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Rust build output
+/target/
+
+# Claude Code local-only files (not project-wide)
+.claude/settings.local.json
+.claude/worktrees/
+
+# macOS
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# AGENTS.md — Agentic Development Guide
+
+This file documents the agentic workflow used to develop LLVM-in-Rust with
+Claude Code.  It exists so that Claude can operate **autonomously** on this
+project with minimal back-and-forth, following the same patterns used
+throughout Phases 1–4.
+
+---
+
+## Development Lifecycle
+
+Every feature follows this four-stage cycle, executed end-to-end without
+user prompts at each step:
+
+```
+Plan → Implement → Review → Fix
+```
+
+| Stage | Slash skill | Description |
+|-------|-------------|-------------|
+| Implement a phase | `/implement-phase` | Branch → code → test → commit → PR → merge |
+| Review a merged PR | `/review-and-fix` | Analyse → open issues → fix each → PRs → merge |
+| Fix one issue | `/fix-issue <N>` | Read issue → fix → test → PR → merge |
+
+---
+
+## Git Workflow Conventions
+
+These rules prevent common mistakes in the multi-worktree setup:
+
+| Rule | Reason |
+|------|--------|
+| Always branch from `origin/main`, not `main` | `main` is checked out in the primary worktree; checking it out again fails |
+| `gh pr merge <N> --squash` (no `--delete-branch`) | Same worktree conflict |
+| Stage specific files, never `git add -A` | Avoids accidentally committing `target/` or secret files |
+| Never use `--no-verify` | Fix the hook failure instead |
+| Run `cargo test` before every commit | All tests must be green |
+
+**Branch naming:**
+- Features: `feature/phase<N>-<slug>` (e.g. `feature/phase4-x86-backend`)
+- Fixes: `fix/issue-<N>-<slug>` (e.g. `fix/issue-30-mov-to-preg`)
+
+---
+
+## Agent Usage Guide
+
+### Plan agent
+Use **before** starting a new phase or a non-trivial fix.
+
+```
+Invoke: Agent tool with subagent_type="Plan"
+When:   Implementing a new crate, designing a data structure, or planning
+        multiple-file changes across >3 files.
+Output: Step-by-step plan written to /Users/yudong/.claude/plans/<name>.md
+        followed by ExitPlanMode.
+```
+
+### Explore agent
+Use for **codebase searches** when the location of something is unknown.
+
+```
+Invoke: Agent tool with subagent_type="Explore"
+When:   Looking for where a trait is implemented, all uses of a type,
+        or understanding how an existing subsystem works.
+Levels: "quick" (single grep), "medium" (several files), "very thorough" (deep)
+```
+
+### general-purpose agent (background)
+Use for **parallel independent work** — e.g. running tests in the background
+while writing another file, or fetching GitHub issue data while reading source.
+
+```
+Invoke: Agent tool with subagent_type="general-purpose", run_in_background=true
+When:   The sub-task is independent of the current work and would block
+        the main thread if run synchronously.
+```
+
+### When NOT to use agents
+- Reading a specific known file → use `Read` directly
+- Searching for a specific class or function → use `Grep` directly
+- Simple one-file edits → use `Edit` directly
+
+---
+
+## Code Quality Standards
+
+Every PR merged into `main` must satisfy:
+
+1. **`cargo test` all green** — no skipped tests, no `#[ignore]` added.
+2. **Targeted tests** — every bug fix adds at least one regression test named
+   after what it verifies (e.g. `udiv_uses_div_r_not_idiv_r`).
+3. **Minimal diff** — only the lines necessary to fix the bug or implement
+   the feature; no reformatting or unrelated cleanup.
+4. **Squash merge** — one commit per PR on `main`; branch history preserved
+   in the PR.
+5. **Closes #N in commit message** — so GitHub auto-closes the issue.
+
+---
+
+## Phase Roadmap
+
+| Phase | Crates | Status |
+|-------|--------|--------|
+| 1 — IR Foundation | `llvm-ir`, `llvm-ir-parser` | ✅ Complete |
+| 2 — Analysis | `llvm-analysis` | ✅ Complete |
+| 3 — Optimizations | `llvm-transforms` | ✅ Complete |
+| 4 — x86_64 Backend | `llvm-codegen`, `llvm-target-x86` | ✅ Complete + reviewed |
+| 5 — AArch64 + Bitcode | `llvm-target-arm`, `llvm-bitcode` | 🔲 Next |
+
+For Phase 5 details see the open issue #7 and `CLAUDE.md` §"Phase 5".
+
+---
+
+## Memory & Context
+
+Persistent cross-session notes live at:
+```
+/Users/yudong/.claude/projects/-Users-yudong-work-claude-LLVM-in-Rust/memory/MEMORY.md
+```
+
+**Always read `MEMORY.md` at the start of a session** to avoid re-doing work.
+**Always update `MEMORY.md` after a phase completes** with new status, key
+file paths, and design decisions.
+
+Topic files in the same directory (`debugging.md`, `patterns.md`, etc.) hold
+deeper notes; link to them from `MEMORY.md`.
+
+---
+
+## Commit Message Format
+
+```
+<imperative subject line, ≤72 chars> (closes #N)
+
+<optional body: root cause, approach, notable decisions>
+<blank line if body present>
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+PR body template:
+```markdown
+## Summary
+- <bullet>
+
+## Root cause / Design rationale
+<paragraph>
+
+## Test plan
+- [ ] <new test name> — <what it verifies>
+- [ ] All <X> existing tests pass
+
+Closes #N
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```


### PR DESCRIPTION
## Summary

Introduces three reusable Claude Code slash-command skills and a project-level
`AGENTS.md` to encode the agentic development workflow that has been used
across Phases 1–4 of this project.

### New files

| File | Purpose |
|------|---------|
| `AGENTS.md` | Project-level guide: git conventions, agent selection guide, code quality standards, phase roadmap, commit/PR templates |
| `.claude/skills/implement-phase.md` | `/implement-phase` — plan→implement→test→commit→PR→merge for a full compiler phase |
| `.claude/skills/review-and-fix.md` | `/review-and-fix` — deep PR review, open GitHub issues per bug, fix each in its own PR |
| `.claude/skills/fix-issue.md` | `/fix-issue <N>` — read issue→fix→regression test→commit→PR→merge |
| `.gitignore` | Excludes `target/`, local Claude config; tracks `.claude/skills/` |

### Key conventions encoded in AGENTS.md

- Always branch from `origin/main` (not `main`) because `main` lives in another worktree
- `gh pr merge N --squash` without `--delete-branch` for the same reason
- Stage specific files, never `git add -A`
- `cargo test` must be all green before every commit
- One issue per bug, one PR per issue

### Goal

Reduce back-and-forth: invoking `/implement-phase` or `/review-and-fix` runs
the full workflow end-to-end without prompting for each step.

## Test plan

- [x] `.gitignore` tracks `.claude/skills/` and ignores `target/`, `settings.local.json`, `worktrees/`
- [x] `AGENTS.md` renders correctly as Markdown
- [x] All 157 existing tests continue to pass (no source changes)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)