### PR TITLE
Fix intern_type mapping Metadata to Label type (issue #49)

### DIFF
--- a/llvm-bitcode/src/lib.rs
+++ b/llvm-bitcode/src/lib.rs
@@ -124,6 +124,22 @@ mod tests {
     }
 
     #[test]
+    fn metadata_type_round_trips_as_metadata_not_label() {
+        // A Context that contains a Metadata type must deserialise back as
+        // Metadata, not as Label (which was the previous incorrect fallback).
+        use llvm_ir::TypeData;
+        let mut ctx = Context::new();
+        let meta_ty = ctx.mk_metadata();
+        let module = Module::new("meta_test");
+        let bytes = write_bitcode(&ctx, &module);
+        let (ctx2, _) = read_bitcode(&bytes).expect("round-trip must succeed");
+        // The serialised type at the same index must decode as Metadata.
+        let td = ctx2.get_type(meta_ty);
+        assert_eq!(td, &TypeData::Metadata,
+            "Metadata type must round-trip as TypeData::Metadata, not Label");
+    }
+
+    #[test]
     fn invalid_magic_returns_error() {
         let bad = b"BAAD\x01\x00\x00\x00\x00\x00\x00\x00";
         let result = read_bitcode(bad);

--- a/llvm-bitcode/src/reader.rs
+++ b/llvm-bitcode/src/reader.rs
@@ -172,11 +172,7 @@ fn intern_type(ctx: &mut Context, td: TypeData) -> TypeId {
         TypeData::Float(k)   => ctx.mk_float(k),
         TypeData::Pointer    => ctx.mk_ptr(),
         TypeData::Label      => ctx.mk_label(),
-        TypeData::Metadata   => {
-            // Metadata isn't exposed via a public constructor; intern manually.
-            // Fall back to label_ty as a placeholder (metadata is rare in Phase 1 tests).
-            ctx.mk_label()
-        }
+        TypeData::Metadata   => ctx.mk_metadata(),
         TypeData::Array { element, len } => ctx.mk_array(element, len),
         TypeData::Vector { element, len, scalable } => ctx.mk_vector(element, len, scalable),
         TypeData::Struct(st) => {

--- a/llvm-ir/src/context.rs
+++ b/llvm-ir/src/context.rs
@@ -146,6 +146,10 @@ impl Context {
         self.label_ty
     }
 
+    pub fn mk_metadata(&mut self) -> TypeId {
+        self.intern_anon(TypeData::Metadata)
+    }
+
     pub fn mk_array(&mut self, element: TypeId, len: u64) -> TypeId {
         self.intern_anon(TypeData::Array { element, len })
     }


### PR DESCRIPTION
## Summary
- intern_type in llvm-bitcode/src/reader.rs was mapping TypeData::Metadata to ctx.mk_label() as a fallback because no public constructor existed
- Added Context::mk_metadata() to llvm-ir/src/context.rs
- Fixed intern_type to call ctx.mk_metadata() instead of the wrong fallback
- Added regression test metadata_type_round_trips_as_metadata_not_label

## Test plan
- cargo test -p llvm-bitcode passes (6 tests including new regression test)
- cargo test full suite passes (all green)

Closes #49