### PR TITLE
Fix SExt always using MOVSXD regardless of source width (issue #36)

### DIFF
--- a/llvm-target-x86/src/encode.rs
+++ b/llvm-target-x86/src/encode.rs
@@ -369,6 +369,30 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             }
         }
 
+        // ── MOVSX r64, r/m8  (REX.W 0x0F 0xBE /r) ───────────────────────
+        MOVSX_8 => {
+            if let (Some(dst), Some(src)) = get_dst_src(instr) {
+                maybe_rex(ctx, true, dst, src);
+                ctx.emit(0x0F);
+                ctx.emit(0xBE);
+                ctx.emit(modrm_rr(dst, src));
+            } else {
+                ctx.emit(0x90);
+            }
+        }
+
+        // ── MOVSX r64, r/m16 (REX.W 0x0F 0xBF /r) ───────────────────────
+        MOVSX_16 => {
+            if let (Some(dst), Some(src)) = get_dst_src(instr) {
+                maybe_rex(ctx, true, dst, src);
+                ctx.emit(0x0F);
+                ctx.emit(0xBF);
+                ctx.emit(modrm_rr(dst, src));
+            } else {
+                ctx.emit(0x90);
+            }
+        }
+
         // ── MOVSX (sign-extend 32→64: REX.W 0x63 /r) ────────────────────
         MOVSX_32 => {
             if let (Some(dst), Some(src)) = get_dst_src(instr) {

--- a/llvm-target-x86/src/instructions.rs
+++ b/llvm-target-x86/src/instructions.rs
@@ -13,6 +13,8 @@ pub const MOVSX_32:  MOpcode = MOpcode(0x02);
 pub const MOVSX_8:   MOpcode = MOpcode(0x03);
 /// Zero-extend 8-bit source to 64-bit destination (`movzx`)
 pub const MOVZX_8:   MOpcode = MOpcode(0x04);
+/// Sign-extend 16-bit source to 64-bit destination (`movsx`)
+pub const MOVSX_16:  MOpcode = MOpcode(0x06);
 /// Move VReg source into a fixed physical register destination.
 /// Layout: `operands[0]` = `PReg` (destination, ABI-fixed), `operands[1]` = `VReg`/`PReg` (source).
 /// Used by `emit_mov_to_preg`; unlike `MOV_RR` there is no `dst` field so the

--- a/llvm-target-x86/src/lower.rs
+++ b/llvm-target-x86/src/lower.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use llvm_codegen::isel::{IselBackend, MachineFunction, MInstr, PReg, VReg};
 use llvm_ir::{
     ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind,
-    IntPredicate, Module, ValueRef,
+    IntPredicate, Module, TypeData, ValueRef,
 };
 use crate::{
     abi::{classify_sysv_args, ArgLocation, SYSV_INT_RET},
@@ -340,7 +340,15 @@ fn lower_instr(
         SExt { val, .. } => {
             let dst = new_dst!();
             let src = res!(*val);
-            mf.push(mblock, MInstr::new(MOVSX_32).with_dst(dst).with_vreg(src));
+            // Select the correct sign-extension opcode based on source bit width.
+            let src_bits = func.type_of_value(*val)
+                .map(|tid| match ctx.get_type(tid) {
+                    TypeData::Integer(bits) => *bits,
+                    _ => 32,
+                })
+                .unwrap_or(32);
+            let opcode = if src_bits <= 8 { MOVSX_8 } else if src_bits <= 16 { MOVSX_16 } else { MOVSX_32 };
+            mf.push(mblock, MInstr::new(opcode).with_dst(dst).with_vreg(src));
         }
 
         // ── calls ──────────────────────────────────────────────────────────
@@ -740,5 +748,59 @@ mod tests {
             add_instr.operands.len(), 1,
             "ADD_RR must carry only the RHS operand, not a self-reference (issue #34)"
         );
+    }
+
+    fn make_sext_fn(src_ty_bits: u32) -> (Context, Module) {
+        let mut ctx = Context::new();
+        let mut module = Module::new("test");
+        let src_ty = ctx.mk_int(src_ty_bits);
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "sext_fn",
+            b.ctx.i64_ty,
+            vec![src_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let x = b.get_arg(0);
+        let ext = b.build_sext("ext", x, b.ctx.i64_ty);
+        b.build_ret(ext);
+        (ctx, module)
+    }
+
+    #[test]
+    fn sext_i8_uses_movsx_8() {
+        let (ctx, module) = make_sext_fn(8);
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+        let has_movsx8 = mf.blocks.iter().any(|b| {
+            b.instrs.iter().any(|i| i.opcode == MOVSX_8)
+        });
+        assert!(has_movsx8, "sext from i8 must use MOVSX_8 (0F BE), not MOVSXD (63)");
+    }
+
+    #[test]
+    fn sext_i16_uses_movsx_16() {
+        let (ctx, module) = make_sext_fn(16);
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+        let has_movsx16 = mf.blocks.iter().any(|b| {
+            b.instrs.iter().any(|i| i.opcode == MOVSX_16)
+        });
+        assert!(has_movsx16, "sext from i16 must use MOVSX_16 (0F BF), not MOVSXD (63)");
+    }
+
+    #[test]
+    fn sext_i32_uses_movsx_32() {
+        let (ctx, module) = make_sext_fn(32);
+        let mut be = X86Backend;
+        let mf = be.lower_function(&ctx, &module, &module.functions[0]);
+        let has_movsx32 = mf.blocks.iter().any(|b| {
+            b.instrs.iter().any(|i| i.opcode == MOVSX_32)
+        });
+        assert!(has_movsx32, "sext from i32 must use MOVSX_32 (movsxd, 63)");
     }
 }


### PR DESCRIPTION
## Summary
- Add `MOVSX_16: MOpcode(0x06)` to `instructions.rs` for 16-bit sign-extension
- Fix `SExt` lowering in `lower.rs` to read source type width and dispatch to the correct opcode
- Add `MOVSX_8` encoding (`REX.W 0x0F 0xBE /r`) and `MOVSX_16` encoding (`REX.W 0x0F 0xBF /r`) in `encode.rs`

## Root cause
`SExt` unconditionally emitted `MOVSX_32` (`movsxd`, opcode `0x63`) regardless of source width. For an i8 or i16 source, the hardware interprets the low 32 bits of the source register as a signed 32-bit integer instead of 8/16-bit, producing incorrect results. The encoding table also had no case for `MOVSX_8` (it fell through to NOP).

## Test plan
- [ ] `sext_i8_uses_movsx_8` — verifies i8 source selects `MOVSX_8` (opcode `0F BE`)
- [ ] `sext_i16_uses_movsx_16` — verifies i16 source selects `MOVSX_16` (opcode `0F BF`)
- [ ] `sext_i32_uses_movsx_32` — verifies i32 source still selects `MOVSX_32` (movsxd, opcode `63`)
- [ ] All 36 existing `llvm-target-x86` tests pass
- [ ] Full workspace `cargo test` all green

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)