### PR TITLE
Fix all clippy warnings and apply cargo fmt (quality audit)

### DIFF
--- a/src/llvm-analysis/src/cfg.rs
+++ b/src/llvm-analysis/src/cfg.rs
@@ -55,7 +55,9 @@ impl Cfg {
         if n > 0 {
             let mut stack = vec![0usize];
             while let Some(b) = stack.pop() {
-                if reachable[b] { continue; }
+                if reachable[b] {
+                    continue;
+                }
                 reachable[b] = true;
                 reachable_count += 1;
                 for &succ in &succs[b] {
@@ -64,7 +66,13 @@ impl Cfg {
             }
         }
 
-        Cfg { num_blocks: n, succs, preds, reachable, reachable_count }
+        Cfg {
+            num_blocks: n,
+            succs,
+            preds,
+            reachable,
+            reachable_count,
+        }
     }
 
     /// The function entry block (always index 0).
@@ -133,7 +141,9 @@ impl Cfg {
 
     fn dfs_post(&self, bid: BlockId, visited: &mut Vec<bool>, order: &mut Vec<BlockId>) {
         let idx = bid.0 as usize;
-        if visited[idx] { return; }
+        if visited[idx] {
+            return;
+        }
         visited[idx] = true;
         for &succ in &self.succs[idx] {
             self.dfs_post(succ, visited, order);
@@ -145,7 +155,7 @@ impl Cfg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Context, Function, BasicBlock, Instruction, InstrKind, Linkage, ValueRef};
+    use llvm_ir::{BasicBlock, Context, Function, InstrKind, Instruction, Linkage, ValueRef};
 
     /// Build a test function with `num_blocks` blocks.
     /// `edges`: (src_idx, vec_of_dst_idx) — at most 2 successors per block.
@@ -164,7 +174,9 @@ mod tests {
             has_term[src] = true;
             let kind = match dsts.as_slice() {
                 [] => InstrKind::Unreachable,
-                [dst] => InstrKind::Br { dest: BlockId(*dst as u32) },
+                [dst] => InstrKind::Br {
+                    dest: BlockId(*dst as u32),
+                },
                 [t, f] => {
                     let cond = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 0));
                     InstrKind::CondBr {
@@ -175,12 +187,20 @@ mod tests {
                 }
                 _ => panic!("test only supports 0/1/2 successors"),
             };
-            let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind });
+            let iid = func.alloc_instr(Instruction {
+                name: None,
+                ty: ctx.void_ty,
+                kind,
+            });
             func.blocks[src].set_terminator(iid);
         }
-        for i in 0..num_blocks {
-            if !has_term[i] {
-                let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind: InstrKind::Unreachable });
+        for (i, &needs_term) in has_term.iter().enumerate() {
+            if !needs_term {
+                let iid = func.alloc_instr(Instruction {
+                    name: None,
+                    ty: ctx.void_ty,
+                    kind: InstrKind::Unreachable,
+                });
                 func.blocks[i].set_terminator(iid);
             }
         }
@@ -212,12 +232,10 @@ mod tests {
     #[test]
     fn cfg_diamond() {
         // 0 -> {1, 2} -> 3
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1, 2]),
-            (1, vec![3]),
-            (2, vec![3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1, 2]), (1, vec![3]), (2, vec![3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         assert_eq!(cfg.successors(BlockId(0)).len(), 2);
         assert_eq!(cfg.predecessors(BlockId(3)).len(), 2);
@@ -229,12 +247,10 @@ mod tests {
     #[test]
     fn cfg_loop() {
         // 0 -> 1 -> 2 -> {1, 3}  (back-edge 2→1)
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1]),
-            (1, vec![2]),
-            (2, vec![1, 3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1]), (1, vec![2]), (2, vec![1, 3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         assert!(cfg.predecessors(BlockId(1)).contains(&BlockId(2)));
         assert_eq!(cfg.rpo().len(), 4);

--- a/src/llvm-analysis/src/dominators.rs
+++ b/src/llvm-analysis/src/dominators.rs
@@ -4,9 +4,9 @@
 //! Also provides dominance frontier computation (Cytron et al. 1991),
 //! required for SSA φ-node placement in `mem2reg`.
 
-use std::collections::HashMap;
-use llvm_ir::{BlockId, Function};
 use crate::cfg::Cfg;
+use llvm_ir::{BlockId, Function};
+use std::collections::HashMap;
 
 /// Dominator tree for a single function.
 ///
@@ -87,8 +87,12 @@ impl DomTree {
     /// Walk up both fingers until they meet — the common dominator.
     fn intersect(mut a: usize, mut b: usize, idom: &[usize]) -> usize {
         while a != b {
-            while a > b { a = idom[a]; }
-            while b > a { b = idom[b]; }
+            while a > b {
+                a = idom[a];
+            }
+            while b > a {
+                b = idom[b];
+            }
         }
         a
     }
@@ -102,7 +106,9 @@ impl DomTree {
     /// Returns `true` if block `a` dominates block `b`.
     /// Every block dominates itself.
     pub fn dominates(&self, a: BlockId, b: BlockId) -> bool {
-        if a == b { return true; }
+        if a == b {
+            return true;
+        }
         self.strictly_dominates(a, b)
     }
 
@@ -166,7 +172,7 @@ impl DomTree {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Context, Function, BasicBlock, Instruction, InstrKind, Linkage, ValueRef};
+    use llvm_ir::{BasicBlock, Context, Function, InstrKind, Instruction, Linkage, ValueRef};
 
     fn build_func(num_blocks: usize, edges: &[(usize, Vec<usize>)]) -> (Context, Function) {
         let mut ctx = Context::new();
@@ -180,19 +186,33 @@ mod tests {
             has_term[src] = true;
             let kind = match dsts.as_slice() {
                 [] => InstrKind::Unreachable,
-                [dst] => InstrKind::Br { dest: BlockId(*dst as u32) },
+                [dst] => InstrKind::Br {
+                    dest: BlockId(*dst as u32),
+                },
                 [t, f] => {
                     let cond = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 0));
-                    InstrKind::CondBr { cond, then_dest: BlockId(*t as u32), else_dest: BlockId(*f as u32) }
+                    InstrKind::CondBr {
+                        cond,
+                        then_dest: BlockId(*t as u32),
+                        else_dest: BlockId(*f as u32),
+                    }
                 }
                 _ => panic!("max 2 successors"),
             };
-            let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind });
+            let iid = func.alloc_instr(Instruction {
+                name: None,
+                ty: ctx.void_ty,
+                kind,
+            });
             func.blocks[src].set_terminator(iid);
         }
-        for i in 0..num_blocks {
-            if !has_term[i] {
-                let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind: InstrKind::Unreachable });
+        for (i, &needs_term) in has_term.iter().enumerate() {
+            if !needs_term {
+                let iid = func.alloc_instr(Instruction {
+                    name: None,
+                    ty: ctx.void_ty,
+                    kind: InstrKind::Unreachable,
+                });
                 func.blocks[i].set_terminator(iid);
             }
         }
@@ -226,12 +246,10 @@ mod tests {
     #[test]
     fn domtree_diamond() {
         // 0 -> {1,2} -> 3
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1, 2]),
-            (1, vec![3]),
-            (2, vec![3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1, 2]), (1, vec![3]), (2, vec![3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         // 0 dominates everything; 3's idom is 0 (not 1 or 2).
@@ -244,12 +262,10 @@ mod tests {
     #[test]
     fn domtree_loop() {
         // 0 -> 1 -> 2 -> {1, 3}
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1]),
-            (1, vec![2]),
-            (2, vec![1, 3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1]), (1, vec![2]), (2, vec![1, 3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         assert_eq!(dom.idom(BlockId(1)), Some(BlockId(0)));
@@ -262,18 +278,22 @@ mod tests {
     #[test]
     fn dominance_frontier_diamond() {
         // 0 -> {1,2} -> 3  — classic phi-placement example
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1, 2]),
-            (1, vec![3]),
-            (2, vec![3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1, 2]), (1, vec![3]), (2, vec![3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let df = dom.dominance_frontier(&cfg);
         // DF(1) = DF(2) = {3}, DF(0) = DF(3) = {}
-        assert_eq!(df.get(&BlockId(1)).map(|v| v.as_slice()), Some(&[BlockId(3)][..]));
-        assert_eq!(df.get(&BlockId(2)).map(|v| v.as_slice()), Some(&[BlockId(3)][..]));
+        assert_eq!(
+            df.get(&BlockId(1)).map(|v| v.as_slice()),
+            Some(&[BlockId(3)][..])
+        );
+        assert_eq!(
+            df.get(&BlockId(2)).map(|v| v.as_slice()),
+            Some(&[BlockId(3)][..])
+        );
         assert!(df.get(&BlockId(0)).map_or(true, |v| v.is_empty()));
         assert!(df.get(&BlockId(3)).map_or(true, |v| v.is_empty()));
     }
@@ -281,16 +301,16 @@ mod tests {
     #[test]
     fn dominance_frontier_loop() {
         // 0 -> 1 -> 2 -> {1, 3}: DF(2) = {1} (back-edge creates frontier)
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1]),
-            (1, vec![2]),
-            (2, vec![1, 3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1]), (1, vec![2]), (2, vec![1, 3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let df = dom.dominance_frontier(&cfg);
-        assert!(df.get(&BlockId(2)).map_or(false, |v| v.contains(&BlockId(1))));
+        assert!(df
+            .get(&BlockId(2))
+            .map_or(false, |v| v.contains(&BlockId(1))));
     }
 
     #[test]
@@ -300,20 +320,20 @@ mod tests {
         // and idom[3] = None.  Without the fix the while-condition
         // `Some(runner) != None` would be permanently true until the inner
         // `None => break` fires, producing spurious DF entries for blocks 1 and 2.
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![]),
-            (1, vec![3]),
-            (2, vec![3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(4, &[(0, vec![]), (1, vec![3]), (2, vec![3]), (3, vec![])]);
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let df = dom.dominance_frontier(&cfg);
         // No reachable block exists, so the dominance frontier must be empty.
-        assert!(df.get(&BlockId(1)).map_or(true, |v| v.is_empty()),
-            "spurious DF entry for unreachable block 1: {:?}", df.get(&BlockId(1)));
-        assert!(df.get(&BlockId(2)).map_or(true, |v| v.is_empty()),
-            "spurious DF entry for unreachable block 2: {:?}", df.get(&BlockId(2)));
+        assert!(
+            df.get(&BlockId(1)).map_or(true, |v| v.is_empty()),
+            "spurious DF entry for unreachable block 1: {:?}",
+            df.get(&BlockId(1))
+        );
+        assert!(
+            df.get(&BlockId(2)).map_or(true, |v| v.is_empty()),
+            "spurious DF entry for unreachable block 2: {:?}",
+            df.get(&BlockId(2))
+        );
     }
 }
-

--- a/src/llvm-analysis/src/loops.rs
+++ b/src/llvm-analysis/src/loops.rs
@@ -24,10 +24,10 @@
 //! * structurise the CFG before calling `LoopInfo::compute`, or
 //! * use a full SCC-based (Havlak/Sreedhar) algorithm instead.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use llvm_ir::{BlockId, Function};
 use crate::cfg::Cfg;
 use crate::dominators::DomTree;
+use llvm_ir::{BlockId, Function};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// A single natural loop.
 #[derive(Debug)]
@@ -57,7 +57,10 @@ impl LoopInfo {
     /// details and mitigation options.
     pub fn compute(func: &Function, cfg: &Cfg, dom: &DomTree) -> Self {
         if func.num_blocks() == 0 {
-            return LoopInfo { loops: vec![], block_loop: HashMap::new() };
+            return LoopInfo {
+                loops: vec![],
+                block_loop: HashMap::new(),
+            };
         }
 
         // Find back-edges and build one loop per back-edge.
@@ -111,7 +114,9 @@ impl LoopInfo {
         let mut visited = HashSet::new();
         let mut stack = vec![cfg.entry()];
         while let Some(b) = stack.pop() {
-            if !visited.insert(b) { continue; }
+            if !visited.insert(b) {
+                continue;
+            }
             for &succ in cfg.successors(b) {
                 if dom.dominates(succ, b) {
                     back_edges.push((b, succ));
@@ -177,7 +182,7 @@ impl LoopInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Context, Function, BasicBlock, Instruction, InstrKind, Linkage, ValueRef};
+    use llvm_ir::{BasicBlock, Context, Function, InstrKind, Instruction, Linkage, ValueRef};
 
     fn build_func(num_blocks: usize, edges: &[(usize, Vec<usize>)]) -> (Context, Function) {
         let mut ctx = Context::new();
@@ -191,19 +196,33 @@ mod tests {
             has_term[src] = true;
             let kind = match dsts.as_slice() {
                 [] => InstrKind::Unreachable,
-                [dst] => InstrKind::Br { dest: BlockId(*dst as u32) },
+                [dst] => InstrKind::Br {
+                    dest: BlockId(*dst as u32),
+                },
                 [t, f] => {
                     let cond = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 0));
-                    InstrKind::CondBr { cond, then_dest: BlockId(*t as u32), else_dest: BlockId(*f as u32) }
+                    InstrKind::CondBr {
+                        cond,
+                        then_dest: BlockId(*t as u32),
+                        else_dest: BlockId(*f as u32),
+                    }
                 }
                 _ => panic!("max 2 successors"),
             };
-            let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind });
+            let iid = func.alloc_instr(Instruction {
+                name: None,
+                ty: ctx.void_ty,
+                kind,
+            });
             func.blocks[src].set_terminator(iid);
         }
-        for i in 0..num_blocks {
-            if !has_term[i] {
-                let iid = func.alloc_instr(Instruction { name: None, ty: ctx.void_ty, kind: InstrKind::Unreachable });
+        for (i, &needs_term) in has_term.iter().enumerate() {
+            if !needs_term {
+                let iid = func.alloc_instr(Instruction {
+                    name: None,
+                    ty: ctx.void_ty,
+                    kind: InstrKind::Unreachable,
+                });
                 func.blocks[i].set_terminator(iid);
             }
         }
@@ -225,12 +244,10 @@ mod tests {
     #[test]
     fn simple_loop() {
         // 0 -> 1 -> 2 -> {1(back), 3}
-        let (_ctx, func) = build_func(4, &[
-            (0, vec![1]),
-            (1, vec![2]),
-            (2, vec![1, 3]),
-            (3, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            4,
+            &[(0, vec![1]), (1, vec![2]), (2, vec![1, 3]), (3, vec![])],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let li = LoopInfo::compute(&func, &cfg, &dom);
@@ -255,13 +272,16 @@ mod tests {
         // Outer loop header=1: body={1,2,3}
         // Inner loop header=2: body={2,3}
         // CFG: 0->1, 1->{2,4}, 2->3, 3->{2(inner back),1(outer back)}, 4 exit
-        let (_ctx, func) = build_func(5, &[
-            (0, vec![1]),
-            (1, vec![2, 4]),
-            (2, vec![3]),
-            (3, vec![2, 1]),
-            (4, vec![]),
-        ]);
+        let (_ctx, func) = build_func(
+            5,
+            &[
+                (0, vec![1]),
+                (1, vec![2, 4]),
+                (2, vec![3]),
+                (3, vec![2, 1]),
+                (4, vec![]),
+            ],
+        );
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let li = LoopInfo::compute(&func, &cfg, &dom);
@@ -287,11 +307,7 @@ mod tests {
         // back-edge is detected by the dominance-based algorithm.  This test
         // documents the known limitation described in issue #9: natural loop
         // detection silently under-reports loops in irreducible CFGs.
-        let (_ctx, func) = build_func(3, &[
-            (0, vec![1, 2]),
-            (1, vec![2]),
-            (2, vec![1]),
-        ]);
+        let (_ctx, func) = build_func(3, &[(0, vec![1, 2]), (1, vec![2]), (2, vec![1])]);
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let li = LoopInfo::compute(&func, &cfg, &dom);

--- a/src/llvm-analysis/src/use_def.rs
+++ b/src/llvm-analysis/src/use_def.rs
@@ -20,8 +20,8 @@
 //! | `uses_of` | phi's own block | DCE (`is_dead`), simple def-use traversal |
 //! | `phi_uses_of` | predecessor block | liveness analysis, mem2reg, SSA destruction |
 
+use llvm_ir::{BlockId, Function, InstrId, InstrKind, ValueRef};
 use std::collections::HashMap;
-use llvm_ir::{BlockId, InstrId, InstrKind, ValueRef, Function};
 
 /// Use-def / def-use information for a single function.
 pub struct UseDefInfo {
@@ -74,7 +74,11 @@ impl UseDefInfo {
             }
         }
 
-        UseDefInfo { instr_block, uses, phi_uses }
+        UseDefInfo {
+            instr_block,
+            uses,
+            phi_uses,
+        }
     }
 
     /// The block in which `id` is defined, or `None` if not found.
@@ -114,15 +118,20 @@ impl UseDefInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{ArgId, Context, Module, Builder, Linkage};
+    use llvm_ir::{ArgId, Builder, Context, Linkage, Module};
 
     fn make_add_fn() -> (Context, Module) {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("add", b.ctx.i32_ty,
+        b.add_function(
+            "add",
+            b.ctx.i32_ty,
             vec![b.ctx.i32_ty, b.ctx.i32_ty],
-            vec!["a".into(), "b".into()], false, Linkage::External);
+            vec!["a".into(), "b".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let a = b.get_arg(0);
@@ -155,8 +164,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("f", b.ctx.i32_ty, vec![b.ctx.i32_ty],
-            vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "f",
+            b.ctx.i32_ty,
+            vec![b.ctx.i32_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let x = b.get_arg(0);
@@ -177,8 +192,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("f", b.ctx.void_ty, vec![b.ctx.i1_ty],
-            vec!["c".into()], false, Linkage::External);
+        b.add_function(
+            "f",
+            b.ctx.void_ty,
+            vec![b.ctx.i1_ty],
+            vec!["c".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         let then_bb = b.add_block("then");
         let else_bb = b.add_block("else");
@@ -212,9 +233,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("phi_fn", b.ctx.i32_ty,
+        b.add_function(
+            "phi_fn",
+            b.ctx.i32_ty,
             vec![b.ctx.i1_ty, b.ctx.i32_ty, b.ctx.i32_ty],
-            vec!["cond".into(), "a".into(), "bv".into()], false, Linkage::External);
+            vec!["cond".into(), "a".into(), "bv".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         let then_bb = b.add_block("then");
         let else_bb = b.add_block("else");
@@ -251,15 +277,24 @@ mod tests {
         let b_ref = ValueRef::Argument(ArgId(2));
 
         let a_phi_uses = info.phi_uses_of(a_ref);
-        assert_eq!(a_phi_uses.len(), 1,
-            "a should appear in exactly one phi incoming list");
-        assert_eq!(a_phi_uses[0].0, BlockId(1),
-            "a's phi use should be at predecessor then_bb (block 1), not merge");
+        assert_eq!(
+            a_phi_uses.len(),
+            1,
+            "a should appear in exactly one phi incoming list"
+        );
+        assert_eq!(
+            a_phi_uses[0].0,
+            BlockId(1),
+            "a's phi use should be at predecessor then_bb (block 1), not merge"
+        );
 
         let b_phi_uses = info.phi_uses_of(b_ref);
         assert_eq!(b_phi_uses.len(), 1);
-        assert_eq!(b_phi_uses[0].0, BlockId(2),
-            "bv's phi use should be at predecessor else_bb (block 2), not merge");
+        assert_eq!(
+            b_phi_uses[0].0,
+            BlockId(2),
+            "bv's phi use should be at predecessor else_bb (block 2), not merge"
+        );
     }
 
     #[test]
@@ -274,8 +309,11 @@ mod tests {
         let uses = info.uses_of(a_ref);
         // %a is used by the phi in merge (BlockId 3).
         assert_eq!(uses.len(), 1);
-        assert_eq!(uses[0].0, BlockId(3),
-            "uses_of should record phi operands at the phi's own block (merge = block 3)");
+        assert_eq!(
+            uses[0].0,
+            BlockId(3),
+            "uses_of should record phi operands at the phi's own block (merge = block 3)"
+        );
 
         // %a is not dead — it appears in a phi.
         assert!(!info.is_dead(a_ref));

--- a/src/llvm-bitcode/src/error.rs
+++ b/src/llvm-bitcode/src/error.rs
@@ -20,12 +20,12 @@ pub enum BitcodeError {
 impl std::fmt::Display for BitcodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BitcodeError::InvalidMagic        => write!(f, "invalid magic bytes (not LRIR format)"),
-            BitcodeError::TruncatedInput      => write!(f, "input is truncated"),
-            BitcodeError::UnexpectedEof       => write!(f, "unexpected end of file"),
+            BitcodeError::InvalidMagic => write!(f, "invalid magic bytes (not LRIR format)"),
+            BitcodeError::TruncatedInput => write!(f, "input is truncated"),
+            BitcodeError::UnexpectedEof => write!(f, "unexpected end of file"),
             BitcodeError::UnsupportedRecord(t) => write!(f, "unsupported record type: {}", t),
-            BitcodeError::InvalidType         => write!(f, "invalid type tag"),
-            BitcodeError::ParseError(msg)     => write!(f, "parse error: {}", msg),
+            BitcodeError::InvalidType => write!(f, "invalid type tag"),
+            BitcodeError::ParseError(msg) => write!(f, "parse error: {}", msg),
         }
     }
 }

--- a/src/llvm-bitcode/src/lib.rs
+++ b/src/llvm-bitcode/src/lib.rs
@@ -9,8 +9,8 @@ pub mod reader;
 pub mod writer;
 
 pub use error::BitcodeError;
-pub use writer::write_bitcode;
 pub use reader::read_bitcode;
+pub use writer::write_bitcode;
 
 // ── tests ──────────────────────────────────────────────────────────────────
 
@@ -135,8 +135,11 @@ mod tests {
         let (ctx2, _) = read_bitcode(&bytes).expect("round-trip must succeed");
         // The serialised type at the same index must decode as Metadata.
         let td = ctx2.get_type(meta_ty);
-        assert_eq!(td, &TypeData::Metadata,
-            "Metadata type must round-trip as TypeData::Metadata, not Label");
+        assert_eq!(
+            td,
+            &TypeData::Metadata,
+            "Metadata type must round-trip as TypeData::Metadata, not Label"
+        );
     }
 
     #[test]
@@ -144,7 +147,8 @@ mod tests {
         let bad = b"BAAD\x01\x00\x00\x00\x00\x00\x00\x00";
         let result = read_bitcode(bad);
         assert!(result.is_err(), "invalid magic must return an error");
-        if let Err(BitcodeError::InvalidMagic) = result { /* ok */ } else {
+        if let Err(BitcodeError::InvalidMagic) = result { /* ok */
+        } else {
             panic!("expected InvalidMagic error");
         }
     }

--- a/src/llvm-bitcode/src/reader.rs
+++ b/src/llvm-bitcode/src/reader.rs
@@ -1,12 +1,12 @@
 //! Bitcode reader: parses the LRIR binary format and reconstructs a `(Context, Module)`.
 
-use llvm_ir::{
-    ArgId, BasicBlock, BlockId, ConstId, ConstantData, Context, FloatKind, Function, GlobalId,
-    InstrId, InstrKind, Instruction, IntArithFlags, FastMathFlags, IntPredicate,
-    FloatPredicate, TailCallKind, Linkage, Module, TypeData, TypeId, ValueRef,
-};
-use llvm_ir::value::Argument;
 use crate::error::BitcodeError;
+use llvm_ir::value::Argument;
+use llvm_ir::{
+    ArgId, BasicBlock, BlockId, ConstId, ConstantData, Context, FastMathFlags, FloatKind,
+    FloatPredicate, Function, GlobalId, InstrId, InstrKind, Instruction, IntArithFlags,
+    IntPredicate, Linkage, Module, TailCallKind, TypeData, TypeId, ValueRef,
+};
 
 /// Magic bytes for the LRIR format.
 const MAGIC: &[u8; 4] = b"LRIR";
@@ -22,7 +22,10 @@ pub fn read_bitcode(bytes: &[u8]) -> Result<(Context, Module), BitcodeError> {
     }
     let version = r.u32()?;
     if version != 1 {
-        return Err(BitcodeError::ParseError(format!("unsupported version {}", version)));
+        return Err(BitcodeError::ParseError(format!(
+            "unsupported version {}",
+            version
+        )));
     }
 
     // ── type table ────────────────────────────────────────────────────────
@@ -66,24 +69,24 @@ pub fn read_bitcode(bytes: &[u8]) -> Result<(Context, Module), BitcodeError> {
 // ── type decoding ──────────────────────────────────────────────────────────
 
 mod type_tag {
-    pub const VOID:     u8 = 0;
-    pub const INTEGER:  u8 = 1;
-    pub const FLOAT:    u8 = 2;
-    pub const POINTER:  u8 = 3;
-    pub const ARRAY:    u8 = 4;
-    pub const VECTOR:   u8 = 5;
-    pub const STRUCT:   u8 = 6;
+    pub const VOID: u8 = 0;
+    pub const INTEGER: u8 = 1;
+    pub const FLOAT: u8 = 2;
+    pub const POINTER: u8 = 3;
+    pub const ARRAY: u8 = 4;
+    pub const VECTOR: u8 = 5;
+    pub const STRUCT: u8 = 6;
     pub const FUNCTION: u8 = 7;
-    pub const LABEL:    u8 = 8;
+    pub const LABEL: u8 = 8;
     pub const METADATA: u8 = 9;
 }
 
 mod float_tag {
-    pub const HALF:    u8 = 0;
-    pub const BFLOAT:  u8 = 1;
-    pub const SINGLE:  u8 = 2;
-    pub const DOUBLE:  u8 = 3;
-    pub const FP128:   u8 = 4;
+    pub const HALF: u8 = 0;
+    pub const BFLOAT: u8 = 1;
+    pub const SINGLE: u8 = 2;
+    pub const DOUBLE: u8 = 3;
+    pub const FP128: u8 = 4;
     pub const X86FP80: u8 = 5;
 }
 
@@ -91,7 +94,7 @@ mod float_tag {
 fn decode_type(r: &mut Reader, type_id_map: &[TypeId]) -> Result<TypeData, BitcodeError> {
     let tag = r.u8()?;
     match tag {
-        type_tag::VOID    => Ok(TypeData::Void),
+        type_tag::VOID => Ok(TypeData::Void),
         type_tag::INTEGER => {
             let bits = r.u32()?;
             Ok(TypeData::Integer(bits))
@@ -99,13 +102,13 @@ fn decode_type(r: &mut Reader, type_id_map: &[TypeId]) -> Result<TypeData, Bitco
         type_tag::FLOAT => {
             let ftag = r.u8()?;
             let kind = match ftag {
-                float_tag::HALF    => FloatKind::Half,
-                float_tag::BFLOAT  => FloatKind::BFloat,
-                float_tag::SINGLE  => FloatKind::Single,
-                float_tag::DOUBLE  => FloatKind::Double,
-                float_tag::FP128   => FloatKind::Fp128,
+                float_tag::HALF => FloatKind::Half,
+                float_tag::BFLOAT => FloatKind::BFloat,
+                float_tag::SINGLE => FloatKind::Single,
+                float_tag::DOUBLE => FloatKind::Double,
+                float_tag::FP128 => FloatKind::Fp128,
                 float_tag::X86FP80 => FloatKind::X86Fp80,
-                _  => return Err(BitcodeError::InvalidType),
+                _ => return Err(BitcodeError::InvalidType),
             };
             Ok(TypeData::Float(kind))
         }
@@ -121,7 +124,11 @@ fn decode_type(r: &mut Reader, type_id_map: &[TypeId]) -> Result<TypeData, Bitco
             let len = r.u32()?;
             let scalable = r.u8()? != 0;
             let element = map_type_id(type_id_map, elem_raw)?;
-            Ok(TypeData::Vector { element, len, scalable })
+            Ok(TypeData::Vector {
+                element,
+                len,
+                scalable,
+            })
         }
         type_tag::STRUCT => {
             let name = r.opt_string()?;
@@ -132,7 +139,11 @@ fn decode_type(r: &mut Reader, type_id_map: &[TypeId]) -> Result<TypeData, Bitco
                 let fid_raw = r.u32()? as usize;
                 fields.push(map_type_id(type_id_map, fid_raw)?);
             }
-            Ok(TypeData::Struct(llvm_ir::StructType { name, fields, packed }))
+            Ok(TypeData::Struct(llvm_ir::StructType {
+                name,
+                fields,
+                packed,
+            }))
         }
         type_tag::FUNCTION => {
             let ret_raw = r.u32()? as usize;
@@ -144,37 +155,50 @@ fn decode_type(r: &mut Reader, type_id_map: &[TypeId]) -> Result<TypeData, Bitco
                 params.push(map_type_id(type_id_map, pid_raw)?);
             }
             let ret = map_type_id(type_id_map, ret_raw)?;
-            Ok(TypeData::Function(llvm_ir::FunctionType { ret, params, variadic }))
+            Ok(TypeData::Function(llvm_ir::FunctionType {
+                ret,
+                params,
+                variadic,
+            }))
         }
-        type_tag::LABEL    => Ok(TypeData::Label),
+        type_tag::LABEL => Ok(TypeData::Label),
         type_tag::METADATA => Ok(TypeData::Metadata),
-        _  => Err(BitcodeError::InvalidType),
+        _ => Err(BitcodeError::InvalidType),
     }
 }
 
 fn map_type_id(type_id_map: &[TypeId], raw: usize) -> Result<TypeId, BitcodeError> {
-    type_id_map.get(raw).copied().ok_or(BitcodeError::ParseError(
-        format!("type id {} out of range (table size {})", raw, type_id_map.len())
-    ))
+    type_id_map.get(raw).copied().ok_or_else(|| {
+        BitcodeError::ParseError(format!(
+            "type id {} out of range (table size {})",
+            raw,
+            type_id_map.len()
+        ))
+    })
 }
 
 fn map_const_id(const_id_map: &[ConstId], raw: usize) -> Result<ConstId, BitcodeError> {
-    const_id_map.get(raw).copied().ok_or(BitcodeError::ParseError(
-        format!("const id {} out of range", raw)
-    ))
+    const_id_map
+        .get(raw)
+        .copied()
+        .ok_or_else(|| BitcodeError::ParseError(format!("const id {} out of range", raw)))
 }
 
 /// Intern a TypeData into the Context and return the TypeId.
 fn intern_type(ctx: &mut Context, td: TypeData) -> TypeId {
     match td {
-        TypeData::Void       => ctx.void_ty,
+        TypeData::Void => ctx.void_ty,
         TypeData::Integer(b) => ctx.mk_int(b),
-        TypeData::Float(k)   => ctx.mk_float(k),
-        TypeData::Pointer    => ctx.mk_ptr(),
-        TypeData::Label      => ctx.mk_label(),
-        TypeData::Metadata   => ctx.mk_metadata(),
+        TypeData::Float(k) => ctx.mk_float(k),
+        TypeData::Pointer => ctx.mk_ptr(),
+        TypeData::Label => ctx.mk_label(),
+        TypeData::Metadata => ctx.mk_metadata(),
         TypeData::Array { element, len } => ctx.mk_array(element, len),
-        TypeData::Vector { element, len, scalable } => ctx.mk_vector(element, len, scalable),
+        TypeData::Vector {
+            element,
+            len,
+            scalable,
+        } => ctx.mk_vector(element, len, scalable),
         TypeData::Struct(st) => {
             if let Some(ref name) = st.name {
                 let id = ctx.mk_struct_named(name.clone());
@@ -191,16 +215,16 @@ fn intern_type(ctx: &mut Context, td: TypeData) -> TypeId {
 // ── constant decoding ─────────────────────────────────────────────────────
 
 mod const_tag {
-    pub const INT:        u8 = 0;
-    pub const INT_WIDE:   u8 = 1;
-    pub const FLOAT:      u8 = 2;
-    pub const NULL:       u8 = 3;
-    pub const UNDEF:      u8 = 4;
-    pub const POISON:     u8 = 5;
-    pub const ZERO_INIT:  u8 = 6;
-    pub const ARRAY:      u8 = 7;
-    pub const STRUCT:     u8 = 8;
-    pub const VECTOR:     u8 = 9;
+    pub const INT: u8 = 0;
+    pub const INT_WIDE: u8 = 1;
+    pub const FLOAT: u8 = 2;
+    pub const NULL: u8 = 3;
+    pub const UNDEF: u8 = 4;
+    pub const POISON: u8 = 5;
+    pub const ZERO_INIT: u8 = 6;
+    pub const ARRAY: u8 = 7;
+    pub const STRUCT: u8 = 8;
+    pub const VECTOR: u8 = 9;
     pub const GLOBAL_REF: u8 = 10;
 }
 
@@ -220,7 +244,9 @@ fn decode_const(
             let ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let word_count = r.u32()? as usize;
             let mut words = Vec::with_capacity(word_count);
-            for _ in 0..word_count { words.push(r.u64()?); }
+            for _ in 0..word_count {
+                words.push(r.u64()?);
+            }
             Ok(ConstantData::IntWide { ty, words })
         }
         const_tag::FLOAT => {
@@ -228,36 +254,64 @@ fn decode_const(
             let bits = r.u64()?;
             Ok(ConstantData::Float { ty, bits })
         }
-        const_tag::NULL      => { let ty = map_type_id(type_id_map, r.u32()? as usize)?; Ok(ConstantData::Null(ty)) }
-        const_tag::UNDEF     => { let ty = map_type_id(type_id_map, r.u32()? as usize)?; Ok(ConstantData::Undef(ty)) }
-        const_tag::POISON    => { let ty = map_type_id(type_id_map, r.u32()? as usize)?; Ok(ConstantData::Poison(ty)) }
-        const_tag::ZERO_INIT => { let ty = map_type_id(type_id_map, r.u32()? as usize)?; Ok(ConstantData::ZeroInitializer(ty)) }
+        const_tag::NULL => {
+            let ty = map_type_id(type_id_map, r.u32()? as usize)?;
+            Ok(ConstantData::Null(ty))
+        }
+        const_tag::UNDEF => {
+            let ty = map_type_id(type_id_map, r.u32()? as usize)?;
+            Ok(ConstantData::Undef(ty))
+        }
+        const_tag::POISON => {
+            let ty = map_type_id(type_id_map, r.u32()? as usize)?;
+            Ok(ConstantData::Poison(ty))
+        }
+        const_tag::ZERO_INIT => {
+            let ty = map_type_id(type_id_map, r.u32()? as usize)?;
+            Ok(ConstantData::ZeroInitializer(ty))
+        }
         const_tag::ARRAY => {
             let ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let n = r.u32()? as usize;
             let mut elems = Vec::with_capacity(n);
-            for _ in 0..n { elems.push(map_const_id(const_id_map, r.u32()? as usize)?); }
-            Ok(ConstantData::Array { ty, elements: elems })
+            for _ in 0..n {
+                elems.push(map_const_id(const_id_map, r.u32()? as usize)?);
+            }
+            Ok(ConstantData::Array {
+                ty,
+                elements: elems,
+            })
         }
         const_tag::STRUCT => {
             let ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let n = r.u32()? as usize;
             let mut fields = Vec::with_capacity(n);
-            for _ in 0..n { fields.push(map_const_id(const_id_map, r.u32()? as usize)?); }
+            for _ in 0..n {
+                fields.push(map_const_id(const_id_map, r.u32()? as usize)?);
+            }
             Ok(ConstantData::Struct { ty, fields })
         }
         const_tag::VECTOR => {
             let ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let n = r.u32()? as usize;
             let mut elems = Vec::with_capacity(n);
-            for _ in 0..n { elems.push(map_const_id(const_id_map, r.u32()? as usize)?); }
-            Ok(ConstantData::Vector { ty, elements: elems })
+            for _ in 0..n {
+                elems.push(map_const_id(const_id_map, r.u32()? as usize)?);
+            }
+            Ok(ConstantData::Vector {
+                ty,
+                elements: elems,
+            })
         }
         const_tag::GLOBAL_REF => {
             let ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let id_raw = r.u32()?;
             let name = r.string()?;
-            Ok(ConstantData::GlobalRef { ty, id: GlobalId(id_raw), name })
+            Ok(ConstantData::GlobalRef {
+                ty,
+                id: GlobalId(id_raw),
+                name,
+            })
         }
         other => Err(BitcodeError::UnsupportedRecord(other as u32)),
     }
@@ -266,27 +320,27 @@ fn decode_const(
 // ── function decoding ─────────────────────────────────────────────────────
 
 mod linkage_tag {
-    pub const PRIVATE:               u8 = 0;
-    pub const INTERNAL:              u8 = 1;
-    pub const EXTERNAL:              u8 = 2;
-    pub const WEAK:                  u8 = 3;
-    pub const WEAK_ODR:              u8 = 4;
-    pub const LINK_ONCE:             u8 = 5;
-    pub const LINK_ONCE_ODR:         u8 = 6;
-    pub const COMMON:                u8 = 7;
-    pub const AVAILABLE_EXTERNALLY:  u8 = 8;
+    pub const PRIVATE: u8 = 0;
+    pub const INTERNAL: u8 = 1;
+    pub const EXTERNAL: u8 = 2;
+    pub const WEAK: u8 = 3;
+    pub const WEAK_ODR: u8 = 4;
+    pub const LINK_ONCE: u8 = 5;
+    pub const LINK_ONCE_ODR: u8 = 6;
+    pub const COMMON: u8 = 7;
+    pub const AVAILABLE_EXTERNALLY: u8 = 8;
 }
 
 fn decode_linkage(tag: u8) -> Result<Linkage, BitcodeError> {
     match tag {
-        linkage_tag::PRIVATE              => Ok(Linkage::Private),
-        linkage_tag::INTERNAL             => Ok(Linkage::Internal),
-        linkage_tag::EXTERNAL             => Ok(Linkage::External),
-        linkage_tag::WEAK                 => Ok(Linkage::Weak),
-        linkage_tag::WEAK_ODR             => Ok(Linkage::WeakOdr),
-        linkage_tag::LINK_ONCE            => Ok(Linkage::LinkOnce),
-        linkage_tag::LINK_ONCE_ODR        => Ok(Linkage::LinkOnceOdr),
-        linkage_tag::COMMON               => Ok(Linkage::Common),
+        linkage_tag::PRIVATE => Ok(Linkage::Private),
+        linkage_tag::INTERNAL => Ok(Linkage::Internal),
+        linkage_tag::EXTERNAL => Ok(Linkage::External),
+        linkage_tag::WEAK => Ok(Linkage::Weak),
+        linkage_tag::WEAK_ODR => Ok(Linkage::WeakOdr),
+        linkage_tag::LINK_ONCE => Ok(Linkage::LinkOnce),
+        linkage_tag::LINK_ONCE_ODR => Ok(Linkage::LinkOnceOdr),
+        linkage_tag::COMMON => Ok(Linkage::Common),
         linkage_tag::AVAILABLE_EXTERNALLY => Ok(Linkage::AvailableExternally),
         other => Err(BitcodeError::UnsupportedRecord(other as u32)),
     }
@@ -311,7 +365,11 @@ fn decode_function(
         let aty_raw = r.u32()? as usize;
         let aty = map_type_id(type_id_map, aty_raw)?;
         let index = r.u32()?;
-        args.push(Argument { name: aname, ty: aty, index });
+        args.push(Argument {
+            name: aname,
+            ty: aty,
+            index,
+        });
     }
 
     let mut func = if is_declaration {
@@ -329,7 +387,9 @@ fn decode_function(
         let bname = r.string()?;
         let body_count = r.u32()? as usize;
         let mut body = Vec::with_capacity(body_count);
-        for _ in 0..body_count { body.push(r.u32()?); }
+        for _ in 0..body_count {
+            body.push(r.u32()?);
+        }
         let term = r.u32()?;
         block_records.push((bname, body, term));
     }
@@ -361,57 +421,57 @@ fn decode_function(
 // ── instruction decoding ──────────────────────────────────────────────────
 
 mod instr_tag {
-    pub const ADD:          u32 = 0;
-    pub const SUB:          u32 = 1;
-    pub const MUL:          u32 = 2;
-    pub const UDIV:         u32 = 3;
-    pub const SDIV:         u32 = 4;
-    pub const UREM:         u32 = 5;
-    pub const SREM:         u32 = 6;
-    pub const AND:          u32 = 10;
-    pub const OR:           u32 = 11;
-    pub const XOR:          u32 = 12;
-    pub const SHL:          u32 = 13;
-    pub const LSHR:         u32 = 14;
-    pub const ASHR:         u32 = 15;
-    pub const FADD:         u32 = 20;
-    pub const FSUB:         u32 = 21;
-    pub const FMUL:         u32 = 22;
-    pub const FDIV:         u32 = 23;
-    pub const FREM:         u32 = 24;
-    pub const FNEG:         u32 = 25;
-    pub const ICMP:         u32 = 30;
-    pub const FCMP:         u32 = 31;
-    pub const ALLOCA:       u32 = 40;
-    pub const LOAD:         u32 = 41;
-    pub const STORE:        u32 = 42;
-    pub const GEP:          u32 = 43;
-    pub const TRUNC:        u32 = 50;
-    pub const ZEXT:         u32 = 51;
-    pub const SEXT:         u32 = 52;
-    pub const FPTRUNC:      u32 = 53;
-    pub const FPEXT:        u32 = 54;
-    pub const FPTOUI:       u32 = 55;
-    pub const FPTOSI:       u32 = 56;
-    pub const UITOFP:       u32 = 57;
-    pub const SITOFP:       u32 = 58;
-    pub const PTRTOINT:     u32 = 59;
-    pub const INTTOPTR:     u32 = 60;
-    pub const BITCAST:      u32 = 61;
+    pub const ADD: u32 = 0;
+    pub const SUB: u32 = 1;
+    pub const MUL: u32 = 2;
+    pub const UDIV: u32 = 3;
+    pub const SDIV: u32 = 4;
+    pub const UREM: u32 = 5;
+    pub const SREM: u32 = 6;
+    pub const AND: u32 = 10;
+    pub const OR: u32 = 11;
+    pub const XOR: u32 = 12;
+    pub const SHL: u32 = 13;
+    pub const LSHR: u32 = 14;
+    pub const ASHR: u32 = 15;
+    pub const FADD: u32 = 20;
+    pub const FSUB: u32 = 21;
+    pub const FMUL: u32 = 22;
+    pub const FDIV: u32 = 23;
+    pub const FREM: u32 = 24;
+    pub const FNEG: u32 = 25;
+    pub const ICMP: u32 = 30;
+    pub const FCMP: u32 = 31;
+    pub const ALLOCA: u32 = 40;
+    pub const LOAD: u32 = 41;
+    pub const STORE: u32 = 42;
+    pub const GEP: u32 = 43;
+    pub const TRUNC: u32 = 50;
+    pub const ZEXT: u32 = 51;
+    pub const SEXT: u32 = 52;
+    pub const FPTRUNC: u32 = 53;
+    pub const FPEXT: u32 = 54;
+    pub const FPTOUI: u32 = 55;
+    pub const FPTOSI: u32 = 56;
+    pub const UITOFP: u32 = 57;
+    pub const SITOFP: u32 = 58;
+    pub const PTRTOINT: u32 = 59;
+    pub const INTTOPTR: u32 = 60;
+    pub const BITCAST: u32 = 61;
     pub const ADDRSPACECAST: u32 = 62;
-    pub const SELECT:       u32 = 70;
-    pub const PHI:          u32 = 71;
+    pub const SELECT: u32 = 70;
+    pub const PHI: u32 = 71;
     pub const EXTRACTVALUE: u32 = 72;
-    pub const INSERTVALUE:  u32 = 73;
-    pub const EXTRACTELEM:  u32 = 74;
-    pub const INSERTELEM:   u32 = 75;
-    pub const SHUFFLEVEC:   u32 = 76;
-    pub const CALL:         u32 = 80;
-    pub const RET:          u32 = 90;
-    pub const BR:           u32 = 91;
-    pub const CONDBR:       u32 = 92;
-    pub const SWITCH:       u32 = 93;
-    pub const UNREACHABLE:  u32 = 94;
+    pub const INSERTVALUE: u32 = 73;
+    pub const EXTRACTELEM: u32 = 74;
+    pub const INSERTELEM: u32 = 75;
+    pub const SHUFFLEVEC: u32 = 76;
+    pub const CALL: u32 = 80;
+    pub const RET: u32 = 90;
+    pub const BR: u32 = 91;
+    pub const CONDBR: u32 = 92;
+    pub const SWITCH: u32 = 93;
+    pub const UNREACHABLE: u32 = 94;
 }
 
 fn decode_vref(r: &mut Reader) -> Result<ValueRef, BitcodeError> {
@@ -428,35 +488,56 @@ fn decode_vref(r: &mut Reader) -> Result<ValueRef, BitcodeError> {
 
 fn decode_opt_vref(r: &mut Reader) -> Result<Option<ValueRef>, BitcodeError> {
     let present = r.u8()?;
-    if present != 0 { Ok(Some(decode_vref(r)?)) } else { Ok(None) }
+    if present != 0 {
+        Ok(Some(decode_vref(r)?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn decode_opt_u32(r: &mut Reader) -> Result<Option<u32>, BitcodeError> {
     let present = r.u8()?;
-    if present != 0 { Ok(Some(r.u32()?)) } else { Ok(None) }
+    if present != 0 {
+        Ok(Some(r.u32()?))
+    } else {
+        Ok(None)
+    }
 }
 
 fn decode_int_pred(tag: u8) -> Result<IntPredicate, BitcodeError> {
     match tag {
-        0 => Ok(IntPredicate::Eq),  1 => Ok(IntPredicate::Ne),
-        2 => Ok(IntPredicate::Ugt), 3 => Ok(IntPredicate::Uge),
-        4 => Ok(IntPredicate::Ult), 5 => Ok(IntPredicate::Ule),
-        6 => Ok(IntPredicate::Sgt), 7 => Ok(IntPredicate::Sge),
-        8 => Ok(IntPredicate::Slt), 9 => Ok(IntPredicate::Sle),
+        0 => Ok(IntPredicate::Eq),
+        1 => Ok(IntPredicate::Ne),
+        2 => Ok(IntPredicate::Ugt),
+        3 => Ok(IntPredicate::Uge),
+        4 => Ok(IntPredicate::Ult),
+        5 => Ok(IntPredicate::Ule),
+        6 => Ok(IntPredicate::Sgt),
+        7 => Ok(IntPredicate::Sge),
+        8 => Ok(IntPredicate::Slt),
+        9 => Ok(IntPredicate::Sle),
         other => Err(BitcodeError::UnsupportedRecord(other as u32)),
     }
 }
 
 fn decode_float_pred(tag: u8) -> Result<FloatPredicate, BitcodeError> {
     match tag {
-        0  => Ok(FloatPredicate::False), 1  => Ok(FloatPredicate::Oeq),
-        2  => Ok(FloatPredicate::Ogt),   3  => Ok(FloatPredicate::Oge),
-        4  => Ok(FloatPredicate::Olt),   5  => Ok(FloatPredicate::Ole),
-        6  => Ok(FloatPredicate::One),   7  => Ok(FloatPredicate::Ord),
-        8  => Ok(FloatPredicate::Uno),   9  => Ok(FloatPredicate::Ueq),
-        10 => Ok(FloatPredicate::Ugt),   11 => Ok(FloatPredicate::Uge),
-        12 => Ok(FloatPredicate::Ult),   13 => Ok(FloatPredicate::Ule),
-        14 => Ok(FloatPredicate::Une),   15 => Ok(FloatPredicate::True),
+        0 => Ok(FloatPredicate::False),
+        1 => Ok(FloatPredicate::Oeq),
+        2 => Ok(FloatPredicate::Ogt),
+        3 => Ok(FloatPredicate::Oge),
+        4 => Ok(FloatPredicate::Olt),
+        5 => Ok(FloatPredicate::Ole),
+        6 => Ok(FloatPredicate::One),
+        7 => Ok(FloatPredicate::Ord),
+        8 => Ok(FloatPredicate::Uno),
+        9 => Ok(FloatPredicate::Ueq),
+        10 => Ok(FloatPredicate::Ugt),
+        11 => Ok(FloatPredicate::Uge),
+        12 => Ok(FloatPredicate::Ult),
+        13 => Ok(FloatPredicate::Ule),
+        14 => Ok(FloatPredicate::Une),
+        15 => Ok(FloatPredicate::True),
         other => Err(BitcodeError::UnsupportedRecord(other as u32)),
     }
 }
@@ -473,80 +554,177 @@ fn decode_instr(
     let tag = r.u32()?;
 
     let kind = match tag {
-        instr_tag::ADD  => {
-            let nuw = r.u8()? != 0; let nsw = r.u8()? != 0;
+        instr_tag::ADD => {
+            let nuw = r.u8()? != 0;
+            let nsw = r.u8()? != 0;
             let flags = IntArithFlags { nuw, nsw };
-            InstrKind::Add  { flags, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::Add {
+                flags,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
-        instr_tag::SUB  => {
-            let nuw = r.u8()? != 0; let nsw = r.u8()? != 0;
+        instr_tag::SUB => {
+            let nuw = r.u8()? != 0;
+            let nsw = r.u8()? != 0;
             let flags = IntArithFlags { nuw, nsw };
-            InstrKind::Sub  { flags, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::Sub {
+                flags,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
-        instr_tag::MUL  => {
-            let nuw = r.u8()? != 0; let nsw = r.u8()? != 0;
+        instr_tag::MUL => {
+            let nuw = r.u8()? != 0;
+            let nsw = r.u8()? != 0;
             let flags = IntArithFlags { nuw, nsw };
-            InstrKind::Mul  { flags, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::Mul {
+                flags,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::UDIV => {
             let exact = r.u8()? != 0;
-            InstrKind::UDiv { exact, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::UDiv {
+                exact,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::SDIV => {
             let exact = r.u8()? != 0;
-            InstrKind::SDiv { exact, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::SDiv {
+                exact,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
-        instr_tag::UREM => InstrKind::URem { lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::SREM => InstrKind::SRem { lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::AND  => InstrKind::And  { lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::OR   => InstrKind::Or   { lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::XOR  => InstrKind::Xor  { lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::SHL  => {
-            let nuw = r.u8()? != 0; let nsw = r.u8()? != 0;
+        instr_tag::UREM => InstrKind::URem {
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::SREM => InstrKind::SRem {
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::AND => InstrKind::And {
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::OR => InstrKind::Or {
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::XOR => InstrKind::Xor {
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::SHL => {
+            let nuw = r.u8()? != 0;
+            let nsw = r.u8()? != 0;
             let flags = IntArithFlags { nuw, nsw };
-            InstrKind::Shl  { flags, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::Shl {
+                flags,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::LSHR => {
             let exact = r.u8()? != 0;
-            InstrKind::LShr { exact, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::LShr {
+                exact,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::ASHR => {
             let exact = r.u8()? != 0;
-            InstrKind::AShr { exact, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::AShr {
+                exact,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
-        instr_tag::FADD => InstrKind::FAdd { flags: FastMathFlags::default(), lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::FSUB => InstrKind::FSub { flags: FastMathFlags::default(), lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::FMUL => InstrKind::FMul { flags: FastMathFlags::default(), lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::FDIV => InstrKind::FDiv { flags: FastMathFlags::default(), lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::FREM => InstrKind::FRem { flags: FastMathFlags::default(), lhs: decode_vref(r)?, rhs: decode_vref(r)? },
-        instr_tag::FNEG => InstrKind::FNeg { flags: FastMathFlags::default(), operand: decode_vref(r)? },
+        instr_tag::FADD => InstrKind::FAdd {
+            flags: FastMathFlags::default(),
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::FSUB => InstrKind::FSub {
+            flags: FastMathFlags::default(),
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::FMUL => InstrKind::FMul {
+            flags: FastMathFlags::default(),
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::FDIV => InstrKind::FDiv {
+            flags: FastMathFlags::default(),
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::FREM => InstrKind::FRem {
+            flags: FastMathFlags::default(),
+            lhs: decode_vref(r)?,
+            rhs: decode_vref(r)?,
+        },
+        instr_tag::FNEG => InstrKind::FNeg {
+            flags: FastMathFlags::default(),
+            operand: decode_vref(r)?,
+        },
         instr_tag::ICMP => {
             let pred = decode_int_pred(r.u8()?)?;
-            InstrKind::ICmp { pred, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::ICmp {
+                pred,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::FCMP => {
             let pred = decode_float_pred(r.u8()?)?;
-            InstrKind::FCmp { flags: FastMathFlags::default(), pred, lhs: decode_vref(r)?, rhs: decode_vref(r)? }
+            InstrKind::FCmp {
+                flags: FastMathFlags::default(),
+                pred,
+                lhs: decode_vref(r)?,
+                rhs: decode_vref(r)?,
+            }
         }
         instr_tag::ALLOCA => {
             let alloc_ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let num_elements = decode_opt_vref(r)?;
             let align = decode_opt_u32(r)?;
-            InstrKind::Alloca { alloc_ty, num_elements, align }
+            InstrKind::Alloca {
+                alloc_ty,
+                num_elements,
+                align,
+            }
         }
         instr_tag::LOAD => {
             let lty = map_type_id(type_id_map, r.u32()? as usize)?;
             let ptr = decode_vref(r)?;
             let align = decode_opt_u32(r)?;
             let volatile = r.u8()? != 0;
-            InstrKind::Load { ty: lty, ptr, align, volatile }
+            InstrKind::Load {
+                ty: lty,
+                ptr,
+                align,
+                volatile,
+            }
         }
         instr_tag::STORE => {
             let val = decode_vref(r)?;
             let ptr = decode_vref(r)?;
             let align = decode_opt_u32(r)?;
             let volatile = r.u8()? != 0;
-            InstrKind::Store { val, ptr, align, volatile }
+            InstrKind::Store {
+                val,
+                ptr,
+                align,
+                volatile,
+            }
         }
         instr_tag::GEP => {
             let inbounds = r.u8()? != 0;
@@ -554,25 +732,86 @@ fn decode_instr(
             let ptr = decode_vref(r)?;
             let idx_count = r.u32()? as usize;
             let mut indices = Vec::with_capacity(idx_count);
-            for _ in 0..idx_count { indices.push(decode_vref(r)?); }
-            InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices }
+            for _ in 0..idx_count {
+                indices.push(decode_vref(r)?);
+            }
+            InstrKind::GetElementPtr {
+                inbounds,
+                base_ty,
+                ptr,
+                indices,
+            }
         }
-        instr_tag::TRUNC        => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::Trunc { val, to } }
-        instr_tag::ZEXT         => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::ZExt { val, to } }
-        instr_tag::SEXT         => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::SExt { val, to } }
-        instr_tag::FPTRUNC      => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::FPTrunc { val, to } }
-        instr_tag::FPEXT        => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::FPExt { val, to } }
-        instr_tag::FPTOUI       => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::FPToUI { val, to } }
-        instr_tag::FPTOSI       => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::FPToSI { val, to } }
-        instr_tag::UITOFP       => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::UIToFP { val, to } }
-        instr_tag::SITOFP       => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::SIToFP { val, to } }
-        instr_tag::PTRTOINT     => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::PtrToInt { val, to } }
-        instr_tag::INTTOPTR     => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::IntToPtr { val, to } }
-        instr_tag::BITCAST      => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::BitCast { val, to } }
-        instr_tag::ADDRSPACECAST => { let val = decode_vref(r)?; let to = map_type_id(type_id_map, r.u32()? as usize)?; InstrKind::AddrSpaceCast { val, to } }
-        instr_tag::SELECT => {
-            InstrKind::Select { cond: decode_vref(r)?, then_val: decode_vref(r)?, else_val: decode_vref(r)? }
+        instr_tag::TRUNC => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::Trunc { val, to }
         }
+        instr_tag::ZEXT => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::ZExt { val, to }
+        }
+        instr_tag::SEXT => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::SExt { val, to }
+        }
+        instr_tag::FPTRUNC => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::FPTrunc { val, to }
+        }
+        instr_tag::FPEXT => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::FPExt { val, to }
+        }
+        instr_tag::FPTOUI => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::FPToUI { val, to }
+        }
+        instr_tag::FPTOSI => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::FPToSI { val, to }
+        }
+        instr_tag::UITOFP => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::UIToFP { val, to }
+        }
+        instr_tag::SITOFP => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::SIToFP { val, to }
+        }
+        instr_tag::PTRTOINT => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::PtrToInt { val, to }
+        }
+        instr_tag::INTTOPTR => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::IntToPtr { val, to }
+        }
+        instr_tag::BITCAST => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::BitCast { val, to }
+        }
+        instr_tag::ADDRSPACECAST => {
+            let val = decode_vref(r)?;
+            let to = map_type_id(type_id_map, r.u32()? as usize)?;
+            InstrKind::AddrSpaceCast { val, to }
+        }
+        instr_tag::SELECT => InstrKind::Select {
+            cond: decode_vref(r)?,
+            then_val: decode_vref(r)?,
+            else_val: decode_vref(r)?,
+        },
         instr_tag::PHI => {
             let phi_ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let in_count = r.u32()? as usize;
@@ -582,56 +821,93 @@ fn decode_instr(
                 let bid = BlockId(r.u32()?);
                 incoming.push((vr, bid));
             }
-            InstrKind::Phi { ty: phi_ty, incoming }
+            InstrKind::Phi {
+                ty: phi_ty,
+                incoming,
+            }
         }
         instr_tag::EXTRACTVALUE => {
             let agg = decode_vref(r)?;
             let idx_count = r.u32()? as usize;
             let mut indices = Vec::with_capacity(idx_count);
-            for _ in 0..idx_count { indices.push(r.u32()?); }
-            InstrKind::ExtractValue { aggregate: agg, indices }
+            for _ in 0..idx_count {
+                indices.push(r.u32()?);
+            }
+            InstrKind::ExtractValue {
+                aggregate: agg,
+                indices,
+            }
         }
         instr_tag::INSERTVALUE => {
             let agg = decode_vref(r)?;
             let val = decode_vref(r)?;
             let idx_count = r.u32()? as usize;
             let mut indices = Vec::with_capacity(idx_count);
-            for _ in 0..idx_count { indices.push(r.u32()?); }
-            InstrKind::InsertValue { aggregate: agg, val, indices }
+            for _ in 0..idx_count {
+                indices.push(r.u32()?);
+            }
+            InstrKind::InsertValue {
+                aggregate: agg,
+                val,
+                indices,
+            }
         }
-        instr_tag::EXTRACTELEM => {
-            InstrKind::ExtractElement { vec: decode_vref(r)?, idx: decode_vref(r)? }
-        }
-        instr_tag::INSERTELEM => {
-            InstrKind::InsertElement { vec: decode_vref(r)?, val: decode_vref(r)?, idx: decode_vref(r)? }
-        }
+        instr_tag::EXTRACTELEM => InstrKind::ExtractElement {
+            vec: decode_vref(r)?,
+            idx: decode_vref(r)?,
+        },
+        instr_tag::INSERTELEM => InstrKind::InsertElement {
+            vec: decode_vref(r)?,
+            val: decode_vref(r)?,
+            idx: decode_vref(r)?,
+        },
         instr_tag::SHUFFLEVEC => {
-            let v1 = decode_vref(r)?; let v2 = decode_vref(r)?;
+            let v1 = decode_vref(r)?;
+            let v2 = decode_vref(r)?;
             let n = r.u32()? as usize;
             let mut mask = Vec::with_capacity(n);
-            for _ in 0..n { mask.push(r.i32()?); }
+            for _ in 0..n {
+                mask.push(r.i32()?);
+            }
             InstrKind::ShuffleVector { v1, v2, mask }
         }
         instr_tag::CALL => {
             let tail_tag = r.u8()?;
             let tail = match tail_tag {
-                0 => TailCallKind::None, 1 => TailCallKind::Tail,
-                2 => TailCallKind::MustTail, _ => TailCallKind::NoTail,
+                0 => TailCallKind::None,
+                1 => TailCallKind::Tail,
+                2 => TailCallKind::MustTail,
+                _ => TailCallKind::NoTail,
             };
             let callee_ty = map_type_id(type_id_map, r.u32()? as usize)?;
             let callee = decode_vref(r)?;
             let arg_count = r.u32()? as usize;
             let mut args = Vec::with_capacity(arg_count);
-            for _ in 0..arg_count { args.push(decode_vref(r)?); }
-            InstrKind::Call { tail, callee_ty, callee, args }
+            for _ in 0..arg_count {
+                args.push(decode_vref(r)?);
+            }
+            InstrKind::Call {
+                tail,
+                callee_ty,
+                callee,
+                args,
+            }
         }
-        instr_tag::RET => InstrKind::Ret { val: decode_opt_vref(r)? },
-        instr_tag::BR  => InstrKind::Br  { dest: BlockId(r.u32()?) },
+        instr_tag::RET => InstrKind::Ret {
+            val: decode_opt_vref(r)?,
+        },
+        instr_tag::BR => InstrKind::Br {
+            dest: BlockId(r.u32()?),
+        },
         instr_tag::CONDBR => {
             let cond = decode_vref(r)?;
             let then_dest = BlockId(r.u32()?);
             let else_dest = BlockId(r.u32()?);
-            InstrKind::CondBr { cond, then_dest, else_dest }
+            InstrKind::CondBr {
+                cond,
+                then_dest,
+                else_dest,
+            }
         }
         instr_tag::SWITCH => {
             let val = decode_vref(r)?;
@@ -643,7 +919,11 @@ fn decode_instr(
                 let bd = BlockId(r.u32()?);
                 cases.push((cv, bd));
             }
-            InstrKind::Switch { val, default, cases }
+            InstrKind::Switch {
+                val,
+                default,
+                cases,
+            }
         }
         instr_tag::UNREACHABLE => InstrKind::Unreachable,
         other => return Err(BitcodeError::UnsupportedRecord(other)),
@@ -660,7 +940,9 @@ struct Reader<'a> {
 }
 
 impl<'a> Reader<'a> {
-    fn new(data: &'a [u8]) -> Self { Reader { data, pos: 0 } }
+    fn new(data: &'a [u8]) -> Self {
+        Reader { data, pos: 0 }
+    }
 
     fn read_bytes(&mut self, n: usize) -> Result<&[u8], BitcodeError> {
         if self.pos + n > self.data.len() {
@@ -688,7 +970,9 @@ impl<'a> Reader<'a> {
 
     fn u64(&mut self) -> Result<u64, BitcodeError> {
         let b = self.read_bytes(8)?;
-        Ok(u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+        Ok(u64::from_le_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
     }
 
     /// Read a length-prefixed string (u32 len + UTF-8 bytes).

--- a/src/llvm-bitcode/src/writer.rs
+++ b/src/llvm-bitcode/src/writer.rs
@@ -22,8 +22,8 @@
 //! Optional strings use a 0 length to mean "absent".
 
 use llvm_ir::{
-    BasicBlock, Context, Function, InstrKind, Instruction, Module, TypeData, FloatKind,
-    ConstantData, ValueRef,
+    BasicBlock, ConstantData, Context, FloatKind, Function, InstrKind, Instruction, Module,
+    TypeData, ValueRef,
 };
 
 /// Serialize `(ctx, module)` into the LRIR binary format.
@@ -67,50 +67,61 @@ pub fn write_bitcode(ctx: &Context, module: &Module) -> Vec<u8> {
 
 /// Tag bytes for type records.
 mod type_tag {
-    pub const VOID:     u8 = 0;
-    pub const INTEGER:  u8 = 1;
-    pub const FLOAT:    u8 = 2;
-    pub const POINTER:  u8 = 3;
-    pub const ARRAY:    u8 = 4;
-    pub const VECTOR:   u8 = 5;
-    pub const STRUCT:   u8 = 6;
+    pub const VOID: u8 = 0;
+    pub const INTEGER: u8 = 1;
+    pub const FLOAT: u8 = 2;
+    pub const POINTER: u8 = 3;
+    pub const ARRAY: u8 = 4;
+    pub const VECTOR: u8 = 5;
+    pub const STRUCT: u8 = 6;
     pub const FUNCTION: u8 = 7;
-    pub const LABEL:    u8 = 8;
+    pub const LABEL: u8 = 8;
     pub const METADATA: u8 = 9;
 }
 
 mod float_tag {
-    pub const HALF:    u8 = 0;
-    pub const BFLOAT:  u8 = 1;
-    pub const SINGLE:  u8 = 2;
-    pub const DOUBLE:  u8 = 3;
-    pub const FP128:   u8 = 4;
+    pub const HALF: u8 = 0;
+    pub const BFLOAT: u8 = 1;
+    pub const SINGLE: u8 = 2;
+    pub const DOUBLE: u8 = 3;
+    pub const FP128: u8 = 4;
     pub const X86FP80: u8 = 5;
 }
 
 fn encode_type(w: &mut Writer, td: &TypeData) {
     match td {
-        TypeData::Void    => { w.u8(type_tag::VOID); }
-        TypeData::Integer(bits) => { w.u8(type_tag::INTEGER); w.u32(*bits); }
+        TypeData::Void => {
+            w.u8(type_tag::VOID);
+        }
+        TypeData::Integer(bits) => {
+            w.u8(type_tag::INTEGER);
+            w.u32(*bits);
+        }
         TypeData::Float(kind) => {
             w.u8(type_tag::FLOAT);
             let tag = match kind {
-                FloatKind::Half    => float_tag::HALF,
-                FloatKind::BFloat  => float_tag::BFLOAT,
-                FloatKind::Single  => float_tag::SINGLE,
-                FloatKind::Double  => float_tag::DOUBLE,
-                FloatKind::Fp128   => float_tag::FP128,
+                FloatKind::Half => float_tag::HALF,
+                FloatKind::BFloat => float_tag::BFLOAT,
+                FloatKind::Single => float_tag::SINGLE,
+                FloatKind::Double => float_tag::DOUBLE,
+                FloatKind::Fp128 => float_tag::FP128,
                 FloatKind::X86Fp80 => float_tag::X86FP80,
             };
             w.u8(tag);
         }
-        TypeData::Pointer => { w.u8(type_tag::POINTER); }
+        TypeData::Pointer => {
+            w.u8(type_tag::POINTER);
+        }
         TypeData::Array { element, len } => {
             w.u8(type_tag::ARRAY);
             w.u32(element.0);
             w.u64(*len);
         }
-        TypeData::Vector { element, len, scalable } => {
+        TypeData::Vector {
+            element,
+            len,
+            scalable,
+        } => {
             w.u8(type_tag::VECTOR);
             w.u32(element.0);
             w.u32(*len);
@@ -121,7 +132,7 @@ fn encode_type(w: &mut Writer, td: &TypeData) {
             // Optional name.
             match &st.name {
                 Some(n) => w.string(n),
-                None    => w.u32(0),
+                None => w.u32(0),
             }
             w.u8(if st.packed { 1 } else { 0 });
             w.u32(st.fields.len() as u32);
@@ -138,25 +149,29 @@ fn encode_type(w: &mut Writer, td: &TypeData) {
                 w.u32(p.0);
             }
         }
-        TypeData::Label    => { w.u8(type_tag::LABEL); }
-        TypeData::Metadata => { w.u8(type_tag::METADATA); }
+        TypeData::Label => {
+            w.u8(type_tag::LABEL);
+        }
+        TypeData::Metadata => {
+            w.u8(type_tag::METADATA);
+        }
     }
 }
 
 // ── constant encoding ─────────────────────────────────────────────────────
 
 mod const_tag {
-    pub const INT:             u8 = 0;
-    pub const INT_WIDE:        u8 = 1;
-    pub const FLOAT:           u8 = 2;
-    pub const NULL:            u8 = 3;
-    pub const UNDEF:           u8 = 4;
-    pub const POISON:          u8 = 5;
-    pub const ZERO_INIT:       u8 = 6;
-    pub const ARRAY:           u8 = 7;
-    pub const STRUCT:          u8 = 8;
-    pub const VECTOR:          u8 = 9;
-    pub const GLOBAL_REF:      u8 = 10;
+    pub const INT: u8 = 0;
+    pub const INT_WIDE: u8 = 1;
+    pub const FLOAT: u8 = 2;
+    pub const NULL: u8 = 3;
+    pub const UNDEF: u8 = 4;
+    pub const POISON: u8 = 5;
+    pub const ZERO_INIT: u8 = 6;
+    pub const ARRAY: u8 = 7;
+    pub const STRUCT: u8 = 8;
+    pub const VECTOR: u8 = 9;
+    pub const GLOBAL_REF: u8 = 10;
 }
 
 fn encode_const(w: &mut Writer, cd: &ConstantData) {
@@ -179,27 +194,45 @@ fn encode_const(w: &mut Writer, cd: &ConstantData) {
             w.u32(ty.0);
             w.u64(*bits);
         }
-        ConstantData::Null(ty) => { w.u8(const_tag::NULL); w.u32(ty.0); }
-        ConstantData::Undef(ty) => { w.u8(const_tag::UNDEF); w.u32(ty.0); }
-        ConstantData::Poison(ty) => { w.u8(const_tag::POISON); w.u32(ty.0); }
-        ConstantData::ZeroInitializer(ty) => { w.u8(const_tag::ZERO_INIT); w.u32(ty.0); }
+        ConstantData::Null(ty) => {
+            w.u8(const_tag::NULL);
+            w.u32(ty.0);
+        }
+        ConstantData::Undef(ty) => {
+            w.u8(const_tag::UNDEF);
+            w.u32(ty.0);
+        }
+        ConstantData::Poison(ty) => {
+            w.u8(const_tag::POISON);
+            w.u32(ty.0);
+        }
+        ConstantData::ZeroInitializer(ty) => {
+            w.u8(const_tag::ZERO_INIT);
+            w.u32(ty.0);
+        }
         ConstantData::Array { ty, elements } => {
             w.u8(const_tag::ARRAY);
             w.u32(ty.0);
             w.u32(elements.len() as u32);
-            for &e in elements { w.u32(e.0); }
+            for &e in elements {
+                w.u32(e.0);
+            }
         }
         ConstantData::Struct { ty, fields } => {
             w.u8(const_tag::STRUCT);
             w.u32(ty.0);
             w.u32(fields.len() as u32);
-            for &f in fields { w.u32(f.0); }
+            for &f in fields {
+                w.u32(f.0);
+            }
         }
         ConstantData::Vector { ty, elements } => {
             w.u8(const_tag::VECTOR);
             w.u32(ty.0);
             w.u32(elements.len() as u32);
-            for &e in elements { w.u32(e.0); }
+            for &e in elements {
+                w.u32(e.0);
+            }
         }
         ConstantData::GlobalRef { ty, id, name } => {
             w.u8(const_tag::GLOBAL_REF);
@@ -213,15 +246,15 @@ fn encode_const(w: &mut Writer, cd: &ConstantData) {
 // ── function encoding ─────────────────────────────────────────────────────
 
 mod linkage_tag {
-    pub const PRIVATE:               u8 = 0;
-    pub const INTERNAL:              u8 = 1;
-    pub const EXTERNAL:              u8 = 2;
-    pub const WEAK:                  u8 = 3;
-    pub const WEAK_ODR:              u8 = 4;
-    pub const LINK_ONCE:             u8 = 5;
-    pub const LINK_ONCE_ODR:         u8 = 6;
-    pub const COMMON:                u8 = 7;
-    pub const AVAILABLE_EXTERNALLY:  u8 = 8;
+    pub const PRIVATE: u8 = 0;
+    pub const INTERNAL: u8 = 1;
+    pub const EXTERNAL: u8 = 2;
+    pub const WEAK: u8 = 3;
+    pub const WEAK_ODR: u8 = 4;
+    pub const LINK_ONCE: u8 = 5;
+    pub const LINK_ONCE_ODR: u8 = 6;
+    pub const COMMON: u8 = 7;
+    pub const AVAILABLE_EXTERNALLY: u8 = 8;
 }
 
 fn encode_function(w: &mut Writer, func: &Function) {
@@ -230,15 +263,15 @@ fn encode_function(w: &mut Writer, func: &Function) {
     // Linkage.
     use llvm_ir::Linkage;
     let ltag = match func.linkage {
-        Linkage::Private              => linkage_tag::PRIVATE,
-        Linkage::Internal             => linkage_tag::INTERNAL,
-        Linkage::External             => linkage_tag::EXTERNAL,
-        Linkage::Weak                 => linkage_tag::WEAK,
-        Linkage::WeakOdr              => linkage_tag::WEAK_ODR,
-        Linkage::LinkOnce             => linkage_tag::LINK_ONCE,
-        Linkage::LinkOnceOdr          => linkage_tag::LINK_ONCE_ODR,
-        Linkage::Common               => linkage_tag::COMMON,
-        Linkage::AvailableExternally  => linkage_tag::AVAILABLE_EXTERNALLY,
+        Linkage::Private => linkage_tag::PRIVATE,
+        Linkage::Internal => linkage_tag::INTERNAL,
+        Linkage::External => linkage_tag::EXTERNAL,
+        Linkage::Weak => linkage_tag::WEAK,
+        Linkage::WeakOdr => linkage_tag::WEAK_ODR,
+        Linkage::LinkOnce => linkage_tag::LINK_ONCE,
+        Linkage::LinkOnceOdr => linkage_tag::LINK_ONCE_ODR,
+        Linkage::Common => linkage_tag::COMMON,
+        Linkage::AvailableExternally => linkage_tag::AVAILABLE_EXTERNALLY,
     };
     w.u8(ltag);
     w.u8(if func.is_declaration { 1 } else { 0 });
@@ -273,7 +306,7 @@ fn encode_block(w: &mut Writer, bb: &BasicBlock, func: &Function) {
     // Terminator: 0xFFFFFFFF means None.
     match bb.terminator {
         Some(tid) => w.u32(tid.0),
-        None      => w.u32(0xFFFF_FFFF),
+        None => w.u32(0xFFFF_FFFF),
     }
     let _ = func;
 }
@@ -284,72 +317,89 @@ fn encode_block(w: &mut Writer, bb: &BasicBlock, func: &Function) {
 // For the full round-trip, we need the instruction name, type, and kind.
 
 mod instr_tag {
-    pub const ADD:         u32 = 0;
-    pub const SUB:         u32 = 1;
-    pub const MUL:         u32 = 2;
-    pub const UDIV:        u32 = 3;
-    pub const SDIV:        u32 = 4;
-    pub const UREM:        u32 = 5;
-    pub const SREM:        u32 = 6;
-    pub const AND:         u32 = 10;
-    pub const OR:          u32 = 11;
-    pub const XOR:         u32 = 12;
-    pub const SHL:         u32 = 13;
-    pub const LSHR:        u32 = 14;
-    pub const ASHR:        u32 = 15;
-    pub const FADD:        u32 = 20;
-    pub const FSUB:        u32 = 21;
-    pub const FMUL:        u32 = 22;
-    pub const FDIV:        u32 = 23;
-    pub const FREM:        u32 = 24;
-    pub const FNEG:        u32 = 25;
-    pub const ICMP:        u32 = 30;
-    pub const FCMP:        u32 = 31;
-    pub const ALLOCA:      u32 = 40;
-    pub const LOAD:        u32 = 41;
-    pub const STORE:       u32 = 42;
-    pub const GEP:         u32 = 43;
-    pub const TRUNC:       u32 = 50;
-    pub const ZEXT:        u32 = 51;
-    pub const SEXT:        u32 = 52;
-    pub const FPTRUNC:     u32 = 53;
-    pub const FPEXT:       u32 = 54;
-    pub const FPTOUI:      u32 = 55;
-    pub const FPTOSI:      u32 = 56;
-    pub const UITOFP:      u32 = 57;
-    pub const SITOFP:      u32 = 58;
-    pub const PTRTOINT:    u32 = 59;
-    pub const INTTOPTR:    u32 = 60;
-    pub const BITCAST:     u32 = 61;
+    pub const ADD: u32 = 0;
+    pub const SUB: u32 = 1;
+    pub const MUL: u32 = 2;
+    pub const UDIV: u32 = 3;
+    pub const SDIV: u32 = 4;
+    pub const UREM: u32 = 5;
+    pub const SREM: u32 = 6;
+    pub const AND: u32 = 10;
+    pub const OR: u32 = 11;
+    pub const XOR: u32 = 12;
+    pub const SHL: u32 = 13;
+    pub const LSHR: u32 = 14;
+    pub const ASHR: u32 = 15;
+    pub const FADD: u32 = 20;
+    pub const FSUB: u32 = 21;
+    pub const FMUL: u32 = 22;
+    pub const FDIV: u32 = 23;
+    pub const FREM: u32 = 24;
+    pub const FNEG: u32 = 25;
+    pub const ICMP: u32 = 30;
+    pub const FCMP: u32 = 31;
+    pub const ALLOCA: u32 = 40;
+    pub const LOAD: u32 = 41;
+    pub const STORE: u32 = 42;
+    pub const GEP: u32 = 43;
+    pub const TRUNC: u32 = 50;
+    pub const ZEXT: u32 = 51;
+    pub const SEXT: u32 = 52;
+    pub const FPTRUNC: u32 = 53;
+    pub const FPEXT: u32 = 54;
+    pub const FPTOUI: u32 = 55;
+    pub const FPTOSI: u32 = 56;
+    pub const UITOFP: u32 = 57;
+    pub const SITOFP: u32 = 58;
+    pub const PTRTOINT: u32 = 59;
+    pub const INTTOPTR: u32 = 60;
+    pub const BITCAST: u32 = 61;
     pub const ADDRSPACECAST: u32 = 62;
-    pub const SELECT:      u32 = 70;
-    pub const PHI:         u32 = 71;
+    pub const SELECT: u32 = 70;
+    pub const PHI: u32 = 71;
     pub const EXTRACTVALUE: u32 = 72;
-    pub const INSERTVALUE:  u32 = 73;
-    pub const EXTRACTELEM:  u32 = 74;
-    pub const INSERTELEM:   u32 = 75;
-    pub const SHUFFLEVEC:   u32 = 76;
-    pub const CALL:         u32 = 80;
-    pub const RET:          u32 = 90;
-    pub const BR:           u32 = 91;
-    pub const CONDBR:       u32 = 92;
-    pub const SWITCH:       u32 = 93;
-    pub const UNREACHABLE:  u32 = 94;
+    pub const INSERTVALUE: u32 = 73;
+    pub const EXTRACTELEM: u32 = 74;
+    pub const INSERTELEM: u32 = 75;
+    pub const SHUFFLEVEC: u32 = 76;
+    pub const CALL: u32 = 80;
+    pub const RET: u32 = 90;
+    pub const BR: u32 = 91;
+    pub const CONDBR: u32 = 92;
+    pub const SWITCH: u32 = 93;
+    pub const UNREACHABLE: u32 = 94;
 }
 
 fn encode_vref(w: &mut Writer, vr: &ValueRef) {
     match vr {
-        ValueRef::Instruction(id) => { w.u8(0); w.u32(id.0); }
-        ValueRef::Argument(id)    => { w.u8(1); w.u32(id.0); }
-        ValueRef::Constant(id)    => { w.u8(2); w.u32(id.0); }
-        ValueRef::Global(id)      => { w.u8(3); w.u32(id.0); }
+        ValueRef::Instruction(id) => {
+            w.u8(0);
+            w.u32(id.0);
+        }
+        ValueRef::Argument(id) => {
+            w.u8(1);
+            w.u32(id.0);
+        }
+        ValueRef::Constant(id) => {
+            w.u8(2);
+            w.u32(id.0);
+        }
+        ValueRef::Global(id) => {
+            w.u8(3);
+            w.u32(id.0);
+        }
     }
 }
 
 fn encode_opt_vref(w: &mut Writer, ovr: &Option<ValueRef>) {
     match ovr {
-        Some(vr) => { w.u8(1); encode_vref(w, vr); }
-        None     => { w.u8(0); }
+        Some(vr) => {
+            w.u8(1);
+            encode_vref(w, vr);
+        }
+        None => {
+            w.u8(0);
+        }
     }
 }
 
@@ -357,7 +407,7 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
     // Name: empty string → unnamed.
     match &instr.name {
         Some(n) => w.string(n),
-        None    => w.u32(0),
+        None => w.u32(0),
     }
     // Result type.
     w.u32(instr.ty.0);
@@ -365,121 +415,259 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
     // Kind tag + operands.
     use InstrKind::*;
     match &instr.kind {
-        Add { flags, lhs, rhs, .. } => {
+        Add {
+            flags, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::ADD);
             w.u8(if flags.nuw { 1 } else { 0 });
             w.u8(if flags.nsw { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        Sub { flags, lhs, rhs, .. } => {
+        Sub {
+            flags, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::SUB);
             w.u8(if flags.nuw { 1 } else { 0 });
             w.u8(if flags.nsw { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        Mul { flags, lhs, rhs, .. } => {
+        Mul {
+            flags, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::MUL);
             w.u8(if flags.nuw { 1 } else { 0 });
             w.u8(if flags.nsw { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
         UDiv { exact, lhs, rhs } => {
             w.u32(instr_tag::UDIV);
             w.u8(if *exact { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
         SDiv { exact, lhs, rhs } => {
             w.u32(instr_tag::SDIV);
             w.u8(if *exact { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
         URem { lhs, rhs } => {
             w.u32(instr_tag::UREM);
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
         SRem { lhs, rhs } => {
             w.u32(instr_tag::SREM);
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        And { lhs, rhs } => { w.u32(instr_tag::AND); encode_vref(w, lhs); encode_vref(w, rhs); }
-        Or  { lhs, rhs } => { w.u32(instr_tag::OR);  encode_vref(w, lhs); encode_vref(w, rhs); }
-        Xor { lhs, rhs } => { w.u32(instr_tag::XOR); encode_vref(w, lhs); encode_vref(w, rhs); }
-        Shl  { flags, lhs, rhs, .. } => {
+        And { lhs, rhs } => {
+            w.u32(instr_tag::AND);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        Or { lhs, rhs } => {
+            w.u32(instr_tag::OR);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        Xor { lhs, rhs } => {
+            w.u32(instr_tag::XOR);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        Shl {
+            flags, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::SHL);
             w.u8(if flags.nuw { 1 } else { 0 });
             w.u8(if flags.nsw { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        LShr { exact, lhs, rhs, .. } => {
+        LShr {
+            exact, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::LSHR);
             w.u8(if *exact { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        AShr { exact, lhs, rhs, .. } => {
+        AShr {
+            exact, lhs, rhs, ..
+        } => {
             w.u32(instr_tag::ASHR);
             w.u8(if *exact { 1 } else { 0 });
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        FAdd { lhs, rhs, .. } => { w.u32(instr_tag::FADD); encode_vref(w, lhs); encode_vref(w, rhs); }
-        FSub { lhs, rhs, .. } => { w.u32(instr_tag::FSUB); encode_vref(w, lhs); encode_vref(w, rhs); }
-        FMul { lhs, rhs, .. } => { w.u32(instr_tag::FMUL); encode_vref(w, lhs); encode_vref(w, rhs); }
-        FDiv { lhs, rhs, .. } => { w.u32(instr_tag::FDIV); encode_vref(w, lhs); encode_vref(w, rhs); }
-        FRem { lhs, rhs, .. } => { w.u32(instr_tag::FREM); encode_vref(w, lhs); encode_vref(w, rhs); }
-        FNeg { operand, .. }  => { w.u32(instr_tag::FNEG); encode_vref(w, operand); }
+        FAdd { lhs, rhs, .. } => {
+            w.u32(instr_tag::FADD);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        FSub { lhs, rhs, .. } => {
+            w.u32(instr_tag::FSUB);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        FMul { lhs, rhs, .. } => {
+            w.u32(instr_tag::FMUL);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        FDiv { lhs, rhs, .. } => {
+            w.u32(instr_tag::FDIV);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        FRem { lhs, rhs, .. } => {
+            w.u32(instr_tag::FREM);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
+        }
+        FNeg { operand, .. } => {
+            w.u32(instr_tag::FNEG);
+            encode_vref(w, operand);
+        }
         ICmp { pred, lhs, rhs } => {
             w.u32(instr_tag::ICMP);
             w.u8(encode_int_pred(*pred));
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
         FCmp { pred, lhs, rhs, .. } => {
             w.u32(instr_tag::FCMP);
             w.u8(encode_float_pred(*pred));
-            encode_vref(w, lhs); encode_vref(w, rhs);
+            encode_vref(w, lhs);
+            encode_vref(w, rhs);
         }
-        Alloca { alloc_ty, num_elements, align } => {
+        Alloca {
+            alloc_ty,
+            num_elements,
+            align,
+        } => {
             w.u32(instr_tag::ALLOCA);
             w.u32(alloc_ty.0);
             encode_opt_vref(w, num_elements);
             encode_opt_u32(w, *align);
         }
-        Load { ty, ptr, align, volatile } => {
+        Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => {
             w.u32(instr_tag::LOAD);
             w.u32(ty.0);
             encode_vref(w, ptr);
             encode_opt_u32(w, *align);
             w.u8(if *volatile { 1 } else { 0 });
         }
-        Store { val, ptr, align, volatile } => {
+        Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => {
             w.u32(instr_tag::STORE);
             encode_vref(w, val);
             encode_vref(w, ptr);
             encode_opt_u32(w, *align);
             w.u8(if *volatile { 1 } else { 0 });
         }
-        GetElementPtr { inbounds, base_ty, ptr, indices } => {
+        GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        } => {
             w.u32(instr_tag::GEP);
             w.u8(if *inbounds { 1 } else { 0 });
             w.u32(base_ty.0);
             encode_vref(w, ptr);
             w.u32(indices.len() as u32);
-            for idx in indices { encode_vref(w, idx); }
+            for idx in indices {
+                encode_vref(w, idx);
+            }
         }
-        Trunc { val, to }        => { w.u32(instr_tag::TRUNC);    encode_vref(w, val); w.u32(to.0); }
-        ZExt  { val, to }        => { w.u32(instr_tag::ZEXT);     encode_vref(w, val); w.u32(to.0); }
-        SExt  { val, to }        => { w.u32(instr_tag::SEXT);     encode_vref(w, val); w.u32(to.0); }
-        FPTrunc { val, to }      => { w.u32(instr_tag::FPTRUNC);  encode_vref(w, val); w.u32(to.0); }
-        FPExt   { val, to }      => { w.u32(instr_tag::FPEXT);    encode_vref(w, val); w.u32(to.0); }
-        FPToUI  { val, to }      => { w.u32(instr_tag::FPTOUI);   encode_vref(w, val); w.u32(to.0); }
-        FPToSI  { val, to }      => { w.u32(instr_tag::FPTOSI);   encode_vref(w, val); w.u32(to.0); }
-        UIToFP  { val, to }      => { w.u32(instr_tag::UITOFP);   encode_vref(w, val); w.u32(to.0); }
-        SIToFP  { val, to }      => { w.u32(instr_tag::SITOFP);   encode_vref(w, val); w.u32(to.0); }
-        PtrToInt { val, to }     => { w.u32(instr_tag::PTRTOINT); encode_vref(w, val); w.u32(to.0); }
-        IntToPtr { val, to }     => { w.u32(instr_tag::INTTOPTR); encode_vref(w, val); w.u32(to.0); }
-        BitCast  { val, to }     => { w.u32(instr_tag::BITCAST);  encode_vref(w, val); w.u32(to.0); }
-        AddrSpaceCast { val, to }=> { w.u32(instr_tag::ADDRSPACECAST); encode_vref(w, val); w.u32(to.0); }
-        Select { cond, then_val, else_val } => {
+        Trunc { val, to } => {
+            w.u32(instr_tag::TRUNC);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        ZExt { val, to } => {
+            w.u32(instr_tag::ZEXT);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        SExt { val, to } => {
+            w.u32(instr_tag::SEXT);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        FPTrunc { val, to } => {
+            w.u32(instr_tag::FPTRUNC);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        FPExt { val, to } => {
+            w.u32(instr_tag::FPEXT);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        FPToUI { val, to } => {
+            w.u32(instr_tag::FPTOUI);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        FPToSI { val, to } => {
+            w.u32(instr_tag::FPTOSI);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        UIToFP { val, to } => {
+            w.u32(instr_tag::UITOFP);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        SIToFP { val, to } => {
+            w.u32(instr_tag::SITOFP);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        PtrToInt { val, to } => {
+            w.u32(instr_tag::PTRTOINT);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        IntToPtr { val, to } => {
+            w.u32(instr_tag::INTTOPTR);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        BitCast { val, to } => {
+            w.u32(instr_tag::BITCAST);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        AddrSpaceCast { val, to } => {
+            w.u32(instr_tag::ADDRSPACECAST);
+            encode_vref(w, val);
+            w.u32(to.0);
+        }
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             w.u32(instr_tag::SELECT);
-            encode_vref(w, cond); encode_vref(w, then_val); encode_vref(w, else_val);
+            encode_vref(w, cond);
+            encode_vref(w, then_val);
+            encode_vref(w, else_val);
         }
         Phi { ty, incoming } => {
             w.u32(instr_tag::PHI);
@@ -494,43 +682,64 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
             w.u32(instr_tag::EXTRACTVALUE);
             encode_vref(w, aggregate);
             w.u32(indices.len() as u32);
-            for &i in indices { w.u32(i); }
+            for &i in indices {
+                w.u32(i);
+            }
         }
-        InsertValue { aggregate, val, indices } => {
+        InsertValue {
+            aggregate,
+            val,
+            indices,
+        } => {
             w.u32(instr_tag::INSERTVALUE);
             encode_vref(w, aggregate);
             encode_vref(w, val);
             w.u32(indices.len() as u32);
-            for &i in indices { w.u32(i); }
+            for &i in indices {
+                w.u32(i);
+            }
         }
         ExtractElement { vec, idx } => {
             w.u32(instr_tag::EXTRACTELEM);
-            encode_vref(w, vec); encode_vref(w, idx);
+            encode_vref(w, vec);
+            encode_vref(w, idx);
         }
         InsertElement { vec, val, idx } => {
             w.u32(instr_tag::INSERTELEM);
-            encode_vref(w, vec); encode_vref(w, val); encode_vref(w, idx);
+            encode_vref(w, vec);
+            encode_vref(w, val);
+            encode_vref(w, idx);
         }
         ShuffleVector { v1, v2, mask } => {
             w.u32(instr_tag::SHUFFLEVEC);
-            encode_vref(w, v1); encode_vref(w, v2);
+            encode_vref(w, v1);
+            encode_vref(w, v2);
             w.u32(mask.len() as u32);
-            for &m in mask { w.i32(m); }
+            for &m in mask {
+                w.i32(m);
+            }
         }
-        Call { tail, callee_ty, callee, args } => {
+        Call {
+            tail,
+            callee_ty,
+            callee,
+            args,
+        } => {
             w.u32(instr_tag::CALL);
             use llvm_ir::TailCallKind;
             let tail_tag = match tail {
-                TailCallKind::None     => 0u8,
-                TailCallKind::Tail     => 1,
+                TailCallKind::None => 0u8,
+                TailCallKind::Tail => 1,
                 TailCallKind::MustTail => 2,
-                TailCallKind::NoTail   => 3,
+                TailCallKind::NoTail => 3,
             };
             w.u8(tail_tag);
             w.u32(callee_ty.0);
             encode_vref(w, callee);
             w.u32(args.len() as u32);
-            for arg in args { encode_vref(w, arg); }
+            for arg in args {
+                encode_vref(w, arg);
+            }
         }
         Ret { val } => {
             w.u32(instr_tag::RET);
@@ -540,13 +749,21 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
             w.u32(instr_tag::BR);
             w.u32(dest.0);
         }
-        CondBr { cond, then_dest, else_dest } => {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => {
             w.u32(instr_tag::CONDBR);
             encode_vref(w, cond);
             w.u32(then_dest.0);
             w.u32(else_dest.0);
         }
-        Switch { val, default, cases } => {
+        Switch {
+            val,
+            default,
+            cases,
+        } => {
             w.u32(instr_tag::SWITCH);
             encode_vref(w, val);
             w.u32(default.0);
@@ -556,27 +773,59 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
                 w.u32(bd.0);
             }
         }
-        Unreachable => { w.u32(instr_tag::UNREACHABLE); }
+        Unreachable => {
+            w.u32(instr_tag::UNREACHABLE);
+        }
     }
 }
 
 fn encode_opt_u32(w: &mut Writer, v: Option<u32>) {
     match v {
-        Some(x) => { w.u8(1); w.u32(x); }
-        None    => { w.u8(0); }
+        Some(x) => {
+            w.u8(1);
+            w.u32(x);
+        }
+        None => {
+            w.u8(0);
+        }
     }
 }
 
 fn encode_int_pred(pred: llvm_ir::IntPredicate) -> u8 {
     use llvm_ir::IntPredicate::*;
-    match pred { Eq => 0, Ne => 1, Ugt => 2, Uge => 3, Ult => 4, Ule => 5, Sgt => 6, Sge => 7, Slt => 8, Sle => 9 }
+    match pred {
+        Eq => 0,
+        Ne => 1,
+        Ugt => 2,
+        Uge => 3,
+        Ult => 4,
+        Ule => 5,
+        Sgt => 6,
+        Sge => 7,
+        Slt => 8,
+        Sle => 9,
+    }
 }
 
 fn encode_float_pred(pred: llvm_ir::FloatPredicate) -> u8 {
     use llvm_ir::FloatPredicate::*;
     match pred {
-        False => 0, Oeq => 1, Ogt => 2, Oge => 3, Olt => 4, Ole => 5, One => 6, Ord => 7,
-        Uno => 8, Ueq => 9, Ugt => 10, Uge => 11, Ult => 12, Ule => 13, Une => 14, True => 15,
+        False => 0,
+        Oeq => 1,
+        Ogt => 2,
+        Oge => 3,
+        Olt => 4,
+        Ole => 5,
+        One => 6,
+        Ord => 7,
+        Uno => 8,
+        Ueq => 9,
+        Ugt => 10,
+        Uge => 11,
+        Ult => 12,
+        Ule => 13,
+        Une => 14,
+        True => 15,
     }
 }
 
@@ -588,11 +837,21 @@ struct Writer {
 }
 
 impl Writer {
-    fn raw(&mut self, b: &[u8]) { self.buf.extend_from_slice(b); }
-    fn u8(&mut self, v: u8)  { self.buf.push(v); }
-    fn u32(&mut self, v: u32) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    fn i32(&mut self, v: i32) { self.buf.extend_from_slice(&v.to_le_bytes()); }
-    fn u64(&mut self, v: u64) { self.buf.extend_from_slice(&v.to_le_bytes()); }
+    fn raw(&mut self, b: &[u8]) {
+        self.buf.extend_from_slice(b);
+    }
+    fn u8(&mut self, v: u8) {
+        self.buf.push(v);
+    }
+    fn u32(&mut self, v: u32) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn i32(&mut self, v: i32) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.buf.extend_from_slice(&v.to_le_bytes());
+    }
     /// Length-prefixed UTF-8 string.  A length of 0 means "absent/empty".
     fn string(&mut self, s: &str) {
         self.u32(s.len() as u32);

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -66,7 +66,7 @@ impl ObjectFile {
     /// Serialize the object file to raw bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         match self.format {
-            ObjectFormat::Elf   => serialize_elf(self),
+            ObjectFormat::Elf => serialize_elf(self),
             ObjectFormat::MachO => serialize_macho(self),
         }
     }
@@ -119,39 +119,46 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
 fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
     // ── string tables ───────────────────────────────────────────────────────
     let mut shstrtab: Vec<u8> = vec![0u8]; // index 0 = empty string
-    let text_name_off    = push_str(&mut shstrtab, b".text");
-    let symtab_name_off  = push_str(&mut shstrtab, b".symtab");
-    let strtab_name_off  = push_str(&mut shstrtab, b".strtab");
+    let text_name_off = push_str(&mut shstrtab, b".text");
+    let symtab_name_off = push_str(&mut shstrtab, b".symtab");
+    let strtab_name_off = push_str(&mut shstrtab, b".strtab");
     let shstrtab_name_off = push_str(&mut shstrtab, b".shstrtab");
 
-    let text_data  = obj.sections.first().map_or(&[][..], |s| s.data.as_slice());
-    let text_relocs = obj.sections.first().map_or(&[][..], |s| s.relocs.as_slice());
+    let text_data = obj.sections.first().map_or(&[][..], |s| s.data.as_slice());
+    let text_relocs = obj
+        .sections
+        .first()
+        .map_or(&[][..], |s| s.relocs.as_slice());
     let has_relocs = !text_relocs.is_empty();
 
     let relatext_name_off = if has_relocs {
         push_str(&mut shstrtab, b".rela.text")
-    } else { 0 };
+    } else {
+        0
+    };
 
     let mut strtab: Vec<u8> = vec![0u8];
-    let sym_name_offs: Vec<u32> = obj.symbols.iter().map(|s| {
-        push_str(&mut strtab, s.name.as_bytes())
-    }).collect();
+    let sym_name_offs: Vec<u32> = obj
+        .symbols
+        .iter()
+        .map(|s| push_str(&mut strtab, s.name.as_bytes()))
+        .collect();
 
     // ── layout ─────────────────────────────────────────────────────────────
-    const ELF_HDR: u64  = 64;
-    const SH_ENT: u64   = 64;
-    const SYM_ENT: u64  = 24;
+    const ELF_HDR: u64 = 64;
+    const SH_ENT: u64 = 64;
+    const SYM_ENT: u64 = 24;
     const RELA_ENT: u64 = 24;
 
     let num_sections: u16 = if has_relocs { 6 } else { 5 };
     let sh_table_size = num_sections as u64 * SH_ENT;
 
-    let text_off    = ELF_HDR + sh_table_size;
-    let text_size   = text_data.len() as u64;
-    let sym_count   = 1 + obj.symbols.len() as u64; // null + symbols
-    let symtab_off  = text_off + text_size;
+    let text_off = ELF_HDR + sh_table_size;
+    let text_size = text_data.len() as u64;
+    let sym_count = 1 + obj.symbols.len() as u64; // null + symbols
+    let symtab_off = text_off + text_size;
     let symtab_size = sym_count * SYM_ENT;
-    let strtab_off  = symtab_off + symtab_size;
+    let strtab_off = symtab_off + symtab_size;
     let shstrtab_off = strtab_off + strtab.len() as u64;
     let relatext_off = shstrtab_off + shstrtab.len() as u64;
     let relatext_size = text_relocs.len() as u64 * RELA_ENT;
@@ -161,48 +168,117 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
 
     // ELF header
     buf.extend_from_slice(b"\x7fELF"); // magic
-    buf.push(2);                        // EI_CLASS: 64-bit
-    buf.push(1);                        // EI_DATA: little-endian
-    buf.push(1);                        // EI_VERSION
-    buf.push(0);                        // EI_OSABI: System V
-    buf.extend_from_slice(&[0u8; 8]);   // padding
-    w16(&mut buf, 1);                   // e_type: ET_REL
-    w16(&mut buf, 62);                  // e_machine: EM_X86_64
-    w32(&mut buf, 1);                   // e_version
-    w64(&mut buf, 0);                   // e_entry
-    w64(&mut buf, 0);                   // e_phoff
-    w64(&mut buf, ELF_HDR);             // e_shoff
-    w32(&mut buf, 0);                   // e_flags
-    w16(&mut buf, ELF_HDR as u16);      // e_ehsize
-    w16(&mut buf, 0);                   // e_phentsize
-    w16(&mut buf, 0);                   // e_phnum
-    w16(&mut buf, SH_ENT as u16);       // e_shentsize
-    w16(&mut buf, num_sections);        // e_shnum
-    w16(&mut buf, 4);                   // e_shstrndx (.shstrtab at index 4)
+    buf.push(2); // EI_CLASS: 64-bit
+    buf.push(1); // EI_DATA: little-endian
+    buf.push(1); // EI_VERSION
+    buf.push(0); // EI_OSABI: System V
+    buf.extend_from_slice(&[0u8; 8]); // padding
+    w16(&mut buf, 1); // e_type: ET_REL
+    w16(&mut buf, 62); // e_machine: EM_X86_64
+    w32(&mut buf, 1); // e_version
+    w64(&mut buf, 0); // e_entry
+    w64(&mut buf, 0); // e_phoff
+    w64(&mut buf, ELF_HDR); // e_shoff
+    w32(&mut buf, 0); // e_flags
+    w16(&mut buf, ELF_HDR as u16); // e_ehsize
+    w16(&mut buf, 0); // e_phentsize
+    w16(&mut buf, 0); // e_phnum
+    w16(&mut buf, SH_ENT as u16); // e_shentsize
+    w16(&mut buf, num_sections); // e_shnum
+    w16(&mut buf, 4); // e_shstrndx (.shstrtab at index 4)
 
     // Helper: write a 64-byte section header entry
     let write_shdr = |buf: &mut Vec<u8>,
-                      name: u32, sh_type: u32, flags: u64,
-                      addr: u64, off: u64, size: u64,
-                      link: u32, info: u32, align: u64, entsize: u64| {
-        w32(buf, name); w32(buf, sh_type); w64(buf, flags);
-        w64(buf, addr); w64(buf, off);     w64(buf, size);
-        w32(buf, link); w32(buf, info);    w64(buf, align); w64(buf, entsize);
+                      name: u32,
+                      sh_type: u32,
+                      flags: u64,
+                      addr: u64,
+                      off: u64,
+                      size: u64,
+                      link: u32,
+                      info: u32,
+                      align: u64,
+                      entsize: u64| {
+        w32(buf, name);
+        w32(buf, sh_type);
+        w64(buf, flags);
+        w64(buf, addr);
+        w64(buf, off);
+        w64(buf, size);
+        w32(buf, link);
+        w32(buf, info);
+        w64(buf, align);
+        w64(buf, entsize);
     };
 
     // Section headers
-    write_shdr(&mut buf, 0,0,0,0,0,0,0,0,0,0);          // [0] null
-    write_shdr(&mut buf, text_name_off,   1, 6,           // [1] .text  SHF_ALLOC|SHF_EXECINSTR
-        0, text_off, text_size, 0, 0, 16, 0);
-    write_shdr(&mut buf, symtab_name_off, 2, 0,           // [2] .symtab link=3 info=first_global(1)
-        0, symtab_off, symtab_size, 3, 1, 8, SYM_ENT);
-    write_shdr(&mut buf, strtab_name_off, 3, 0,           // [3] .strtab
-        0, strtab_off, strtab.len() as u64, 0, 0, 1, 0);
-    write_shdr(&mut buf, shstrtab_name_off, 3, 0,         // [4] .shstrtab
-        0, shstrtab_off, shstrtab.len() as u64, 0, 0, 1, 0);
+    write_shdr(&mut buf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); // [0] null
+    write_shdr(
+        &mut buf,
+        text_name_off,
+        1,
+        6, // [1] .text  SHF_ALLOC|SHF_EXECINSTR
+        0,
+        text_off,
+        text_size,
+        0,
+        0,
+        16,
+        0,
+    );
+    write_shdr(
+        &mut buf,
+        symtab_name_off,
+        2,
+        0, // [2] .symtab link=3 info=first_global(1)
+        0,
+        symtab_off,
+        symtab_size,
+        3,
+        1,
+        8,
+        SYM_ENT,
+    );
+    write_shdr(
+        &mut buf,
+        strtab_name_off,
+        3,
+        0, // [3] .strtab
+        0,
+        strtab_off,
+        strtab.len() as u64,
+        0,
+        0,
+        1,
+        0,
+    );
+    write_shdr(
+        &mut buf,
+        shstrtab_name_off,
+        3,
+        0, // [4] .shstrtab
+        0,
+        shstrtab_off,
+        shstrtab.len() as u64,
+        0,
+        0,
+        1,
+        0,
+    );
     if has_relocs {
-        write_shdr(&mut buf, relatext_name_off, 4, 0,     // [5] .rela.text link=2 info=1
-            0, relatext_off, relatext_size, 2, 1, 8, RELA_ENT);
+        write_shdr(
+            &mut buf,
+            relatext_name_off,
+            4,
+            0, // [5] .rela.text link=2 info=1
+            0,
+            relatext_off,
+            relatext_size,
+            2,
+            1,
+            8,
+            RELA_ENT,
+        );
     }
 
     // Section data: .text
@@ -215,7 +291,7 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         let st_shndx: u16 = (sym.section + 1) as u16; // +1 for null section header
         w32(&mut buf, sym_name_offs[i]);
         buf.push(st_info);
-        buf.push(0);               // st_other
+        buf.push(0); // st_other
         w16(&mut buf, st_shndx);
         w64(&mut buf, sym.offset);
         w64(&mut buf, sym.size);
@@ -232,8 +308,8 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         for reloc in text_relocs {
             let sym_idx = (reloc.symbol + 1) as u64;
             let r_type: u64 = match reloc.kind {
-                RelocKind::Pc32  => 2,  // R_X86_64_PC32
-                RelocKind::Abs64 => 1,  // R_X86_64_64
+                RelocKind::Pc32 => 2,  // R_X86_64_PC32
+                RelocKind::Abs64 => 1, // R_X86_64_64
             };
             let r_info = (sym_idx << 32) | r_type;
             w64(&mut buf, reloc.offset);
@@ -261,41 +337,50 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
 //   string table
 
 fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
-    let text_data   = obj.sections.first().map_or(&[][..], |s| s.data.as_slice());
-    let text_size   = text_data.len() as u32;
-    let text_relocs = obj.sections.first().map_or(&[][..], |s| s.relocs.as_slice());
+    let text_data = obj.sections.first().map_or(&[][..], |s| s.data.as_slice());
+    let text_size = text_data.len() as u32;
+    let text_relocs = obj
+        .sections
+        .first()
+        .map_or(&[][..], |s| s.relocs.as_slice());
 
-    const MH_HDR:      u32 = 32;
-    const SEG_CMD:     u32 = 72;
-    const SECT_HDR:    u32 = 80;
-    const SYMTAB_CMD:  u32 = 24;
+    const MH_HDR: u32 = 32;
+    const SEG_CMD: u32 = 72;
+    const SECT_HDR: u32 = 80;
+    const SYMTAB_CMD: u32 = 24;
     const DYSYMTAB_CMD: u32 = 80;
-    const SYM_ENT:     u32 = 16; // nlist_64
+    const SYM_ENT: u32 = 16; // nlist_64
 
     let header_size = MH_HDR + SEG_CMD + SECT_HDR + SYMTAB_CMD + DYSYMTAB_CMD;
-    let cmds_size   = SEG_CMD + SECT_HDR + SYMTAB_CMD + DYSYMTAB_CMD;
+    let cmds_size = SEG_CMD + SECT_HDR + SYMTAB_CMD + DYSYMTAB_CMD;
 
     // Align __text to 16-byte boundary after headers.
-    let text_align    = 16u32;
-    let text_pad      = (text_align - (header_size % text_align)) % text_align;
-    let text_off      = header_size + text_pad;
-    let reloc_off     = text_off + text_size;
-    let reloc_size    = text_relocs.len() as u32 * 8;
+    let text_align = 16u32;
+    let text_pad = (text_align - (header_size % text_align)) % text_align;
+    let text_off = header_size + text_pad;
+    let reloc_off = text_off + text_size;
+    let reloc_size = text_relocs.len() as u32 * 8;
 
     // String table: index 0 = \0 (null, required by Mach-O spec — empty string).
     let mut strtab: Vec<u8> = vec![0u8];
-    let sym_name_offs: Vec<u32> = obj.symbols.iter().map(|s| {
-        let off = strtab.len() as u32;
-        strtab.push(b'_'); // C symbol underscore prefix
-        strtab.extend_from_slice(s.name.as_bytes());
+    let sym_name_offs: Vec<u32> = obj
+        .symbols
+        .iter()
+        .map(|s| {
+            let off = strtab.len() as u32;
+            strtab.push(b'_'); // C symbol underscore prefix
+            strtab.extend_from_slice(s.name.as_bytes());
+            strtab.push(0);
+            off
+        })
+        .collect();
+    while strtab.len() % 4 != 0 {
         strtab.push(0);
-        off
-    }).collect();
-    while strtab.len() % 4 != 0 { strtab.push(0); } // align to 4 bytes
+    } // align to 4 bytes
 
-    let symtab_off  = reloc_off + reloc_size;
+    let symtab_off = reloc_off + reloc_size;
     let symtab_size = obj.symbols.len() as u32 * SYM_ENT;
-    let strtab_off  = symtab_off + symtab_size;
+    let strtab_off = symtab_off + symtab_size;
 
     let mut buf = Vec::<u8>::new();
 
@@ -303,38 +388,40 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     w32(&mut buf, 0xfeedfacf); // MH_MAGIC_64
     w32(&mut buf, 0x01000007); // CPU_TYPE_X86_64
     w32(&mut buf, 0x00000003); // CPU_SUBTYPE_X86_64_ALL
-    w32(&mut buf, 1);          // MH_OBJECT
-    w32(&mut buf, 3);          // ncmds
-    w32(&mut buf, cmds_size);  // sizeofcmds
-    w32(&mut buf, 0);          // flags
+    w32(&mut buf, 1); // MH_OBJECT
+    w32(&mut buf, 3); // ncmds
+    w32(&mut buf, cmds_size); // sizeofcmds
+    w32(&mut buf, 0); // flags
 
     // LC_SEGMENT_64
-    w32(&mut buf, 0x19);                          // LC_SEGMENT_64
-    w32(&mut buf, SEG_CMD + SECT_HDR);            // cmdsize
+    w32(&mut buf, 0x19); // LC_SEGMENT_64
+    w32(&mut buf, SEG_CMD + SECT_HDR); // cmdsize
     buf.extend_from_slice(b"__TEXT\0\0\0\0\0\0\0\0\0\0"); // segname[16]
-    w64(&mut buf, 0);                             // vmaddr
-    w64(&mut buf, text_size as u64);              // vmsize
-    w64(&mut buf, text_off as u64);               // fileoff
-    w64(&mut buf, text_size as u64);              // filesize
-    w32(&mut buf, 7);                             // maxprot
-    w32(&mut buf, 5);                             // initprot (R|X)
-    w32(&mut buf, 1);                             // nsects
-    w32(&mut buf, 0);                             // flags
+    w64(&mut buf, 0); // vmaddr
+    w64(&mut buf, text_size as u64); // vmsize
+    w64(&mut buf, text_off as u64); // fileoff
+    w64(&mut buf, text_size as u64); // filesize
+    w32(&mut buf, 7); // maxprot
+    w32(&mut buf, 5); // initprot (R|X)
+    w32(&mut buf, 1); // nsects
+    w32(&mut buf, 0); // flags
 
     // section_64 __TEXT,__text
-    buf.extend_from_slice(b"__text\0\0\0\0\0\0\0\0\0\0");  // sectname[16]
+    buf.extend_from_slice(b"__text\0\0\0\0\0\0\0\0\0\0"); // sectname[16]
     buf.extend_from_slice(b"__TEXT\0\0\0\0\0\0\0\0\0\0"); // segname[16]
-    w64(&mut buf, 0);                             // addr
-    w64(&mut buf, text_size as u64);              // size
-    w32(&mut buf, text_off);                      // offset
-    w32(&mut buf, 4);                             // align (2^4 = 16)
-    w32(&mut buf, reloc_off);                     // reloff
-    w32(&mut buf, text_relocs.len() as u32);      // nreloc
-    w32(&mut buf, 0x80000400);                    // S_ATTR_PURE_INSTRUCTIONS|S_ATTR_SOME_INSTRUCTIONS
-    w32(&mut buf, 0); w32(&mut buf, 0); w32(&mut buf, 0); // reserved1-3
+    w64(&mut buf, 0); // addr
+    w64(&mut buf, text_size as u64); // size
+    w32(&mut buf, text_off); // offset
+    w32(&mut buf, 4); // align (2^4 = 16)
+    w32(&mut buf, reloc_off); // reloff
+    w32(&mut buf, text_relocs.len() as u32); // nreloc
+    w32(&mut buf, 0x80000400); // S_ATTR_PURE_INSTRUCTIONS|S_ATTR_SOME_INSTRUCTIONS
+    w32(&mut buf, 0);
+    w32(&mut buf, 0);
+    w32(&mut buf, 0); // reserved1-3
 
     // LC_SYMTAB
-    w32(&mut buf, 2);              // LC_SYMTAB
+    w32(&mut buf, 2); // LC_SYMTAB
     w32(&mut buf, SYMTAB_CMD);
     w32(&mut buf, symtab_off);
     w32(&mut buf, obj.symbols.len() as u32);
@@ -342,16 +429,19 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     w32(&mut buf, strtab.len() as u32);
 
     // LC_DYSYMTAB
-    w32(&mut buf, 0xB);            // LC_DYSYMTAB
+    w32(&mut buf, 0xB); // LC_DYSYMTAB
     w32(&mut buf, DYSYMTAB_CMD);
     let n_globals = obj.symbols.iter().filter(|s| s.global).count() as u32;
-    w32(&mut buf, 0); w32(&mut buf, 0);             // ilocalsym, nlocalsym
-    w32(&mut buf, 0); w32(&mut buf, n_globals);      // iextdefsym, nextdefsym
-    w32(&mut buf, n_globals); w32(&mut buf, 0);      // iundefsym, nundefsym
-    buf.extend_from_slice(&[0u8; 48]);               // remaining fields
+    w32(&mut buf, 0);
+    w32(&mut buf, 0); // ilocalsym, nlocalsym
+    w32(&mut buf, 0);
+    w32(&mut buf, n_globals); // iextdefsym, nextdefsym
+    w32(&mut buf, n_globals);
+    w32(&mut buf, 0); // iundefsym, nundefsym
+    buf.extend_from_slice(&[0u8; 48]); // remaining fields
 
     // padding
-    for _ in 0..text_pad { buf.push(0); }
+    buf.resize(buf.len() + text_pad as usize, 0);
 
     // __text section data
     buf.extend_from_slice(text_data);
@@ -360,15 +450,12 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     for reloc in text_relocs {
         let sym_idx = reloc.symbol as u32;
         let (r_type, r_length, r_pcrel): (u32, u32, u32) = match reloc.kind {
-            RelocKind::Pc32  => (2, 2, 1), // X86_64_RELOC_BRANCH, 4 bytes, PC-rel
+            RelocKind::Pc32 => (2, 2, 1),  // X86_64_RELOC_BRANCH, 4 bytes, PC-rel
             RelocKind::Abs64 => (0, 3, 0), // X86_64_RELOC_UNSIGNED, 8 bytes, abs
         };
         let r_extern: u32 = 1;
-        let r_info = sym_idx
-            | (r_pcrel  << 24)
-            | (r_length << 25)
-            | (r_extern << 27)
-            | (r_type   << 28);
+        let r_info =
+            sym_idx | (r_pcrel << 24) | (r_length << 25) | (r_extern << 27) | (r_type << 28);
         w32(&mut buf, reloc.offset as u32); // r_address
         w32(&mut buf, r_info);
     }
@@ -377,10 +464,10 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     for (i, sym) in obj.symbols.iter().enumerate() {
         let n_type: u8 = if sym.global { 0x0F } else { 0x0E }; // N_EXT|N_SECT
         w32(&mut buf, sym_name_offs[i]); // n_strx
-        buf.push(n_type);                // n_type
-        buf.push(1);                     // n_sect (1-based, __text = 1)
-        w16(&mut buf, 0);                // n_desc
-        w64(&mut buf, sym.offset);       // n_value
+        buf.push(n_type); // n_type
+        buf.push(1); // n_sect (1-based, __text = 1)
+        w16(&mut buf, 0); // n_desc
+        w64(&mut buf, sym.offset); // n_value
     }
 
     // string table
@@ -391,9 +478,18 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
 
 // ── byte-writing helpers ───────────────────────────────────────────────────
 
-#[inline] fn w16(buf: &mut Vec<u8>, v: u16) { buf.extend_from_slice(&v.to_le_bytes()); }
-#[inline] fn w32(buf: &mut Vec<u8>, v: u32) { buf.extend_from_slice(&v.to_le_bytes()); }
-#[inline] fn w64(buf: &mut Vec<u8>, v: u64) { buf.extend_from_slice(&v.to_le_bytes()); }
+#[inline]
+fn w16(buf: &mut Vec<u8>, v: u16) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+#[inline]
+fn w32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+#[inline]
+fn w64(buf: &mut Vec<u8>, v: u64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
 
 /// Append a null-terminated string to `table` and return its start offset.
 fn push_str(table: &mut Vec<u8>, s: &[u8]) -> u32 {
@@ -411,13 +507,23 @@ mod tests {
 
     fn make_obj(fmt: ObjectFormat, code: Vec<u8>) -> ObjectFile {
         let section_name = match fmt {
-            ObjectFormat::Elf   => ".text",
+            ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
         };
         ObjectFile {
             format: fmt,
-            sections: vec![Section { name: section_name.into(), data: code, relocs: vec![] }],
-            symbols: vec![Symbol { name: "f".into(), section: 0, offset: 0, size: 1, global: true }],
+            sections: vec![Section {
+                name: section_name.into(),
+                data: code,
+                relocs: vec![],
+            }],
+            symbols: vec![Symbol {
+                name: "f".into(),
+                section: 0,
+                offset: 0,
+                size: 1,
+                global: true,
+            }],
         }
     }
 
@@ -465,25 +571,37 @@ mod tests {
         let bytes = make_obj(ObjectFormat::MachO, vec![0xc3]).to_bytes();
         // strtab is padded to 4 bytes: [\0, '_', 'f', \0] = 4 bytes.
         let strtab_first = bytes[bytes.len() - 4];
-        assert_eq!(strtab_first, 0x00,
-            "Mach-O strtab[0] must be null (\\0), was 0x{:02x}", strtab_first);
+        assert_eq!(
+            strtab_first, 0x00,
+            "Mach-O strtab[0] must be null (\\0), was 0x{:02x}",
+            strtab_first
+        );
     }
 
     #[test]
     fn emit_object_roundtrip() {
-        use crate::isel::{MachineFunction, MachineBlock};
+        use crate::isel::{MachineBlock, MachineFunction};
 
         struct NopEmitter;
         impl Emitter for NopEmitter {
             fn emit_function(&mut self, mf: &MachineFunction) -> Section {
                 let _ = mf;
-                Section { name: ".text".into(), data: vec![0x90], relocs: vec![] }
+                Section {
+                    name: ".text".into(),
+                    data: vec![0x90],
+                    relocs: vec![],
+                }
             }
-            fn object_format(&self) -> ObjectFormat { ObjectFormat::Elf }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Elf
+            }
         }
 
         let mut mf = MachineFunction::new("test".into());
-        mf.blocks.push(MachineBlock { label: "entry".into(), instrs: vec![] });
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
         let obj = emit_object(&mf, &mut NopEmitter);
         assert_eq!(obj.symbols[0].name, "test");
         assert_eq!(obj.sections[0].data, vec![0x90]);

--- a/src/llvm-codegen/src/isel.rs
+++ b/src/llvm-codegen/src/isel.rs
@@ -139,7 +139,10 @@ impl MachineFunction {
     /// Append a new empty machine block and return its index.
     pub fn add_block(&mut self, label: impl Into<String>) -> usize {
         let idx = self.blocks.len();
-        self.blocks.push(MachineBlock { label: label.into(), instrs: Vec::new() });
+        self.blocks.push(MachineBlock {
+            label: label.into(),
+            instrs: Vec::new(),
+        });
         idx
     }
 

--- a/src/llvm-codegen/src/lib.rs
+++ b/src/llvm-codegen/src/lib.rs
@@ -6,5 +6,5 @@ pub mod legalize;
 pub mod regalloc;
 pub mod schedule;
 
-pub use emit::{emit_object, Emitter, ObjectFile, ObjectFormat, Section, Symbol, Reloc, RelocKind};
-pub use isel::{IselBackend, MachineFunction, MachineBlock, MInstr, MOpcode, MOperand, PReg, VReg};
+pub use emit::{emit_object, Emitter, ObjectFile, ObjectFormat, Reloc, RelocKind, Section, Symbol};
+pub use isel::{IselBackend, MInstr, MOpcode, MOperand, MachineBlock, MachineFunction, PReg, VReg};

--- a/src/llvm-codegen/src/regalloc.rs
+++ b/src/llvm-codegen/src/regalloc.rs
@@ -10,8 +10,8 @@
 //!    - If a free register exists, assign it.
 //!    - Otherwise spill the interval with the largest end point.
 
+use crate::isel::{MOperand, MachineFunction, PReg, VReg};
 use std::collections::HashMap;
-use crate::isel::{MachineFunction, MOperand, PReg, VReg};
 
 // ── live intervals ─────────────────────────────────────────────────────────
 
@@ -47,15 +47,23 @@ pub fn compute_live_intervals(mf: &MachineFunction) -> Vec<LiveInterval> {
             // Definition extends interval to at least [pos, pos+1).
             if let Some(dst) = instr.dst {
                 let e = map.entry(dst).or_insert((pos, pos + 1));
-                if pos < e.0 { e.0 = pos; }
-                if pos + 1 > e.1 { e.1 = pos + 1; }
+                if pos < e.0 {
+                    e.0 = pos;
+                }
+                if pos + 1 > e.1 {
+                    e.1 = pos + 1;
+                }
             }
             // Uses extend the end of the interval.
             for op in &instr.operands {
                 if let MOperand::VReg(vr) = op {
                     let e = map.entry(*vr).or_insert((pos, pos + 1));
-                    if pos < e.0 { e.0 = pos; }
-                    if pos + 1 > e.1 { e.1 = pos + 1; }
+                    if pos < e.0 {
+                        e.0 = pos;
+                    }
+                    if pos + 1 > e.1 {
+                        e.1 = pos + 1;
+                    }
                 }
             }
             pos += 1;
@@ -82,10 +90,7 @@ pub struct RegAllocResult {
 /// Run linear-scan allocation over `intervals` using `allocatable` registers.
 ///
 /// Spilled VRegs are recorded in [`RegAllocResult::spilled`].
-pub fn linear_scan(
-    intervals: &[LiveInterval],
-    allocatable: &[PReg],
-) -> RegAllocResult {
+pub fn linear_scan(intervals: &[LiveInterval], allocatable: &[PReg]) -> RegAllocResult {
     if allocatable.is_empty() {
         return RegAllocResult {
             vreg_to_preg: HashMap::new(),
@@ -118,7 +123,11 @@ pub fn linear_scan(
         if free.is_empty() {
             // Spill: the active set is kept sorted by end, so the interval with
             // the largest end is always at the back — O(1) lookup instead of O(n).
-            let spill_idx = if active.is_empty() { None } else { Some(active.len() - 1) };
+            let spill_idx = if active.is_empty() {
+                None
+            } else {
+                Some(active.len() - 1)
+            };
 
             if let Some(idx) = spill_idx {
                 let (spill_end, spill_vr, spill_pr) = active[idx];
@@ -187,7 +196,11 @@ mod tests {
     use super::*;
 
     fn iv(vreg: u32, start: usize, end: usize) -> LiveInterval {
-        LiveInterval { vreg: VReg(vreg), start, end }
+        LiveInterval {
+            vreg: VReg(vreg),
+            start,
+            end,
+        }
     }
 
     #[test]
@@ -239,7 +252,7 @@ mod tests {
 
     #[test]
     fn apply_allocation_rewrites_operands() {
-        use crate::isel::{MachineFunction, MInstr, MOpcode};
+        use crate::isel::{MInstr, MOpcode, MachineFunction};
         let mut mf = MachineFunction::new("f".into());
         let b = mf.add_block("entry");
         let v0 = mf.fresh_vreg();
@@ -254,7 +267,7 @@ mod tests {
         apply_allocation(&mut mf, &result);
 
         // instr 0: dst=v0→PReg(3), src operand v1→PReg(7)
-        assert_eq!(mf.blocks[0].instrs[0].dst, Some(VReg(3)));  // physical reg 3
+        assert_eq!(mf.blocks[0].instrs[0].dst, Some(VReg(3))); // physical reg 3
         assert_eq!(mf.blocks[0].instrs[0].operands[0], MOperand::PReg(PReg(7)));
         // instr 1: src operand v0→PReg(3)
         assert_eq!(mf.blocks[0].instrs[1].operands[0], MOperand::PReg(PReg(3)));
@@ -262,7 +275,7 @@ mod tests {
 
     #[test]
     fn apply_allocation_rewrites_dst_register() {
-        use crate::isel::{MachineFunction, MInstr, MOpcode};
+        use crate::isel::{MInstr, MOpcode, MachineFunction};
         let mut mf = MachineFunction::new("f".into());
         let b = mf.add_block("entry");
         let v5 = VReg(5); // VReg 5 allocated to PReg 2
@@ -284,17 +297,24 @@ mod tests {
         // partition_point insertion correctly maintains the sorted invariant.
         // 5 intervals all starting at 0 with different ends — need 5 registers.
         let intervals = vec![
-            iv(0, 0, 10), iv(1, 0, 8), iv(2, 0, 6), iv(3, 0, 4), iv(4, 0, 2),
+            iv(0, 0, 10),
+            iv(1, 0, 8),
+            iv(2, 0, 6),
+            iv(3, 0, 4),
+            iv(4, 0, 2),
         ];
         let alloc: Vec<PReg> = (0u8..5).map(PReg).collect();
         let result = linear_scan(&intervals, &alloc);
-        assert!(result.spilled.is_empty(), "no spills: 5 regs for 5 simultaneous live ranges");
+        assert!(
+            result.spilled.is_empty(),
+            "no spills: 5 regs for 5 simultaneous live ranges"
+        );
         assert_eq!(result.vreg_to_preg.len(), 5);
     }
 
     #[test]
     fn compute_intervals_single_block() {
-        use crate::isel::{MachineFunction, MInstr, MOpcode};
+        use crate::isel::{MInstr, MOpcode, MachineFunction};
         let mut mf = MachineFunction::new("f".into());
         let b = mf.add_block("entry");
         let v0 = mf.fresh_vreg();

--- a/src/llvm-ir-parser/src/lexer.rs
+++ b/src/llvm-ir-parser/src/lexer.rs
@@ -9,13 +9,13 @@ use std::fmt;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Keyword {
     // Directives
-    Source,       // source_filename
-    Target,       // target
-    Triple,       // triple
-    Datalayout,   // datalayout
+    Source,     // source_filename
+    Target,     // target
+    Triple,     // triple
+    Datalayout, // datalayout
     Define,
     Declare,
-    Type,         // "type" keyword after %Foo =
+    Type, // "type" keyword after %Foo =
 
     // Linkage
     Private,
@@ -63,24 +63,81 @@ pub enum Keyword {
     Reassoc,
 
     // Opcodes
-    Add,  Sub,  Mul,  Udiv, Sdiv, Urem, Srem,
-    And,  Or,   Xor,  Shl,  Lshr, Ashr,
-    Fadd, Fsub, Fmul, Fdiv, Frem, Fneg,
-    Icmp, Fcmp,
-    Alloca, Load, Store, Getelementptr,
-    Trunc, Zext, Sext, Fptrunc, Fpext,
-    Fptoui, Fptosi, Uitofp, Sitofp,
-    Ptrtoint, Inttoptr, Bitcast, Addrspacecast,
-    Select, Phi, Extractvalue, Insertvalue,
-    Extractelement, Insertelement, Shufflevector,
+    Add,
+    Sub,
+    Mul,
+    Udiv,
+    Sdiv,
+    Urem,
+    Srem,
+    And,
+    Or,
+    Xor,
+    Shl,
+    Lshr,
+    Ashr,
+    Fadd,
+    Fsub,
+    Fmul,
+    Fdiv,
+    Frem,
+    Fneg,
+    Icmp,
+    Fcmp,
+    Alloca,
+    Load,
+    Store,
+    Getelementptr,
+    Trunc,
+    Zext,
+    Sext,
+    Fptrunc,
+    Fpext,
+    Fptoui,
+    Fptosi,
+    Uitofp,
+    Sitofp,
+    Ptrtoint,
+    Inttoptr,
+    Bitcast,
+    Addrspacecast,
+    Select,
+    Phi,
+    Extractvalue,
+    Insertvalue,
+    Extractelement,
+    Insertelement,
+    Shufflevector,
     Call,
-    Ret, Br, Switch, Unreachable,
+    Ret,
+    Br,
+    Switch,
+    Unreachable,
 
     // ICmp predicates
-    Eq, Ne, Ugt, Uge, Ult, Ule, Sgt, Sge, Slt, Sle,
+    Eq,
+    Ne,
+    Ugt,
+    Uge,
+    Ult,
+    Ule,
+    Sgt,
+    Sge,
+    Slt,
+    Sle,
     // FCmp predicates
-    False, Oeq, Ogt, Oge, Olt, Ole, One, Ord,
-    Uno,   Ueq, Une, True,
+    False,
+    Oeq,
+    Ogt,
+    Oge,
+    Olt,
+    Ole,
+    One,
+    Ord,
+    Uno,
+    Ueq,
+    Une,
+    True,
 
     // Aggregate/misc constants
     Zeroinitializer,
@@ -89,8 +146,8 @@ pub enum Keyword {
     Null,
     Align,
     To,
-    X,             // "x" in vector / array size
-    Vscale,        // "vscale" before "x" in scalable vector
+    X,      // "x" in vector / array size
+    Vscale, // "vscale" before "x" in scalable vector
 }
 
 // ---------------------------------------------------------------------------
@@ -162,7 +219,11 @@ pub struct LexError {
 
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "lex error at {}:{}: {}", self.line, self.col, self.message)
+        write!(
+            f,
+            "lex error at {}:{}: {}",
+            self.line, self.col, self.message
+        )
     }
 }
 
@@ -181,7 +242,13 @@ pub struct Lexer<'src> {
 
 impl<'src> Lexer<'src> {
     pub fn new(src: &'src str) -> Self {
-        Lexer { src: src.as_bytes(), pos: 0, line: 1, col: 1, peeked: None }
+        Lexer {
+            src: src.as_bytes(),
+            pos: 0,
+            line: 1,
+            col: 1,
+            peeked: None,
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -199,7 +266,12 @@ impl<'src> Lexer<'src> {
     fn advance(&mut self) -> Option<u8> {
         let ch = self.src.get(self.pos).copied()?;
         self.pos += 1;
-        if ch == b'\n' { self.line += 1; self.col = 1; } else { self.col += 1; }
+        if ch == b'\n' {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
         Some(ch)
     }
 
@@ -219,7 +291,11 @@ impl<'src> Lexer<'src> {
     }
 
     fn make_err(&self, msg: impl Into<String>) -> LexError {
-        LexError { line: self.line, col: self.col, message: msg.into() }
+        LexError {
+            line: self.line,
+            col: self.col,
+            message: msg.into(),
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -238,6 +314,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Consume and return the next token.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<Token, LexError> {
         if let Some(t) = self.peeked.take() {
             return t;
@@ -248,7 +325,10 @@ impl<'src> Lexer<'src> {
     /// Consume if next token matches; otherwise leave it in the peek buffer.
     pub fn eat(&mut self, expected: &Token) -> bool {
         match self.peek() {
-            Ok(t) if t == expected => { let _ = self.next(); true }
+            Ok(t) if t == expected => {
+                let _ = self.next();
+                true
+            }
             _ => false,
         }
     }
@@ -313,8 +393,12 @@ impl<'src> Lexer<'src> {
         }
     }
 
-    pub fn current_line(&self) -> usize { self.line }
-    pub fn current_col(&self) -> usize { self.col }
+    pub fn current_line(&self) -> usize {
+        self.line
+    }
+    pub fn current_col(&self) -> usize {
+        self.col
+    }
 
     // -----------------------------------------------------------------------
     // Core tokenizer
@@ -348,26 +432,76 @@ impl<'src> Lexer<'src> {
                 Ok(Token::StringLit(s))
             }
             b'-' | b'0'..=b'9' => self.lex_number(),
-            b'=' => { self.advance(); Ok(Token::Equal) }
-            b',' => { self.advance(); Ok(Token::Comma) }
-            b':' => { self.advance(); Ok(Token::Colon) }
-            b'*' => { self.advance(); Ok(Token::Star) }
-            b'(' => { self.advance(); Ok(Token::LParen) }
-            b')' => { self.advance(); Ok(Token::RParen) }
-            b'[' => { self.advance(); Ok(Token::LBracket) }
-            b']' => { self.advance(); Ok(Token::RBracket) }
-            b'{' => { self.advance(); Ok(Token::LBrace) }
-            b'}' => { self.advance(); Ok(Token::RBrace) }
-            b'<' => { self.advance(); Ok(Token::LAngle) }
-            b'>' => { self.advance(); Ok(Token::RAngle) }
-            b'!' => { self.advance(); Ok(Token::Bang) }
-            b'#' => { self.advance(); Ok(Token::Hash) }
+            b'=' => {
+                self.advance();
+                Ok(Token::Equal)
+            }
+            b',' => {
+                self.advance();
+                Ok(Token::Comma)
+            }
+            b':' => {
+                self.advance();
+                Ok(Token::Colon)
+            }
+            b'*' => {
+                self.advance();
+                Ok(Token::Star)
+            }
+            b'(' => {
+                self.advance();
+                Ok(Token::LParen)
+            }
+            b')' => {
+                self.advance();
+                Ok(Token::RParen)
+            }
+            b'[' => {
+                self.advance();
+                Ok(Token::LBracket)
+            }
+            b']' => {
+                self.advance();
+                Ok(Token::RBracket)
+            }
+            b'{' => {
+                self.advance();
+                Ok(Token::LBrace)
+            }
+            b'}' => {
+                self.advance();
+                Ok(Token::RBrace)
+            }
+            b'<' => {
+                self.advance();
+                Ok(Token::LAngle)
+            }
+            b'>' => {
+                self.advance();
+                Ok(Token::RAngle)
+            }
+            b'!' => {
+                self.advance();
+                Ok(Token::Bang)
+            }
+            b'#' => {
+                self.advance();
+                Ok(Token::Hash)
+            }
             b'.' => {
-                if self.src.get(self.pos+1) == Some(&b'.') && self.src.get(self.pos+2) == Some(&b'.') {
-                    self.advance(); self.advance(); self.advance();
+                if self.src.get(self.pos + 1) == Some(&b'.')
+                    && self.src.get(self.pos + 2) == Some(&b'.')
+                {
+                    self.advance();
+                    self.advance();
+                    self.advance();
                     Ok(Token::Ellipsis)
                 } else {
-                    Err(LexError { line: start_line, col: start_col, message: "unexpected '.'".into() })
+                    Err(LexError {
+                        line: start_line,
+                        col: start_col,
+                        message: "unexpected '.'".into(),
+                    })
                 }
             }
             _ if ch.is_ascii_alphabetic() || ch == b'_' || ch == b'$' => {
@@ -376,8 +510,11 @@ impl<'src> Lexer<'src> {
             }
             _ => {
                 self.advance();
-                Err(LexError { line: start_line, col: start_col,
-                    message: format!("unexpected character {:?}", ch as char) })
+                Err(LexError {
+                    line: start_line,
+                    col: start_col,
+                    message: format!("unexpected character {:?}", ch as char),
+                })
             }
         }
     }
@@ -403,11 +540,16 @@ impl<'src> Lexer<'src> {
     fn read_ident_or_int(&mut self) -> Result<String, LexError> {
         if self.peek_ch() == Some(b'"') {
             self.advance();
-            return self.read_string_literal();
+            self.read_string_literal()
         } else if self.peek_ch().map_or(false, |c| c.is_ascii_digit()) {
             let mut s = String::new();
             while let Some(c) = self.peek_ch() {
-                if c.is_ascii_digit() { self.advance(); s.push(c as char); } else { break; }
+                if c.is_ascii_digit() {
+                    self.advance();
+                    s.push(c as char);
+                } else {
+                    break;
+                }
             }
             Ok(s)
         } else {
@@ -429,7 +571,10 @@ impl<'src> Lexer<'src> {
         loop {
             match self.peek_ch() {
                 None => return Err(self.make_err("unterminated string")),
-                Some(b'"') => { self.advance(); break; }
+                Some(b'"') => {
+                    self.advance();
+                    break;
+                }
                 Some(b'\\') => {
                     self.advance();
                     let h1 = self.advance().ok_or_else(|| self.make_err("bad escape"))?;
@@ -439,7 +584,10 @@ impl<'src> Lexer<'src> {
                         .map_err(|_| self.make_err(format!("invalid hex escape \\{}", hex_str)))?;
                     s.push(byte as char);
                 }
-                Some(c) => { self.advance(); s.push(c as char); }
+                Some(c) => {
+                    self.advance();
+                    s.push(c as char);
+                }
             }
         }
         Ok(s)
@@ -451,7 +599,9 @@ impl<'src> Lexer<'src> {
 
     fn lex_number(&mut self) -> Result<Token, LexError> {
         let negative = self.peek_ch() == Some(b'-');
-        if negative { self.advance(); }
+        if negative {
+            self.advance();
+        }
 
         // Hex float "0x..."
         if self.peek_ch() == Some(b'0') && matches!(self.peek_ch2(), Some(b'x') | Some(b'X')) {
@@ -459,10 +609,14 @@ impl<'src> Lexer<'src> {
             self.advance(); // 'x'
             let mut hex = String::new();
             while let Some(c) = self.peek_ch() {
-                if c.is_ascii_hexdigit() { self.advance(); hex.push(c as char); } else { break; }
+                if c.is_ascii_hexdigit() {
+                    self.advance();
+                    hex.push(c as char);
+                } else {
+                    break;
+                }
             }
-            let bits = u64::from_str_radix(&hex, 16)
-                .map_err(|_| self.make_err("bad hex float"))?;
+            let bits = u64::from_str_radix(&hex, 16).map_err(|_| self.make_err("bad hex float"))?;
             let f = f64::from_bits(bits);
             return Ok(Token::FloatLit(if negative { -f } else { f }));
         }
@@ -470,18 +624,32 @@ impl<'src> Lexer<'src> {
         // Read digits.
         let mut digits = String::new();
         while let Some(c) = self.peek_ch() {
-            if c.is_ascii_digit() { self.advance(); digits.push(c as char); } else { break; }
+            if c.is_ascii_digit() {
+                self.advance();
+                digits.push(c as char);
+            } else {
+                break;
+            }
         }
 
         // Float if decimal point or exponent follows.
         let is_float = matches!(self.peek_ch(), Some(b'.') | Some(b'e') | Some(b'E'));
         if is_float {
-            let mut s = if negative { format!("-{}", digits) } else { digits };
+            let mut s = if negative {
+                format!("-{}", digits)
+            } else {
+                digits
+            };
             if self.peek_ch() == Some(b'.') {
                 self.advance();
                 s.push('.');
                 while let Some(c) = self.peek_ch() {
-                    if c.is_ascii_digit() { self.advance(); s.push(c as char); } else { break; }
+                    if c.is_ascii_digit() {
+                        self.advance();
+                        s.push(c as char);
+                    } else {
+                        break;
+                    }
                 }
             }
             if matches!(self.peek_ch(), Some(b'e') | Some(b'E')) {
@@ -492,14 +660,23 @@ impl<'src> Lexer<'src> {
                     s.push(sign as char);
                 }
                 while let Some(c) = self.peek_ch() {
-                    if c.is_ascii_digit() { self.advance(); s.push(c as char); } else { break; }
+                    if c.is_ascii_digit() {
+                        self.advance();
+                        s.push(c as char);
+                    } else {
+                        break;
+                    }
                 }
             }
-            let f: f64 = s.parse().map_err(|_| self.make_err(format!("bad float: {}", s)))?;
+            let f: f64 = s
+                .parse()
+                .map_err(|_| self.make_err(format!("bad float: {}", s)))?;
             Ok(Token::FloatLit(f))
         } else {
             // Integer.
-            let n: u64 = digits.parse().map_err(|_| self.make_err(format!("bad int: {}", digits)))?;
+            let n: u64 = digits
+                .parse()
+                .map_err(|_| self.make_err(format!("bad int: {}", digits)))?;
             if negative {
                 // i64::MIN is -(2^63) = 9223372036854775808; values beyond that don't fit.
                 if n > (i64::MAX as u64) + 1 {
@@ -529,130 +706,130 @@ impl<'src> Lexer<'src> {
         }
 
         let kw = match word {
-            "source_filename"      => Keyword::Source,
-            "target"               => Keyword::Target,
-            "triple"               => Keyword::Triple,
-            "datalayout"           => Keyword::Datalayout,
-            "define"               => Keyword::Define,
-            "declare"              => Keyword::Declare,
-            "type"                 => Keyword::Type,
-            "private"              => Keyword::Private,
-            "internal"             => Keyword::Internal,
-            "external"             => Keyword::External,
-            "weak"                 => Keyword::Weak,
-            "weak_odr"             => Keyword::WeakOdr,
-            "linkonce"             => Keyword::Linkonce,
-            "linkonce_odr"         => Keyword::LinkonceOdr,
-            "common"               => Keyword::Common,
+            "source_filename" => Keyword::Source,
+            "target" => Keyword::Target,
+            "triple" => Keyword::Triple,
+            "datalayout" => Keyword::Datalayout,
+            "define" => Keyword::Define,
+            "declare" => Keyword::Declare,
+            "type" => Keyword::Type,
+            "private" => Keyword::Private,
+            "internal" => Keyword::Internal,
+            "external" => Keyword::External,
+            "weak" => Keyword::Weak,
+            "weak_odr" => Keyword::WeakOdr,
+            "linkonce" => Keyword::Linkonce,
+            "linkonce_odr" => Keyword::LinkonceOdr,
+            "common" => Keyword::Common,
             "available_externally" => Keyword::AvailableExternally,
-            "void"                 => Keyword::Void,
-            "half"                 => Keyword::Half,
-            "bfloat"               => Keyword::Bfloat,
-            "float"                => Keyword::Float,
-            "double"               => Keyword::Double,
-            "fp128"                => Keyword::Fp128,
-            "x86_fp80"             => Keyword::X86Fp80,
-            "label"                => Keyword::Label,
-            "metadata"             => Keyword::Metadata,
-            "ptr"                  => Keyword::Ptr,
-            "global"               => Keyword::Global,
-            "constant"             => Keyword::Constant,
-            "inbounds"             => Keyword::Inbounds,
-            "exact"                => Keyword::Exact,
-            "nuw"                  => Keyword::Nuw,
-            "nsw"                  => Keyword::Nsw,
-            "volatile"             => Keyword::Volatile,
-            "tail"                 => Keyword::Tail,
-            "musttail"             => Keyword::Musttail,
-            "notail"               => Keyword::Notail,
-            "fast"                 => Keyword::Fast,
-            "nnan"                 => Keyword::Nnan,
-            "ninf"                 => Keyword::Ninf,
-            "nsz"                  => Keyword::Nsz,
-            "arcp"                 => Keyword::Arcp,
-            "contract"             => Keyword::Contract,
-            "afn"                  => Keyword::Afn,
-            "reassoc"              => Keyword::Reassoc,
-            "add"                  => Keyword::Add,
-            "sub"                  => Keyword::Sub,
-            "mul"                  => Keyword::Mul,
-            "udiv"                 => Keyword::Udiv,
-            "sdiv"                 => Keyword::Sdiv,
-            "urem"                 => Keyword::Urem,
-            "srem"                 => Keyword::Srem,
-            "and"                  => Keyword::And,
-            "or"                   => Keyword::Or,
-            "xor"                  => Keyword::Xor,
-            "shl"                  => Keyword::Shl,
-            "lshr"                 => Keyword::Lshr,
-            "ashr"                 => Keyword::Ashr,
-            "fadd"                 => Keyword::Fadd,
-            "fsub"                 => Keyword::Fsub,
-            "fmul"                 => Keyword::Fmul,
-            "fdiv"                 => Keyword::Fdiv,
-            "frem"                 => Keyword::Frem,
-            "fneg"                 => Keyword::Fneg,
-            "icmp"                 => Keyword::Icmp,
-            "fcmp"                 => Keyword::Fcmp,
-            "alloca"               => Keyword::Alloca,
-            "load"                 => Keyword::Load,
-            "store"                => Keyword::Store,
-            "getelementptr"        => Keyword::Getelementptr,
-            "trunc"                => Keyword::Trunc,
-            "zext"                 => Keyword::Zext,
-            "sext"                 => Keyword::Sext,
-            "fptrunc"              => Keyword::Fptrunc,
-            "fpext"                => Keyword::Fpext,
-            "fptoui"               => Keyword::Fptoui,
-            "fptosi"               => Keyword::Fptosi,
-            "uitofp"               => Keyword::Uitofp,
-            "sitofp"               => Keyword::Sitofp,
-            "ptrtoint"             => Keyword::Ptrtoint,
-            "inttoptr"             => Keyword::Inttoptr,
-            "bitcast"              => Keyword::Bitcast,
-            "addrspacecast"        => Keyword::Addrspacecast,
-            "select"               => Keyword::Select,
-            "phi"                  => Keyword::Phi,
-            "extractvalue"         => Keyword::Extractvalue,
-            "insertvalue"          => Keyword::Insertvalue,
-            "extractelement"       => Keyword::Extractelement,
-            "insertelement"        => Keyword::Insertelement,
-            "shufflevector"        => Keyword::Shufflevector,
-            "call"                 => Keyword::Call,
-            "ret"                  => Keyword::Ret,
-            "br"                   => Keyword::Br,
-            "switch"               => Keyword::Switch,
-            "unreachable"          => Keyword::Unreachable,
-            "eq"                   => Keyword::Eq,
-            "ne"                   => Keyword::Ne,
-            "ugt"                  => Keyword::Ugt,
-            "uge"                  => Keyword::Uge,
-            "ult"                  => Keyword::Ult,
-            "ule"                  => Keyword::Ule,
-            "sgt"                  => Keyword::Sgt,
-            "sge"                  => Keyword::Sge,
-            "slt"                  => Keyword::Slt,
-            "sle"                  => Keyword::Sle,
-            "false"                => Keyword::False,
-            "oeq"                  => Keyword::Oeq,
-            "ogt"                  => Keyword::Ogt,
-            "oge"                  => Keyword::Oge,
-            "olt"                  => Keyword::Olt,
-            "ole"                  => Keyword::Ole,
-            "one"                  => Keyword::One,
-            "ord"                  => Keyword::Ord,
-            "uno"                  => Keyword::Uno,
-            "ueq"                  => Keyword::Ueq,
-            "une"                  => Keyword::Une,
-            "true"                 => Keyword::True,
-            "zeroinitializer"      => Keyword::Zeroinitializer,
-            "undef"                => Keyword::Undef,
-            "poison"               => Keyword::Poison,
-            "null"                 => Keyword::Null,
-            "align"                => Keyword::Align,
-            "to"                   => Keyword::To,
-            "x"                    => Keyword::X,
-            "vscale"               => Keyword::Vscale,
+            "void" => Keyword::Void,
+            "half" => Keyword::Half,
+            "bfloat" => Keyword::Bfloat,
+            "float" => Keyword::Float,
+            "double" => Keyword::Double,
+            "fp128" => Keyword::Fp128,
+            "x86_fp80" => Keyword::X86Fp80,
+            "label" => Keyword::Label,
+            "metadata" => Keyword::Metadata,
+            "ptr" => Keyword::Ptr,
+            "global" => Keyword::Global,
+            "constant" => Keyword::Constant,
+            "inbounds" => Keyword::Inbounds,
+            "exact" => Keyword::Exact,
+            "nuw" => Keyword::Nuw,
+            "nsw" => Keyword::Nsw,
+            "volatile" => Keyword::Volatile,
+            "tail" => Keyword::Tail,
+            "musttail" => Keyword::Musttail,
+            "notail" => Keyword::Notail,
+            "fast" => Keyword::Fast,
+            "nnan" => Keyword::Nnan,
+            "ninf" => Keyword::Ninf,
+            "nsz" => Keyword::Nsz,
+            "arcp" => Keyword::Arcp,
+            "contract" => Keyword::Contract,
+            "afn" => Keyword::Afn,
+            "reassoc" => Keyword::Reassoc,
+            "add" => Keyword::Add,
+            "sub" => Keyword::Sub,
+            "mul" => Keyword::Mul,
+            "udiv" => Keyword::Udiv,
+            "sdiv" => Keyword::Sdiv,
+            "urem" => Keyword::Urem,
+            "srem" => Keyword::Srem,
+            "and" => Keyword::And,
+            "or" => Keyword::Or,
+            "xor" => Keyword::Xor,
+            "shl" => Keyword::Shl,
+            "lshr" => Keyword::Lshr,
+            "ashr" => Keyword::Ashr,
+            "fadd" => Keyword::Fadd,
+            "fsub" => Keyword::Fsub,
+            "fmul" => Keyword::Fmul,
+            "fdiv" => Keyword::Fdiv,
+            "frem" => Keyword::Frem,
+            "fneg" => Keyword::Fneg,
+            "icmp" => Keyword::Icmp,
+            "fcmp" => Keyword::Fcmp,
+            "alloca" => Keyword::Alloca,
+            "load" => Keyword::Load,
+            "store" => Keyword::Store,
+            "getelementptr" => Keyword::Getelementptr,
+            "trunc" => Keyword::Trunc,
+            "zext" => Keyword::Zext,
+            "sext" => Keyword::Sext,
+            "fptrunc" => Keyword::Fptrunc,
+            "fpext" => Keyword::Fpext,
+            "fptoui" => Keyword::Fptoui,
+            "fptosi" => Keyword::Fptosi,
+            "uitofp" => Keyword::Uitofp,
+            "sitofp" => Keyword::Sitofp,
+            "ptrtoint" => Keyword::Ptrtoint,
+            "inttoptr" => Keyword::Inttoptr,
+            "bitcast" => Keyword::Bitcast,
+            "addrspacecast" => Keyword::Addrspacecast,
+            "select" => Keyword::Select,
+            "phi" => Keyword::Phi,
+            "extractvalue" => Keyword::Extractvalue,
+            "insertvalue" => Keyword::Insertvalue,
+            "extractelement" => Keyword::Extractelement,
+            "insertelement" => Keyword::Insertelement,
+            "shufflevector" => Keyword::Shufflevector,
+            "call" => Keyword::Call,
+            "ret" => Keyword::Ret,
+            "br" => Keyword::Br,
+            "switch" => Keyword::Switch,
+            "unreachable" => Keyword::Unreachable,
+            "eq" => Keyword::Eq,
+            "ne" => Keyword::Ne,
+            "ugt" => Keyword::Ugt,
+            "uge" => Keyword::Uge,
+            "ult" => Keyword::Ult,
+            "ule" => Keyword::Ule,
+            "sgt" => Keyword::Sgt,
+            "sge" => Keyword::Sge,
+            "slt" => Keyword::Slt,
+            "sle" => Keyword::Sle,
+            "false" => Keyword::False,
+            "oeq" => Keyword::Oeq,
+            "ogt" => Keyword::Ogt,
+            "oge" => Keyword::Oge,
+            "olt" => Keyword::Olt,
+            "ole" => Keyword::Ole,
+            "one" => Keyword::One,
+            "ord" => Keyword::Ord,
+            "uno" => Keyword::Uno,
+            "ueq" => Keyword::Ueq,
+            "une" => Keyword::Une,
+            "true" => Keyword::True,
+            "zeroinitializer" => Keyword::Zeroinitializer,
+            "undef" => Keyword::Undef,
+            "poison" => Keyword::Poison,
+            "null" => Keyword::Null,
+            "align" => Keyword::Align,
+            "to" => Keyword::To,
+            "x" => Keyword::X,
+            "vscale" => Keyword::Vscale,
             // Unknown words become bare local identifiers (shouldn't normally happen at module level).
             other => return Token::LocalIdent(other.to_string()),
         };
@@ -669,7 +846,9 @@ mod tests {
         let mut toks = Vec::new();
         loop {
             let t = lex.next().unwrap();
-            if t == Token::Eof { break; }
+            if t == Token::Eof {
+                break;
+            }
             toks.push(t);
         }
         toks

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -6,15 +6,12 @@ use std::collections::HashMap;
 use std::fmt;
 
 use llvm_ir::{
-    Context, Module, Function, BasicBlock, Instruction, InstrKind,
-    TypeId, BlockId, ArgId, ConstId, GlobalId, ValueRef,
-    FloatKind,
-    ConstantData,
-    Argument, GlobalVariable, Linkage,
-    IntArithFlags, FastMathFlags, IntPredicate, FloatPredicate, TailCallKind,
+    ArgId, Argument, BasicBlock, BlockId, ConstId, ConstantData, Context, FastMathFlags, FloatKind,
+    FloatPredicate, Function, GlobalId, GlobalVariable, InstrKind, Instruction, IntArithFlags,
+    IntPredicate, Linkage, Module, TailCallKind, TypeId, ValueRef,
 };
 
-use crate::lexer::{Lexer, Token, Keyword, LexError};
+use crate::lexer::{Keyword, LexError, Lexer, Token};
 
 // ---------------------------------------------------------------------------
 // ParseError
@@ -29,19 +26,31 @@ pub struct ParseError {
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "parse error at {}:{}: {}", self.line, self.col, self.message)
+        write!(
+            f,
+            "parse error at {}:{}: {}",
+            self.line, self.col, self.message
+        )
     }
 }
 
 impl From<LexError> for ParseError {
     fn from(e: LexError) -> Self {
-        ParseError { line: e.line, col: e.col, message: e.message }
+        ParseError {
+            line: e.line,
+            col: e.col,
+            message: e.message,
+        }
     }
 }
 
 impl From<&LexError> for ParseError {
     fn from(e: &LexError) -> Self {
-        ParseError { line: e.line, col: e.col, message: e.message.clone() }
+        ParseError {
+            line: e.line,
+            col: e.col,
+            message: e.message.clone(),
+        }
     }
 }
 
@@ -77,7 +86,11 @@ impl<'src> Parser<'src> {
     }
 
     fn err(&self, msg: impl Into<String>) -> ParseError {
-        ParseError { line: self.lex.current_line(), col: self.lex.current_col(), message: msg.into() }
+        ParseError {
+            line: self.lex.current_line(),
+            col: self.lex.current_col(),
+            message: msg.into(),
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -88,13 +101,27 @@ impl<'src> Parser<'src> {
         loop {
             match self.lex.peek()? {
                 Token::Eof => break,
-                Token::Kw(Keyword::Source) => { self.parse_source_filename()?; }
-                Token::Kw(Keyword::Target) => { self.parse_target()?; }
-                Token::LocalIdent(_) => { self.parse_named_type_def()?; }
-                Token::GlobalIdent(_) => { self.parse_global_or_function()?; }
-                Token::Kw(Keyword::Define) => { self.parse_function(false)?; }
-                Token::Kw(Keyword::Declare) => { self.parse_function(true)?; }
-                Token::Bang => { self.skip_metadata_line()?; }
+                Token::Kw(Keyword::Source) => {
+                    self.parse_source_filename()?;
+                }
+                Token::Kw(Keyword::Target) => {
+                    self.parse_target()?;
+                }
+                Token::LocalIdent(_) => {
+                    self.parse_named_type_def()?;
+                }
+                Token::GlobalIdent(_) => {
+                    self.parse_global_or_function()?;
+                }
+                Token::Kw(Keyword::Define) => {
+                    self.parse_function(false)?;
+                }
+                Token::Kw(Keyword::Declare) => {
+                    self.parse_function(true)?;
+                }
+                Token::Bang => {
+                    self.skip_metadata_line()?;
+                }
                 _ => {
                     let t = self.lex.next()?;
                     return Err(self.err(format!("unexpected top-level token {:?}", t)));
@@ -168,7 +195,13 @@ impl<'src> Parser<'src> {
                 } else {
                     None
                 };
-                let gv = GlobalVariable { name, ty, initializer: init, is_constant: is_const, linkage };
+                let gv = GlobalVariable {
+                    name,
+                    ty,
+                    initializer: init,
+                    is_constant: is_const,
+                    linkage,
+                };
                 self.module.add_global(gv);
             }
             _ => {
@@ -179,7 +212,17 @@ impl<'src> Parser<'src> {
     }
 
     fn at_statement_end(&mut self) -> bool {
-        matches!(self.lex.peek(), Ok(Token::Eof) | Ok(Token::Kw(Keyword::Define)) | Ok(Token::Kw(Keyword::Declare)) | Ok(Token::GlobalIdent(_)) | Ok(Token::LocalIdent(_)) | Ok(Token::Kw(Keyword::Target)) | Ok(Token::Kw(Keyword::Source)) | Ok(Token::Bang))
+        matches!(
+            self.lex.peek(),
+            Ok(Token::Eof)
+                | Ok(Token::Kw(Keyword::Define))
+                | Ok(Token::Kw(Keyword::Declare))
+                | Ok(Token::GlobalIdent(_))
+                | Ok(Token::LocalIdent(_))
+                | Ok(Token::Kw(Keyword::Target))
+                | Ok(Token::Kw(Keyword::Source))
+                | Ok(Token::Bang)
+        )
     }
 
     // -----------------------------------------------------------------------
@@ -188,15 +231,42 @@ impl<'src> Parser<'src> {
 
     fn parse_optional_linkage(&mut self) -> Linkage {
         match self.lex.peek() {
-            Ok(Token::Kw(Keyword::Private))              => { let _ = self.lex.next(); Linkage::Private }
-            Ok(Token::Kw(Keyword::Internal))             => { let _ = self.lex.next(); Linkage::Internal }
-            Ok(Token::Kw(Keyword::External))             => { let _ = self.lex.next(); Linkage::External }
-            Ok(Token::Kw(Keyword::Weak))                 => { let _ = self.lex.next(); Linkage::Weak }
-            Ok(Token::Kw(Keyword::WeakOdr))              => { let _ = self.lex.next(); Linkage::WeakOdr }
-            Ok(Token::Kw(Keyword::Linkonce))             => { let _ = self.lex.next(); Linkage::LinkOnce }
-            Ok(Token::Kw(Keyword::LinkonceOdr))          => { let _ = self.lex.next(); Linkage::LinkOnceOdr }
-            Ok(Token::Kw(Keyword::Common))               => { let _ = self.lex.next(); Linkage::Common }
-            Ok(Token::Kw(Keyword::AvailableExternally))  => { let _ = self.lex.next(); Linkage::AvailableExternally }
+            Ok(Token::Kw(Keyword::Private)) => {
+                let _ = self.lex.next();
+                Linkage::Private
+            }
+            Ok(Token::Kw(Keyword::Internal)) => {
+                let _ = self.lex.next();
+                Linkage::Internal
+            }
+            Ok(Token::Kw(Keyword::External)) => {
+                let _ = self.lex.next();
+                Linkage::External
+            }
+            Ok(Token::Kw(Keyword::Weak)) => {
+                let _ = self.lex.next();
+                Linkage::Weak
+            }
+            Ok(Token::Kw(Keyword::WeakOdr)) => {
+                let _ = self.lex.next();
+                Linkage::WeakOdr
+            }
+            Ok(Token::Kw(Keyword::Linkonce)) => {
+                let _ = self.lex.next();
+                Linkage::LinkOnce
+            }
+            Ok(Token::Kw(Keyword::LinkonceOdr)) => {
+                let _ = self.lex.next();
+                Linkage::LinkOnceOdr
+            }
+            Ok(Token::Kw(Keyword::Common)) => {
+                let _ = self.lex.next();
+                Linkage::Common
+            }
+            Ok(Token::Kw(Keyword::AvailableExternally)) => {
+                let _ = self.lex.next();
+                Linkage::AvailableExternally
+            }
             _ => Linkage::External,
         }
     }
@@ -207,23 +277,50 @@ impl<'src> Parser<'src> {
 
     fn parse_type(&mut self) -> Result<TypeId, ParseError> {
         let base = match self.lex.peek()? {
-            Token::Kw(Keyword::Void)   => { self.lex.next()?; self.ctx.void_ty }
-            Token::Kw(Keyword::Half)   => { self.lex.next()?; self.ctx.mk_float(FloatKind::Half) }
-            Token::Kw(Keyword::Bfloat) => { self.lex.next()?; self.ctx.mk_float(FloatKind::BFloat) }
-            Token::Kw(Keyword::Float)  => { self.lex.next()?; self.ctx.f32_ty }
-            Token::Kw(Keyword::Double) => { self.lex.next()?; self.ctx.f64_ty }
-            Token::Kw(Keyword::Fp128)  => { self.lex.next()?; self.ctx.mk_float(FloatKind::Fp128) }
-            Token::Kw(Keyword::X86Fp80)=> { self.lex.next()?; self.ctx.mk_float(FloatKind::X86Fp80) }
-            Token::Kw(Keyword::Label)  => { self.lex.next()?; self.ctx.label_ty }
-            Token::Kw(Keyword::Ptr)    => { self.lex.next()?; self.ctx.ptr_ty }
+            Token::Kw(Keyword::Void) => {
+                self.lex.next()?;
+                self.ctx.void_ty
+            }
+            Token::Kw(Keyword::Half) => {
+                self.lex.next()?;
+                self.ctx.mk_float(FloatKind::Half)
+            }
+            Token::Kw(Keyword::Bfloat) => {
+                self.lex.next()?;
+                self.ctx.mk_float(FloatKind::BFloat)
+            }
+            Token::Kw(Keyword::Float) => {
+                self.lex.next()?;
+                self.ctx.f32_ty
+            }
+            Token::Kw(Keyword::Double) => {
+                self.lex.next()?;
+                self.ctx.f64_ty
+            }
+            Token::Kw(Keyword::Fp128) => {
+                self.lex.next()?;
+                self.ctx.mk_float(FloatKind::Fp128)
+            }
+            Token::Kw(Keyword::X86Fp80) => {
+                self.lex.next()?;
+                self.ctx.mk_float(FloatKind::X86Fp80)
+            }
+            Token::Kw(Keyword::Label) => {
+                self.lex.next()?;
+                self.ctx.label_ty
+            }
+            Token::Kw(Keyword::Ptr) => {
+                self.lex.next()?;
+                self.ctx.ptr_ty
+            }
             Token::IntType(bits) => {
                 let b = *bits;
                 self.lex.next()?;
                 self.ctx.mk_int(b)
             }
-            Token::LBracket => { self.parse_array_type()? }
-            Token::LAngle   => { self.parse_vector_type()? }
-            Token::LBrace   => {
+            Token::LBracket => self.parse_array_type()?,
+            Token::LAngle => self.parse_vector_type()?,
+            Token::LBrace => {
                 let (fields, packed) = self.parse_struct_body()?;
                 self.ctx.mk_struct_anon(fields, packed)
             }
@@ -239,7 +336,7 @@ impl<'src> Parser<'src> {
         };
 
         // Handle pointer suffix `*` (old-style IR) — consume but return ptr.
-        while self.lex.eat(&Token::Star) {
+        if self.lex.eat(&Token::Star) {
             return Ok(self.ctx.ptr_ty);
         }
 
@@ -281,7 +378,9 @@ impl<'src> Parser<'src> {
             }
         }
         self.lex.expect(&Token::RBrace)?;
-        if packed { self.lex.expect(&Token::RAngle)?; }
+        if packed {
+            self.lex.expect(&Token::RAngle)?;
+        }
         Ok((fields, packed))
     }
 
@@ -296,7 +395,10 @@ impl<'src> Parser<'src> {
             } else {
                 params.push(self.parse_type()?);
                 while self.lex.eat(&Token::Comma) {
-                    if self.lex.eat(&Token::Ellipsis) { variadic = true; break; }
+                    if self.lex.eat(&Token::Ellipsis) {
+                        variadic = true;
+                        break;
+                    }
                     params.push(self.parse_type()?);
                 }
             }
@@ -336,7 +438,10 @@ impl<'src> Parser<'src> {
                 let (ty, pname) = self.parse_param()?;
                 params.push((ty, pname));
                 while self.lex.eat(&Token::Comma) {
-                    if self.lex.eat(&Token::Ellipsis) { variadic = true; break; }
+                    if self.lex.eat(&Token::Ellipsis) {
+                        variadic = true;
+                        break;
+                    }
                     let (ty, pname) = self.parse_param()?;
                     params.push((ty, pname));
                 }
@@ -347,15 +452,17 @@ impl<'src> Parser<'src> {
         // Skip trailing function attributes (e.g. #0, nounwind, ...).
         self.skip_trailing_fn_attrs()?;
 
-        let fn_ty = self.ctx.mk_fn_type(
-            ret_ty,
-            params.iter().map(|(ty, _)| *ty).collect(),
-            variadic,
-        );
+        let fn_ty =
+            self.ctx
+                .mk_fn_type(ret_ty, params.iter().map(|(ty, _)| *ty).collect(), variadic);
         let args: Vec<Argument> = params
             .into_iter()
             .enumerate()
-            .map(|(i, (ty, nm))| Argument { name: nm, ty, index: i as u32 })
+            .map(|(i, (ty, nm))| Argument {
+                name: nm,
+                ty,
+                index: i as u32,
+            })
             .collect();
 
         // Reset local state for this function.
@@ -386,8 +493,13 @@ impl<'src> Parser<'src> {
         self.lex.expect(&Token::LBrace)?;
         loop {
             match self.lex.peek()? {
-                Token::RBrace => { self.lex.next()?; break; }
-                _ => { self.parse_block()?; }
+                Token::RBrace => {
+                    self.lex.next()?;
+                    break;
+                }
+                _ => {
+                    self.parse_block()?;
+                }
             }
         }
 
@@ -429,7 +541,9 @@ impl<'src> Parser<'src> {
             _ => "entry".to_string(),
         };
 
-        let fid = self.current_func.ok_or_else(|| self.err("block outside function"))?;
+        let fid = self
+            .current_func
+            .ok_or_else(|| self.err("block outside function"))?;
         let func = &mut self.module.functions[fid];
 
         // Reuse pre-allocated BlockId if this block was forward-referenced.
@@ -460,7 +574,9 @@ impl<'src> Parser<'src> {
                     }
                     self.parse_instruction(bid)?;
                 }
-                _ => { self.parse_instruction(bid)?; }
+                _ => {
+                    self.parse_instruction(bid)?;
+                }
             }
         }
 
@@ -468,7 +584,10 @@ impl<'src> Parser<'src> {
     }
 
     fn block_is_complete(&self, bid: BlockId) -> bool {
-        let fid = match self.current_func { Some(f) => f, None => return false };
+        let fid = match self.current_func {
+            Some(f) => f,
+            None => return false,
+        };
         self.module.functions[fid].block(bid).is_complete()
     }
 
@@ -477,7 +596,8 @@ impl<'src> Parser<'src> {
     // -----------------------------------------------------------------------
 
     fn parse_instruction(&mut self, bid: BlockId) -> Result<(), ParseError> {
-        let fid = self.current_func
+        let fid = self
+            .current_func
             .ok_or_else(|| self.err("instruction outside function"))?;
 
         // Parse optional result assignment: `%name = ` or `%N = `.
@@ -514,7 +634,9 @@ impl<'src> Parser<'src> {
         let iid = self.module.functions[fid].alloc_instr(instr);
 
         if is_term {
-            self.module.functions[fid].block_mut(bid).set_terminator(iid);
+            self.module.functions[fid]
+                .block_mut(bid)
+                .set_terminator(iid);
         } else {
             self.module.functions[fid].block_mut(bid).append_instr(iid);
         }
@@ -697,7 +819,15 @@ impl<'src> Parser<'src> {
                 self.lex.expect(&Token::Comma)?;
                 let rhs = self.parse_value(_ty)?;
                 let i1 = self.ctx.i1_ty;
-                Ok((InstrKind::FCmp { flags, pred, lhs, rhs }, i1))
+                Ok((
+                    InstrKind::FCmp {
+                        flags,
+                        pred,
+                        lhs,
+                        rhs,
+                    },
+                    i1,
+                ))
             }
             // --- Memory ---
             Token::Kw(Keyword::Alloca) => {
@@ -711,10 +841,19 @@ impl<'src> Parser<'src> {
                             Some(ne)
                         }
                     }
-                } else { None };
+                } else {
+                    None
+                };
                 let align = self.parse_optional_align()?;
                 let ptr_ty = self.ctx.ptr_ty;
-                Ok((InstrKind::Alloca { alloc_ty, num_elements, align }, ptr_ty))
+                Ok((
+                    InstrKind::Alloca {
+                        alloc_ty,
+                        num_elements,
+                        align,
+                    },
+                    ptr_ty,
+                ))
             }
             Token::Kw(Keyword::Load) => {
                 self.lex.next()?;
@@ -726,7 +865,15 @@ impl<'src> Parser<'src> {
                     (ptype, self.parse_value(ptype)?)
                 };
                 let align = self.parse_optional_align()?;
-                Ok((InstrKind::Load { ty, ptr, align, volatile }, ty))
+                Ok((
+                    InstrKind::Load {
+                        ty,
+                        ptr,
+                        align,
+                        volatile,
+                    },
+                    ty,
+                ))
             }
             Token::Kw(Keyword::Store) => {
                 self.lex.next()?;
@@ -737,7 +884,15 @@ impl<'src> Parser<'src> {
                 let ptr = self.parse_value(ptr_ty2)?;
                 let align = self.parse_optional_align()?;
                 let void_ty = self.ctx.void_ty;
-                Ok((InstrKind::Store { val, ptr, align, volatile }, void_ty))
+                Ok((
+                    InstrKind::Store {
+                        val,
+                        ptr,
+                        align,
+                        volatile,
+                    },
+                    void_ty,
+                ))
             }
             Token::Kw(Keyword::Getelementptr) => {
                 self.lex.next()?;
@@ -752,7 +907,15 @@ impl<'src> Parser<'src> {
                     indices.push(idx);
                 }
                 let ptr_ty = self.ctx.ptr_ty;
-                Ok((InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices }, ptr_ty))
+                Ok((
+                    InstrKind::GetElementPtr {
+                        inbounds,
+                        base_ty,
+                        ptr,
+                        indices,
+                    },
+                    ptr_ty,
+                ))
             }
             // --- Casts ---
             Token::Kw(Keyword::Trunc) => {
@@ -854,7 +1017,14 @@ impl<'src> Parser<'src> {
                 let (then_val, ty) = self.parse_typed_value()?;
                 self.lex.expect(&Token::Comma)?;
                 let else_val = self.parse_value(ty)?;
-                Ok((InstrKind::Select { cond, then_val, else_val }, ty))
+                Ok((
+                    InstrKind::Select {
+                        cond,
+                        then_val,
+                        else_val,
+                    },
+                    ty,
+                ))
             }
             Token::Kw(Keyword::Phi) => {
                 self.lex.next()?;
@@ -869,7 +1039,9 @@ impl<'src> Parser<'src> {
                     let bid = self.get_or_create_block(&block_name)?;
                     self.lex.expect(&Token::RBracket)?;
                     incoming.push((val, bid));
-                    if !self.lex.eat(&Token::Comma) { break; }
+                    if !self.lex.eat(&Token::Comma) {
+                        break;
+                    }
                 }
                 Ok((InstrKind::Phi { ty, incoming }, ty))
             }
@@ -894,7 +1066,14 @@ impl<'src> Parser<'src> {
                     let idx = self.lex.expect_uint_lit()? as u32;
                     indices.push(idx);
                 }
-                Ok((InstrKind::InsertValue { aggregate, val, indices }, agg_ty))
+                Ok((
+                    InstrKind::InsertValue {
+                        aggregate,
+                        val,
+                        indices,
+                    },
+                    agg_ty,
+                ))
             }
             Token::Kw(Keyword::Extractelement) => {
                 self.lex.next()?;
@@ -924,12 +1103,23 @@ impl<'src> Parser<'src> {
                 Ok((InstrKind::ShuffleVector { v1, v2, mask }, vec_ty))
             }
             // --- Call ---
-            Token::Kw(Keyword::Call) | Token::Kw(Keyword::Tail)
-            | Token::Kw(Keyword::Musttail) | Token::Kw(Keyword::Notail) => {
+            Token::Kw(Keyword::Call)
+            | Token::Kw(Keyword::Tail)
+            | Token::Kw(Keyword::Musttail)
+            | Token::Kw(Keyword::Notail) => {
                 let tail = match self.lex.peek()? {
-                    Token::Kw(Keyword::Tail)     => { self.lex.next()?; TailCallKind::Tail }
-                    Token::Kw(Keyword::Musttail) => { self.lex.next()?; TailCallKind::MustTail }
-                    Token::Kw(Keyword::Notail)   => { self.lex.next()?; TailCallKind::NoTail }
+                    Token::Kw(Keyword::Tail) => {
+                        self.lex.next()?;
+                        TailCallKind::Tail
+                    }
+                    Token::Kw(Keyword::Musttail) => {
+                        self.lex.next()?;
+                        TailCallKind::MustTail
+                    }
+                    Token::Kw(Keyword::Notail) => {
+                        self.lex.next()?;
+                        TailCallKind::NoTail
+                    }
                     _ => TailCallKind::None,
                 };
                 self.lex.expect_kw(&Keyword::Call)?;
@@ -956,7 +1146,9 @@ impl<'src> Parser<'src> {
                     let (a, _) = self.parse_typed_value()?;
                     args.push(a);
                     while self.lex.eat(&Token::Comma) {
-                        if self.lex.eat(&Token::Ellipsis) { break; }
+                        if self.lex.eat(&Token::Ellipsis) {
+                            break;
+                        }
                         let (a, _) = self.parse_typed_value()?;
                         args.push(a);
                     }
@@ -965,7 +1157,15 @@ impl<'src> Parser<'src> {
                 // Build a function type from what we know.
                 let param_tys: Vec<TypeId> = args.iter().map(|a| self.type_of_vref(*a)).collect();
                 let callee_ty = self.ctx.mk_fn_type(ret_ty, param_tys, false);
-                Ok((InstrKind::Call { tail, callee_ty, callee, args }, ret_ty))
+                Ok((
+                    InstrKind::Call {
+                        tail,
+                        callee_ty,
+                        callee,
+                        args,
+                    },
+                    ret_ty,
+                ))
             }
             // --- Terminators ---
             Token::Kw(Keyword::Ret) => {
@@ -999,7 +1199,14 @@ impl<'src> Parser<'src> {
                         self.lex.expect_kw(&Keyword::Label)?;
                         let else_name = self.lex.expect_local_ident()?;
                         let else_dest = self.get_or_create_block(&else_name)?;
-                        Ok((InstrKind::CondBr { cond, then_dest, else_dest }, void_ty))
+                        Ok((
+                            InstrKind::CondBr {
+                                cond,
+                                then_dest,
+                                else_dest,
+                            },
+                            void_ty,
+                        ))
                     }
                 }
             }
@@ -1022,7 +1229,14 @@ impl<'src> Parser<'src> {
                     cases.push((case_val, dest));
                 }
                 self.lex.expect(&Token::RBracket)?;
-                Ok((InstrKind::Switch { val, default, cases }, void_ty))
+                Ok((
+                    InstrKind::Switch {
+                        val,
+                        default,
+                        cases,
+                    },
+                    void_ty,
+                ))
             }
             Token::Kw(Keyword::Unreachable) => {
                 self.lex.next()?;
@@ -1066,7 +1280,9 @@ impl<'src> Parser<'src> {
                     let bits = f.to_bits();
                     let c = self.ctx.const_float(ty, bits);
                     Ok(ValueRef::Constant(c))
-                } else { unreachable!() }
+                } else {
+                    unreachable!()
+                }
             }
             Token::Kw(Keyword::Undef) => {
                 self.lex.next()?;
@@ -1121,7 +1337,7 @@ impl<'src> Parser<'src> {
         }
         Err(ParseError {
             line: self.lex.current_line(),
-            col:  self.lex.current_col(),
+            col: self.lex.current_col(),
             message: format!("undefined local value '%{}'", name),
         })
     }
@@ -1178,7 +1394,9 @@ impl<'src> Parser<'src> {
     }
 
     fn get_or_create_block(&mut self, name: &str) -> Result<BlockId, ParseError> {
-        let fid = self.current_func.ok_or_else(|| self.err("block reference outside function"))?;
+        let fid = self
+            .current_func
+            .ok_or_else(|| self.err("block reference outside function"))?;
         if let Some(&bid) = self.pending_blocks.get(name) {
             return Ok(bid);
         }
@@ -1195,9 +1413,13 @@ impl<'src> Parser<'src> {
     fn parse_int_arith_flags(&mut self) -> IntArithFlags {
         let mut flags = IntArithFlags::default();
         loop {
-            if self.lex.eat_kw(Keyword::Nuw) { flags.nuw = true; }
-            else if self.lex.eat_kw(Keyword::Nsw) { flags.nsw = true; }
-            else { break; }
+            if self.lex.eat_kw(Keyword::Nuw) {
+                flags.nuw = true;
+            } else if self.lex.eat_kw(Keyword::Nsw) {
+                flags.nsw = true;
+            } else {
+                break;
+            }
         }
         flags
     }
@@ -1205,23 +1427,34 @@ impl<'src> Parser<'src> {
     fn parse_fast_math_flags(&mut self) -> FastMathFlags {
         let mut f = FastMathFlags::default();
         loop {
-            if      self.lex.eat_kw(Keyword::Fast)     { f.fast = true; break; }
-            else if self.lex.eat_kw(Keyword::Nnan)     { f.nnan = true; }
-            else if self.lex.eat_kw(Keyword::Ninf)     { f.ninf = true; }
-            else if self.lex.eat_kw(Keyword::Nsz)      { f.nsz = true; }
-            else if self.lex.eat_kw(Keyword::Arcp)     { f.arcp = true; }
-            else if self.lex.eat_kw(Keyword::Contract) { f.contract = true; }
-            else if self.lex.eat_kw(Keyword::Afn)      { f.afn = true; }
-            else if self.lex.eat_kw(Keyword::Reassoc)  { f.reassoc = true; }
-            else { break; }
+            if self.lex.eat_kw(Keyword::Fast) {
+                f.fast = true;
+                break;
+            } else if self.lex.eat_kw(Keyword::Nnan) {
+                f.nnan = true;
+            } else if self.lex.eat_kw(Keyword::Ninf) {
+                f.ninf = true;
+            } else if self.lex.eat_kw(Keyword::Nsz) {
+                f.nsz = true;
+            } else if self.lex.eat_kw(Keyword::Arcp) {
+                f.arcp = true;
+            } else if self.lex.eat_kw(Keyword::Contract) {
+                f.contract = true;
+            } else if self.lex.eat_kw(Keyword::Afn) {
+                f.afn = true;
+            } else if self.lex.eat_kw(Keyword::Reassoc) {
+                f.reassoc = true;
+            } else {
+                break;
+            }
         }
         f
     }
 
     fn parse_int_pred(&mut self) -> Result<IntPredicate, ParseError> {
         match self.lex.next()? {
-            Token::Kw(Keyword::Eq)  => Ok(IntPredicate::Eq),
-            Token::Kw(Keyword::Ne)  => Ok(IntPredicate::Ne),
+            Token::Kw(Keyword::Eq) => Ok(IntPredicate::Eq),
+            Token::Kw(Keyword::Ne) => Ok(IntPredicate::Ne),
             Token::Kw(Keyword::Ugt) => Ok(IntPredicate::Ugt),
             Token::Kw(Keyword::Uge) => Ok(IntPredicate::Uge),
             Token::Kw(Keyword::Ult) => Ok(IntPredicate::Ult),
@@ -1237,20 +1470,20 @@ impl<'src> Parser<'src> {
     fn parse_float_pred(&mut self) -> Result<FloatPredicate, ParseError> {
         match self.lex.next()? {
             Token::Kw(Keyword::False) => Ok(FloatPredicate::False),
-            Token::Kw(Keyword::Oeq)  => Ok(FloatPredicate::Oeq),
-            Token::Kw(Keyword::Ogt)  => Ok(FloatPredicate::Ogt),
-            Token::Kw(Keyword::Oge)  => Ok(FloatPredicate::Oge),
-            Token::Kw(Keyword::Olt)  => Ok(FloatPredicate::Olt),
-            Token::Kw(Keyword::Ole)  => Ok(FloatPredicate::Ole),
-            Token::Kw(Keyword::One)  => Ok(FloatPredicate::One),
-            Token::Kw(Keyword::Ord)  => Ok(FloatPredicate::Ord),
-            Token::Kw(Keyword::Uno)  => Ok(FloatPredicate::Uno),
-            Token::Kw(Keyword::Ueq)  => Ok(FloatPredicate::Ueq),
-            Token::Kw(Keyword::Ugt)  => Ok(FloatPredicate::Ugt),
-            Token::Kw(Keyword::Uge)  => Ok(FloatPredicate::Uge),
-            Token::Kw(Keyword::Ult)  => Ok(FloatPredicate::Ult),
-            Token::Kw(Keyword::Ule)  => Ok(FloatPredicate::Ule),
-            Token::Kw(Keyword::Une)  => Ok(FloatPredicate::Une),
+            Token::Kw(Keyword::Oeq) => Ok(FloatPredicate::Oeq),
+            Token::Kw(Keyword::Ogt) => Ok(FloatPredicate::Ogt),
+            Token::Kw(Keyword::Oge) => Ok(FloatPredicate::Oge),
+            Token::Kw(Keyword::Olt) => Ok(FloatPredicate::Olt),
+            Token::Kw(Keyword::Ole) => Ok(FloatPredicate::Ole),
+            Token::Kw(Keyword::One) => Ok(FloatPredicate::One),
+            Token::Kw(Keyword::Ord) => Ok(FloatPredicate::Ord),
+            Token::Kw(Keyword::Uno) => Ok(FloatPredicate::Uno),
+            Token::Kw(Keyword::Ueq) => Ok(FloatPredicate::Ueq),
+            Token::Kw(Keyword::Ugt) => Ok(FloatPredicate::Ugt),
+            Token::Kw(Keyword::Uge) => Ok(FloatPredicate::Uge),
+            Token::Kw(Keyword::Ult) => Ok(FloatPredicate::Ult),
+            Token::Kw(Keyword::Ule) => Ok(FloatPredicate::Ule),
+            Token::Kw(Keyword::Une) => Ok(FloatPredicate::Une),
             Token::Kw(Keyword::True) => Ok(FloatPredicate::True),
             t => Err(self.err(format!("expected fcmp predicate, got {:?}", t))),
         }
@@ -1278,7 +1511,9 @@ impl<'src> Parser<'src> {
             let _ = self.parse_type()?;
             let n = self.lex.expect_int_lit()? as i32;
             mask.push(n);
-            if !self.lex.eat(&Token::Comma) { break; }
+            if !self.lex.eat(&Token::Comma) {
+                break;
+            }
         }
         self.lex.expect(&Token::RAngle)?;
         Ok(mask)
@@ -1311,7 +1546,9 @@ impl<'src> Parser<'src> {
                 Token::Kw(Keyword::Private)
                 | Token::Kw(Keyword::Internal)
                 | Token::Kw(Keyword::External)
-                | Token::Kw(Keyword::Weak) => { self.lex.next()?; }
+                | Token::Kw(Keyword::Weak) => {
+                    self.lex.next()?;
+                }
                 Token::Hash => {
                     self.lex.next()?;
                     self.lex.next()?; // skip number
@@ -1327,9 +1564,17 @@ impl<'src> Parser<'src> {
         loop {
             match self.lex.peek()? {
                 Token::LBrace | Token::Eof => break,
-                Token::Hash => { self.lex.next()?; self.lex.next()?; }
-                Token::Bang => { self.skip_metadata_line()?; break; }
-                _ => { self.lex.next()?; }
+                Token::Hash => {
+                    self.lex.next()?;
+                    self.lex.next()?;
+                }
+                Token::Bang => {
+                    self.skip_metadata_line()?;
+                    break;
+                }
+                _ => {
+                    self.lex.next()?;
+                }
             }
         }
         Ok(())
@@ -1344,8 +1589,13 @@ impl<'src> Parser<'src> {
                     self.lex.next()?;
                     self.lex.next()?; // alignment number
                 }
-                Token::Hash => { self.lex.next()?; self.lex.next()?; }
-                _ => { self.lex.next()?; }
+                Token::Hash => {
+                    self.lex.next()?;
+                    self.lex.next()?;
+                }
+                _ => {
+                    self.lex.next()?;
+                }
             }
         }
         Ok(())
@@ -1356,7 +1606,9 @@ impl<'src> Parser<'src> {
             // Consume tokens until newline-ish heuristic: next top-level token.
             // We approximate: consume until we see a GlobalIdent, Kw(Define), etc.
             let tok = self.lex.next()?;
-            if matches!(tok, Token::Eof) { break; }
+            if matches!(tok, Token::Eof) {
+                break;
+            }
             // Metadata lines end at things that look like module-level items.
             // Heuristic: stop when we've consumed something that looks complete.
             // For now we consume an entire "statement" by stopping at Eof.
@@ -1439,7 +1691,10 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 "#;
         let (_ctx, module) = parse(src).expect("parse failed");
         assert_eq!(module.source_filename.as_deref(), Some("test.c"));
-        assert_eq!(module.target_triple.as_deref(), Some("x86_64-unknown-linux-gnu"));
+        assert_eq!(
+            module.target_triple.as_deref(),
+            Some("x86_64-unknown-linux-gnu")
+        );
     }
 
     #[test]

--- a/src/llvm-ir-parser/tests/parse_basic.rs
+++ b/src/llvm-ir-parser/tests/parse_basic.rs
@@ -64,7 +64,10 @@ target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
 "#;
     let (_ctx, module) = parse(src).expect("parse failed");
     assert_eq!(module.source_filename.as_deref(), Some("hello.c"));
-    assert_eq!(module.target_triple.as_deref(), Some("aarch64-apple-darwin"));
+    assert_eq!(
+        module.target_triple.as_deref(),
+        Some("aarch64-apple-darwin")
+    );
     assert!(module.data_layout.is_some());
 }
 

--- a/src/llvm-ir/src/basic_block.rs
+++ b/src/llvm-ir/src/basic_block.rs
@@ -42,10 +42,7 @@ impl BasicBlock {
 
     /// Iterate over all instruction ids in order (body + terminator).
     pub fn instrs(&self) -> impl Iterator<Item = InstrId> + '_ {
-        self.body
-            .iter()
-            .copied()
-            .chain(self.terminator.into_iter())
+        self.body.iter().copied().chain(self.terminator.into_iter())
     }
 
     /// Number of instructions (body + optional terminator).

--- a/src/llvm-ir/src/builder.rs
+++ b/src/llvm-ir/src/builder.rs
@@ -1,12 +1,14 @@
 //! IR builder API for programmatic construction of instructions and basic blocks.
 
-use crate::context::{Context, TypeId, FunctionId, BlockId, ConstId, GlobalId, ValueRef};
-use crate::value::{Argument, Linkage, GlobalVariable};
-use crate::function::Function;
-use crate::module::Module;
 use crate::basic_block::BasicBlock;
-use crate::instruction::{Instruction, InstrKind, IntArithFlags, FastMathFlags,
-                         IntPredicate, FloatPredicate, TailCallKind};
+use crate::context::{BlockId, ConstId, Context, FunctionId, GlobalId, TypeId, ValueRef};
+use crate::function::Function;
+use crate::instruction::{
+    FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
+    TailCallKind,
+};
+use crate::module::Module;
+use crate::value::{Argument, GlobalVariable, Linkage};
 
 /// Programmatic IR builder.
 ///
@@ -21,7 +23,12 @@ pub struct Builder<'a> {
 
 impl<'a> Builder<'a> {
     pub fn new(ctx: &'a mut Context, module: &'a mut Module) -> Self {
-        Builder { ctx, module, current_function: None, current_block: None }
+        Builder {
+            ctx,
+            module,
+            current_function: None,
+            current_block: None,
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -42,7 +49,11 @@ impl<'a> Builder<'a> {
             .iter()
             .zip(param_names.iter().chain(std::iter::repeat(&String::new())))
             .enumerate()
-            .map(|(i, (&ty, name))| Argument { name: name.clone(), ty, index: i as u32 })
+            .map(|(i, (&ty, name))| Argument {
+                name: name.clone(),
+                ty,
+                index: i as u32,
+            })
             .collect();
         let func = Function::new(name, fn_ty, args, linkage);
         let id = self.module.add_function(func);
@@ -62,11 +73,14 @@ impl<'a> Builder<'a> {
         let args: Vec<Argument> = param_tys
             .iter()
             .enumerate()
-            .map(|(i, &ty)| Argument { name: String::new(), ty, index: i as u32 })
+            .map(|(i, &ty)| Argument {
+                name: String::new(),
+                ty,
+                index: i as u32,
+            })
             .collect();
         let func = Function::new_declaration(name, fn_ty, args, Linkage::External);
-        let id = self.module.add_function(func);
-        id
+        self.module.add_function(func)
     }
 
     // -----------------------------------------------------------------------
@@ -160,7 +174,13 @@ impl<'a> Builder<'a> {
         is_constant: bool,
         linkage: Linkage,
     ) -> GlobalId {
-        let gv = GlobalVariable { name: name.into(), ty, initializer, is_constant, linkage };
+        let gv = GlobalVariable {
+            name: name.into(),
+            ty,
+            initializer,
+            is_constant,
+            linkage,
+        };
         self.module.add_global(gv)
     }
 
@@ -175,9 +195,15 @@ impl<'a> Builder<'a> {
         let is_terminator = instr.is_terminator();
         let id = self.module.function_mut(fid).alloc_instr(instr);
         if is_terminator {
-            self.module.function_mut(fid).block_mut(bid).set_terminator(id);
+            self.module
+                .function_mut(fid)
+                .block_mut(bid)
+                .set_terminator(id);
         } else {
-            self.module.function_mut(fid).block_mut(bid).append_instr(id);
+            self.module
+                .function_mut(fid)
+                .block_mut(bid)
+                .append_instr(id);
         }
         ValueRef::Instruction(id)
     }
@@ -188,44 +214,116 @@ impl<'a> Builder<'a> {
 
     pub fn build_add(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Add { flags: IntArithFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_add_nsw(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_add_nsw(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Add { flags: IntArithFlags { nsw: true, nuw: false }, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Add {
+                flags: IntArithFlags {
+                    nsw: true,
+                    nuw: false,
+                },
+                lhs,
+                rhs,
+            },
+        )
     }
 
     pub fn build_sub(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Sub { flags: IntArithFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Sub {
+                flags: IntArithFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
     pub fn build_mul(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Mul { flags: IntArithFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Mul {
+                flags: IntArithFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_udiv(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_udiv(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty, InstrKind::UDiv { exact: false, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::UDiv {
+                exact: false,
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_sdiv(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_sdiv(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty, InstrKind::SDiv { exact: false, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::SDiv {
+                exact: false,
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_urem(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_urem(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
         self.append_instr(Some(name.into()), ty, InstrKind::URem { lhs, rhs })
     }
 
-    pub fn build_srem(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_srem(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
         self.append_instr(Some(name.into()), ty, InstrKind::SRem { lhs, rhs })
     }
@@ -249,111 +347,303 @@ impl<'a> Builder<'a> {
 
     pub fn build_shl(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Shl { flags: IntArithFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Shl {
+                flags: IntArithFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_lshr(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_lshr(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty, InstrKind::LShr { exact: false, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::LShr {
+                exact: false,
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_ashr(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_ashr(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty, InstrKind::AShr { exact: false, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::AShr {
+                exact: false,
+                lhs,
+                rhs,
+            },
+        )
     }
 
     // --- FP arithmetic ---
 
-    pub fn build_fadd(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_fadd(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::FAdd { flags: FastMathFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::FAdd {
+                flags: FastMathFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_fsub(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_fsub(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::FSub { flags: FastMathFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::FSub {
+                flags: FastMathFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_fmul(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_fmul(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::FMul { flags: FastMathFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::FMul {
+                flags: FastMathFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
-    pub fn build_fdiv(&mut self, name: impl Into<String>, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_fdiv(
+        &mut self,
+        name: impl Into<String>,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(lhs);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::FDiv { flags: FastMathFlags::default(), lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::FDiv {
+                flags: FastMathFlags::default(),
+                lhs,
+                rhs,
+            },
+        )
     }
 
     pub fn build_fneg(&mut self, name: impl Into<String>, val: ValueRef) -> ValueRef {
         let ty = self.type_of(val);
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::FNeg { flags: FastMathFlags::default(), operand: val })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::FNeg {
+                flags: FastMathFlags::default(),
+                operand: val,
+            },
+        )
     }
 
     // --- Comparisons ---
 
-    pub fn build_icmp(&mut self, name: impl Into<String>, pred: IntPredicate, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_icmp(
+        &mut self,
+        name: impl Into<String>,
+        pred: IntPredicate,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let i1 = self.ctx.i1_ty;
         self.append_instr(Some(name.into()), i1, InstrKind::ICmp { pred, lhs, rhs })
     }
 
-    pub fn build_fcmp(&mut self, name: impl Into<String>, pred: FloatPredicate, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    pub fn build_fcmp(
+        &mut self,
+        name: impl Into<String>,
+        pred: FloatPredicate,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    ) -> ValueRef {
         let i1 = self.ctx.i1_ty;
-        self.append_instr(Some(name.into()), i1,
-            InstrKind::FCmp { flags: FastMathFlags::default(), pred, lhs, rhs })
+        self.append_instr(
+            Some(name.into()),
+            i1,
+            InstrKind::FCmp {
+                flags: FastMathFlags::default(),
+                pred,
+                lhs,
+                rhs,
+            },
+        )
     }
 
     // --- Memory ---
 
     pub fn build_alloca(&mut self, name: impl Into<String>, alloc_ty: TypeId) -> ValueRef {
         let ptr_ty = self.ctx.ptr_ty;
-        self.append_instr(Some(name.into()), ptr_ty,
-            InstrKind::Alloca { alloc_ty, num_elements: None, align: None })
+        self.append_instr(
+            Some(name.into()),
+            ptr_ty,
+            InstrKind::Alloca {
+                alloc_ty,
+                num_elements: None,
+                align: None,
+            },
+        )
     }
 
-    pub fn build_alloca_aligned(&mut self, name: impl Into<String>, alloc_ty: TypeId, align: u32) -> ValueRef {
+    pub fn build_alloca_aligned(
+        &mut self,
+        name: impl Into<String>,
+        alloc_ty: TypeId,
+        align: u32,
+    ) -> ValueRef {
         let ptr_ty = self.ctx.ptr_ty;
-        self.append_instr(Some(name.into()), ptr_ty,
-            InstrKind::Alloca { alloc_ty, num_elements: None, align: Some(align) })
+        self.append_instr(
+            Some(name.into()),
+            ptr_ty,
+            InstrKind::Alloca {
+                alloc_ty,
+                num_elements: None,
+                align: Some(align),
+            },
+        )
     }
 
     pub fn build_load(&mut self, name: impl Into<String>, ty: TypeId, ptr: ValueRef) -> ValueRef {
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Load { ty, ptr, align: None, volatile: false })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Load {
+                ty,
+                ptr,
+                align: None,
+                volatile: false,
+            },
+        )
     }
 
-    pub fn build_load_aligned(&mut self, name: impl Into<String>, ty: TypeId, ptr: ValueRef, align: u32) -> ValueRef {
-        self.append_instr(Some(name.into()), ty,
-            InstrKind::Load { ty, ptr, align: Some(align), volatile: false })
+    pub fn build_load_aligned(
+        &mut self,
+        name: impl Into<String>,
+        ty: TypeId,
+        ptr: ValueRef,
+        align: u32,
+    ) -> ValueRef {
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Load {
+                ty,
+                ptr,
+                align: Some(align),
+                volatile: false,
+            },
+        )
     }
 
     pub fn build_store(&mut self, val: ValueRef, ptr: ValueRef) -> ValueRef {
         let void_ty = self.ctx.void_ty;
-        self.append_instr(None, void_ty,
-            InstrKind::Store { val, ptr, align: None, volatile: false })
+        self.append_instr(
+            None,
+            void_ty,
+            InstrKind::Store {
+                val,
+                ptr,
+                align: None,
+                volatile: false,
+            },
+        )
     }
 
     pub fn build_store_aligned(&mut self, val: ValueRef, ptr: ValueRef, align: u32) -> ValueRef {
         let void_ty = self.ctx.void_ty;
-        self.append_instr(None, void_ty,
-            InstrKind::Store { val, ptr, align: Some(align), volatile: false })
+        self.append_instr(
+            None,
+            void_ty,
+            InstrKind::Store {
+                val,
+                ptr,
+                align: Some(align),
+                volatile: false,
+            },
+        )
     }
 
-    pub fn build_gep(&mut self, name: impl Into<String>, base_ty: TypeId, ptr: ValueRef, indices: Vec<ValueRef>) -> ValueRef {
+    pub fn build_gep(
+        &mut self,
+        name: impl Into<String>,
+        base_ty: TypeId,
+        ptr: ValueRef,
+        indices: Vec<ValueRef>,
+    ) -> ValueRef {
         let ptr_ty = self.ctx.ptr_ty;
-        self.append_instr(Some(name.into()), ptr_ty,
-            InstrKind::GetElementPtr { inbounds: false, base_ty, ptr, indices })
+        self.append_instr(
+            Some(name.into()),
+            ptr_ty,
+            InstrKind::GetElementPtr {
+                inbounds: false,
+                base_ty,
+                ptr,
+                indices,
+            },
+        )
     }
 
-    pub fn build_gep_inbounds(&mut self, name: impl Into<String>, base_ty: TypeId, ptr: ValueRef, indices: Vec<ValueRef>) -> ValueRef {
+    pub fn build_gep_inbounds(
+        &mut self,
+        name: impl Into<String>,
+        base_ty: TypeId,
+        ptr: ValueRef,
+        indices: Vec<ValueRef>,
+    ) -> ValueRef {
         let ptr_ty = self.ctx.ptr_ty;
-        self.append_instr(Some(name.into()), ptr_ty,
-            InstrKind::GetElementPtr { inbounds: true, base_ty, ptr, indices })
+        self.append_instr(
+            Some(name.into()),
+            ptr_ty,
+            InstrKind::GetElementPtr {
+                inbounds: true,
+                base_ty,
+                ptr,
+                indices,
+            },
+        )
     }
 
     // --- Casts ---
@@ -367,7 +657,12 @@ impl<'a> Builder<'a> {
     pub fn build_sext(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::SExt { val, to })
     }
-    pub fn build_fptrunc(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
+    pub fn build_fptrunc(
+        &mut self,
+        name: impl Into<String>,
+        val: ValueRef,
+        to: TypeId,
+    ) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::FPTrunc { val, to })
     }
     pub fn build_fpext(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
@@ -385,34 +680,92 @@ impl<'a> Builder<'a> {
     pub fn build_sitofp(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::SIToFP { val, to })
     }
-    pub fn build_ptrtoint(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
+    pub fn build_ptrtoint(
+        &mut self,
+        name: impl Into<String>,
+        val: ValueRef,
+        to: TypeId,
+    ) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::PtrToInt { val, to })
     }
-    pub fn build_inttoptr(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
+    pub fn build_inttoptr(
+        &mut self,
+        name: impl Into<String>,
+        val: ValueRef,
+        to: TypeId,
+    ) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::IntToPtr { val, to })
     }
-    pub fn build_bitcast(&mut self, name: impl Into<String>, val: ValueRef, to: TypeId) -> ValueRef {
+    pub fn build_bitcast(
+        &mut self,
+        name: impl Into<String>,
+        val: ValueRef,
+        to: TypeId,
+    ) -> ValueRef {
         self.append_instr(Some(name.into()), to, InstrKind::BitCast { val, to })
     }
 
     // --- Misc ---
 
-    pub fn build_select(&mut self, name: impl Into<String>, cond: ValueRef, then_val: ValueRef, else_val: ValueRef) -> ValueRef {
+    pub fn build_select(
+        &mut self,
+        name: impl Into<String>,
+        cond: ValueRef,
+        then_val: ValueRef,
+        else_val: ValueRef,
+    ) -> ValueRef {
         let ty = self.type_of(then_val);
-        self.append_instr(Some(name.into()), ty, InstrKind::Select { cond, then_val, else_val })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::Select {
+                cond,
+                then_val,
+                else_val,
+            },
+        )
     }
 
-    pub fn build_phi(&mut self, name: impl Into<String>, ty: TypeId, incoming: Vec<(ValueRef, BlockId)>) -> ValueRef {
+    pub fn build_phi(
+        &mut self,
+        name: impl Into<String>,
+        ty: TypeId,
+        incoming: Vec<(ValueRef, BlockId)>,
+    ) -> ValueRef {
         self.append_instr(Some(name.into()), ty, InstrKind::Phi { ty, incoming })
     }
 
-    pub fn build_extractvalue(&mut self, name: impl Into<String>, aggregate: ValueRef, result_ty: TypeId, indices: Vec<u32>) -> ValueRef {
-        self.append_instr(Some(name.into()), result_ty, InstrKind::ExtractValue { aggregate, indices })
+    pub fn build_extractvalue(
+        &mut self,
+        name: impl Into<String>,
+        aggregate: ValueRef,
+        result_ty: TypeId,
+        indices: Vec<u32>,
+    ) -> ValueRef {
+        self.append_instr(
+            Some(name.into()),
+            result_ty,
+            InstrKind::ExtractValue { aggregate, indices },
+        )
     }
 
-    pub fn build_insertvalue(&mut self, name: impl Into<String>, aggregate: ValueRef, val: ValueRef, indices: Vec<u32>) -> ValueRef {
+    pub fn build_insertvalue(
+        &mut self,
+        name: impl Into<String>,
+        aggregate: ValueRef,
+        val: ValueRef,
+        indices: Vec<u32>,
+    ) -> ValueRef {
         let ty = self.type_of(aggregate);
-        self.append_instr(Some(name.into()), ty, InstrKind::InsertValue { aggregate, val, indices })
+        self.append_instr(
+            Some(name.into()),
+            ty,
+            InstrKind::InsertValue {
+                aggregate,
+                val,
+                indices,
+            },
+        )
     }
 
     // --- Call ---
@@ -426,13 +779,21 @@ impl<'a> Builder<'a> {
         args: Vec<ValueRef>,
     ) -> ValueRef {
         let n = name.into();
-        let result_name = if ret_ty == self.ctx.void_ty { None } else { Some(n) };
-        self.append_instr(result_name, ret_ty, InstrKind::Call {
-            tail: TailCallKind::None,
-            callee_ty,
-            callee,
-            args,
-        })
+        let result_name = if ret_ty == self.ctx.void_ty {
+            None
+        } else {
+            Some(n)
+        };
+        self.append_instr(
+            result_name,
+            ret_ty,
+            InstrKind::Call {
+                tail: TailCallKind::None,
+                callee_ty,
+                callee,
+                args,
+            },
+        )
     }
 
     // --- Terminators ---
@@ -452,14 +813,40 @@ impl<'a> Builder<'a> {
         self.append_instr(None, void_ty, InstrKind::Br { dest })
     }
 
-    pub fn build_cond_br(&mut self, cond: ValueRef, then_dest: BlockId, else_dest: BlockId) -> ValueRef {
+    pub fn build_cond_br(
+        &mut self,
+        cond: ValueRef,
+        then_dest: BlockId,
+        else_dest: BlockId,
+    ) -> ValueRef {
         let void_ty = self.ctx.void_ty;
-        self.append_instr(None, void_ty, InstrKind::CondBr { cond, then_dest, else_dest })
+        self.append_instr(
+            None,
+            void_ty,
+            InstrKind::CondBr {
+                cond,
+                then_dest,
+                else_dest,
+            },
+        )
     }
 
-    pub fn build_switch(&mut self, val: ValueRef, default: BlockId, cases: Vec<(ValueRef, BlockId)>) -> ValueRef {
+    pub fn build_switch(
+        &mut self,
+        val: ValueRef,
+        default: BlockId,
+        cases: Vec<(ValueRef, BlockId)>,
+    ) -> ValueRef {
         let void_ty = self.ctx.void_ty;
-        self.append_instr(None, void_ty, InstrKind::Switch { val, default, cases })
+        self.append_instr(
+            None,
+            void_ty,
+            InstrKind::Switch {
+                val,
+                default,
+                cases,
+            },
+        )
     }
 
     pub fn build_unreachable(&mut self) -> ValueRef {
@@ -476,9 +863,9 @@ impl<'a> Builder<'a> {
         let func = self.module.function(fid);
         match vref {
             ValueRef::Instruction(id) => func.instr(id).ty,
-            ValueRef::Argument(id)    => func.arg(id).ty,
-            ValueRef::Constant(id)    => self.ctx.type_of_const(id),
-            ValueRef::Global(_)       => self.ctx.ptr_ty,
+            ValueRef::Argument(id) => func.arg(id).ty,
+            ValueRef::Constant(id) => self.ctx.type_of_const(id),
+            ValueRef::Global(_) => self.ctx.ptr_ty,
         }
     }
 }

--- a/src/llvm-ir/src/context.rs
+++ b/src/llvm-ir/src/context.rs
@@ -1,8 +1,8 @@
 //! Context: interning tables for IR types and constants, plus all newtype index types.
 
-use std::collections::HashMap;
-use crate::types::{TypeData, FloatKind, StructType, FunctionType};
+use crate::types::{FloatKind, FunctionType, StructType, TypeData};
 use crate::value::ConstantData;
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Newtype index types — all u32, Copy
@@ -155,15 +155,27 @@ impl Context {
     }
 
     pub fn mk_vector(&mut self, element: TypeId, len: u32, scalable: bool) -> TypeId {
-        self.intern_anon(TypeData::Vector { element, len, scalable })
+        self.intern_anon(TypeData::Vector {
+            element,
+            len,
+            scalable,
+        })
     }
 
     pub fn mk_fn_type(&mut self, ret: TypeId, params: Vec<TypeId>, variadic: bool) -> TypeId {
-        self.intern_anon(TypeData::Function(FunctionType { ret, params, variadic }))
+        self.intern_anon(TypeData::Function(FunctionType {
+            ret,
+            params,
+            variadic,
+        }))
     }
 
     pub fn mk_struct_anon(&mut self, fields: Vec<TypeId>, packed: bool) -> TypeId {
-        self.intern_anon(TypeData::Struct(StructType { name: None, fields, packed }))
+        self.intern_anon(TypeData::Struct(StructType {
+            name: None,
+            fields,
+            packed,
+        }))
     }
 
     /// Create or look up a named struct. If the name is new, an opaque (empty-body)
@@ -214,7 +226,10 @@ impl Context {
 
     /// Iterate over all (TypeId, TypeData) pairs.
     pub fn types(&self) -> impl Iterator<Item = (TypeId, &TypeData)> {
-        self.types.iter().enumerate().map(|(i, td)| (TypeId(i as u32), td))
+        self.types
+            .iter()
+            .enumerate()
+            .map(|(i, td)| (TypeId(i as u32), td))
     }
 
     // -----------------------------------------------------------------------

--- a/src/llvm-ir/src/function.rs
+++ b/src/llvm-ir/src/function.rs
@@ -1,10 +1,10 @@
 //! Function definition: signature, arguments, basic blocks, and flat instruction pool.
 
-use std::collections::HashMap;
-use crate::context::{TypeId, BlockId, InstrId, ArgId, ValueRef};
 use crate::basic_block::BasicBlock;
+use crate::context::{ArgId, BlockId, InstrId, TypeId, ValueRef};
 use crate::instruction::Instruction;
 use crate::value::{Argument, Linkage};
+use std::collections::HashMap;
 
 /// A function definition or declaration.
 pub struct Function {
@@ -52,7 +52,12 @@ impl Function {
         f
     }
 
-    pub fn new_declaration(name: impl Into<String>, ty: TypeId, args: Vec<Argument>, linkage: Linkage) -> Self {
+    pub fn new_declaration(
+        name: impl Into<String>,
+        ty: TypeId,
+        args: Vec<Argument>,
+        linkage: Linkage,
+    ) -> Self {
         let mut f = Self::new(name, ty, args, linkage);
         f.is_declaration = true;
         f
@@ -156,7 +161,7 @@ impl Function {
     pub fn type_of_value(&self, vref: ValueRef) -> Option<TypeId> {
         match vref {
             ValueRef::Instruction(id) => Some(self.instructions[id.0 as usize].ty),
-            ValueRef::Argument(id)    => Some(self.args[id.0 as usize].ty),
+            ValueRef::Argument(id) => Some(self.args[id.0 as usize].ty),
             ValueRef::Constant(_) | ValueRef::Global(_) => None, // caller must consult Context/Module
         }
     }

--- a/src/llvm-ir/src/instruction.rs
+++ b/src/llvm-ir/src/instruction.rs
@@ -1,6 +1,6 @@
 //! SSA instructions: arithmetic, memory, control flow, and call instructions.
 
-use crate::context::{TypeId, BlockId, ValueRef};
+use crate::context::{BlockId, TypeId, ValueRef};
 
 // ---------------------------------------------------------------------------
 // Flags
@@ -56,8 +56,8 @@ pub enum IntPredicate {
 impl IntPredicate {
     pub fn as_str(self) -> &'static str {
         match self {
-            IntPredicate::Eq  => "eq",
-            IntPredicate::Ne  => "ne",
+            IntPredicate::Eq => "eq",
+            IntPredicate::Ne => "ne",
             IntPredicate::Ugt => "ugt",
             IntPredicate::Uge => "uge",
             IntPredicate::Ult => "ult",
@@ -94,20 +94,20 @@ impl FloatPredicate {
     pub fn as_str(self) -> &'static str {
         match self {
             FloatPredicate::False => "false",
-            FloatPredicate::Oeq  => "oeq",
-            FloatPredicate::Ogt  => "ogt",
-            FloatPredicate::Oge  => "oge",
-            FloatPredicate::Olt  => "olt",
-            FloatPredicate::Ole  => "ole",
-            FloatPredicate::One  => "one",
-            FloatPredicate::Ord  => "ord",
-            FloatPredicate::Uno  => "uno",
-            FloatPredicate::Ueq  => "ueq",
-            FloatPredicate::Ugt  => "ugt",
-            FloatPredicate::Uge  => "uge",
-            FloatPredicate::Ult  => "ult",
-            FloatPredicate::Ule  => "ule",
-            FloatPredicate::Une  => "une",
+            FloatPredicate::Oeq => "oeq",
+            FloatPredicate::Ogt => "ogt",
+            FloatPredicate::Oge => "oge",
+            FloatPredicate::Olt => "olt",
+            FloatPredicate::Ole => "ole",
+            FloatPredicate::One => "one",
+            FloatPredicate::Ord => "ord",
+            FloatPredicate::Uno => "uno",
+            FloatPredicate::Ueq => "ueq",
+            FloatPredicate::Ugt => "ugt",
+            FloatPredicate::Uge => "uge",
+            FloatPredicate::Ult => "ult",
+            FloatPredicate::Ule => "ule",
+            FloatPredicate::Une => "une",
             FloatPredicate::True => "true",
         }
     }
@@ -129,63 +129,225 @@ pub enum TailCallKind {
 #[derive(Clone, Debug, PartialEq)]
 pub enum InstrKind {
     // --- Integer arithmetic ---
-    Add { flags: IntArithFlags, lhs: ValueRef, rhs: ValueRef },
-    Sub { flags: IntArithFlags, lhs: ValueRef, rhs: ValueRef },
-    Mul { flags: IntArithFlags, lhs: ValueRef, rhs: ValueRef },
-    UDiv { exact: bool, lhs: ValueRef, rhs: ValueRef },
-    SDiv { exact: bool, lhs: ValueRef, rhs: ValueRef },
-    URem { lhs: ValueRef, rhs: ValueRef },
-    SRem { lhs: ValueRef, rhs: ValueRef },
+    Add {
+        flags: IntArithFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    Sub {
+        flags: IntArithFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    Mul {
+        flags: IntArithFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    UDiv {
+        exact: bool,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    SDiv {
+        exact: bool,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    URem {
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    SRem {
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
 
     // --- Bitwise ---
-    And { lhs: ValueRef, rhs: ValueRef },
-    Or  { lhs: ValueRef, rhs: ValueRef },
-    Xor { lhs: ValueRef, rhs: ValueRef },
-    Shl { flags: IntArithFlags, lhs: ValueRef, rhs: ValueRef },
-    LShr { exact: bool, lhs: ValueRef, rhs: ValueRef },
-    AShr { exact: bool, lhs: ValueRef, rhs: ValueRef },
+    And {
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    Or {
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    Xor {
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    Shl {
+        flags: IntArithFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    LShr {
+        exact: bool,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    AShr {
+        exact: bool,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
 
     // --- Floating-point arithmetic ---
-    FAdd { flags: FastMathFlags, lhs: ValueRef, rhs: ValueRef },
-    FSub { flags: FastMathFlags, lhs: ValueRef, rhs: ValueRef },
-    FMul { flags: FastMathFlags, lhs: ValueRef, rhs: ValueRef },
-    FDiv { flags: FastMathFlags, lhs: ValueRef, rhs: ValueRef },
-    FRem { flags: FastMathFlags, lhs: ValueRef, rhs: ValueRef },
-    FNeg { flags: FastMathFlags, operand: ValueRef },
+    FAdd {
+        flags: FastMathFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FSub {
+        flags: FastMathFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FMul {
+        flags: FastMathFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FDiv {
+        flags: FastMathFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FRem {
+        flags: FastMathFlags,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FNeg {
+        flags: FastMathFlags,
+        operand: ValueRef,
+    },
 
     // --- Comparisons ---
-    ICmp { pred: IntPredicate, lhs: ValueRef, rhs: ValueRef },
-    FCmp { flags: FastMathFlags, pred: FloatPredicate, lhs: ValueRef, rhs: ValueRef },
+    ICmp {
+        pred: IntPredicate,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
+    FCmp {
+        flags: FastMathFlags,
+        pred: FloatPredicate,
+        lhs: ValueRef,
+        rhs: ValueRef,
+    },
 
     // --- Memory ---
-    Alloca { alloc_ty: TypeId, num_elements: Option<ValueRef>, align: Option<u32> },
-    Load { ty: TypeId, ptr: ValueRef, align: Option<u32>, volatile: bool },
-    Store { val: ValueRef, ptr: ValueRef, align: Option<u32>, volatile: bool },
-    GetElementPtr { inbounds: bool, base_ty: TypeId, ptr: ValueRef, indices: Vec<ValueRef> },
+    Alloca {
+        alloc_ty: TypeId,
+        num_elements: Option<ValueRef>,
+        align: Option<u32>,
+    },
+    Load {
+        ty: TypeId,
+        ptr: ValueRef,
+        align: Option<u32>,
+        volatile: bool,
+    },
+    Store {
+        val: ValueRef,
+        ptr: ValueRef,
+        align: Option<u32>,
+        volatile: bool,
+    },
+    GetElementPtr {
+        inbounds: bool,
+        base_ty: TypeId,
+        ptr: ValueRef,
+        indices: Vec<ValueRef>,
+    },
 
     // --- Casts ---
-    Trunc         { val: ValueRef, to: TypeId },
-    ZExt          { val: ValueRef, to: TypeId },
-    SExt          { val: ValueRef, to: TypeId },
-    FPTrunc       { val: ValueRef, to: TypeId },
-    FPExt         { val: ValueRef, to: TypeId },
-    FPToUI        { val: ValueRef, to: TypeId },
-    FPToSI        { val: ValueRef, to: TypeId },
-    UIToFP        { val: ValueRef, to: TypeId },
-    SIToFP        { val: ValueRef, to: TypeId },
-    PtrToInt      { val: ValueRef, to: TypeId },
-    IntToPtr      { val: ValueRef, to: TypeId },
-    BitCast       { val: ValueRef, to: TypeId },
-    AddrSpaceCast { val: ValueRef, to: TypeId },
+    Trunc {
+        val: ValueRef,
+        to: TypeId,
+    },
+    ZExt {
+        val: ValueRef,
+        to: TypeId,
+    },
+    SExt {
+        val: ValueRef,
+        to: TypeId,
+    },
+    FPTrunc {
+        val: ValueRef,
+        to: TypeId,
+    },
+    FPExt {
+        val: ValueRef,
+        to: TypeId,
+    },
+    FPToUI {
+        val: ValueRef,
+        to: TypeId,
+    },
+    FPToSI {
+        val: ValueRef,
+        to: TypeId,
+    },
+    UIToFP {
+        val: ValueRef,
+        to: TypeId,
+    },
+    SIToFP {
+        val: ValueRef,
+        to: TypeId,
+    },
+    PtrToInt {
+        val: ValueRef,
+        to: TypeId,
+    },
+    IntToPtr {
+        val: ValueRef,
+        to: TypeId,
+    },
+    BitCast {
+        val: ValueRef,
+        to: TypeId,
+    },
+    AddrSpaceCast {
+        val: ValueRef,
+        to: TypeId,
+    },
 
     // --- Misc ---
-    Select { cond: ValueRef, then_val: ValueRef, else_val: ValueRef },
-    Phi    { ty: TypeId, incoming: Vec<(ValueRef, BlockId)> },
-    ExtractValue { aggregate: ValueRef, indices: Vec<u32> },
-    InsertValue  { aggregate: ValueRef, val: ValueRef, indices: Vec<u32> },
-    ExtractElement { vec: ValueRef, idx: ValueRef },
-    InsertElement  { vec: ValueRef, val: ValueRef, idx: ValueRef },
-    ShuffleVector  { v1: ValueRef, v2: ValueRef, mask: Vec<i32> },
+    Select {
+        cond: ValueRef,
+        then_val: ValueRef,
+        else_val: ValueRef,
+    },
+    Phi {
+        ty: TypeId,
+        incoming: Vec<(ValueRef, BlockId)>,
+    },
+    ExtractValue {
+        aggregate: ValueRef,
+        indices: Vec<u32>,
+    },
+    InsertValue {
+        aggregate: ValueRef,
+        val: ValueRef,
+        indices: Vec<u32>,
+    },
+    ExtractElement {
+        vec: ValueRef,
+        idx: ValueRef,
+    },
+    InsertElement {
+        vec: ValueRef,
+        val: ValueRef,
+        idx: ValueRef,
+    },
+    ShuffleVector {
+        v1: ValueRef,
+        v2: ValueRef,
+        mask: Vec<i32>,
+    },
 
     // --- Call ---
     Call {
@@ -196,9 +358,17 @@ pub enum InstrKind {
     },
 
     // --- Terminators ---
-    Ret { val: Option<ValueRef> },
-    Br  { dest: BlockId },
-    CondBr { cond: ValueRef, then_dest: BlockId, else_dest: BlockId },
+    Ret {
+        val: Option<ValueRef>,
+    },
+    Br {
+        dest: BlockId,
+    },
+    CondBr {
+        cond: ValueRef,
+        then_dest: BlockId,
+        else_dest: BlockId,
+    },
     Switch {
         val: ValueRef,
         default: BlockId,
@@ -222,57 +392,57 @@ impl InstrKind {
     /// Return the opcode name for printing.
     pub fn opcode(&self) -> &'static str {
         match self {
-            InstrKind::Add { .. }           => "add",
-            InstrKind::Sub { .. }           => "sub",
-            InstrKind::Mul { .. }           => "mul",
-            InstrKind::UDiv { .. }          => "udiv",
-            InstrKind::SDiv { .. }          => "sdiv",
-            InstrKind::URem { .. }          => "urem",
-            InstrKind::SRem { .. }          => "srem",
-            InstrKind::And { .. }           => "and",
-            InstrKind::Or { .. }            => "or",
-            InstrKind::Xor { .. }           => "xor",
-            InstrKind::Shl { .. }           => "shl",
-            InstrKind::LShr { .. }          => "lshr",
-            InstrKind::AShr { .. }          => "ashr",
-            InstrKind::FAdd { .. }          => "fadd",
-            InstrKind::FSub { .. }          => "fsub",
-            InstrKind::FMul { .. }          => "fmul",
-            InstrKind::FDiv { .. }          => "fdiv",
-            InstrKind::FRem { .. }          => "frem",
-            InstrKind::FNeg { .. }          => "fneg",
-            InstrKind::ICmp { .. }          => "icmp",
-            InstrKind::FCmp { .. }          => "fcmp",
-            InstrKind::Alloca { .. }        => "alloca",
-            InstrKind::Load { .. }          => "load",
-            InstrKind::Store { .. }         => "store",
+            InstrKind::Add { .. } => "add",
+            InstrKind::Sub { .. } => "sub",
+            InstrKind::Mul { .. } => "mul",
+            InstrKind::UDiv { .. } => "udiv",
+            InstrKind::SDiv { .. } => "sdiv",
+            InstrKind::URem { .. } => "urem",
+            InstrKind::SRem { .. } => "srem",
+            InstrKind::And { .. } => "and",
+            InstrKind::Or { .. } => "or",
+            InstrKind::Xor { .. } => "xor",
+            InstrKind::Shl { .. } => "shl",
+            InstrKind::LShr { .. } => "lshr",
+            InstrKind::AShr { .. } => "ashr",
+            InstrKind::FAdd { .. } => "fadd",
+            InstrKind::FSub { .. } => "fsub",
+            InstrKind::FMul { .. } => "fmul",
+            InstrKind::FDiv { .. } => "fdiv",
+            InstrKind::FRem { .. } => "frem",
+            InstrKind::FNeg { .. } => "fneg",
+            InstrKind::ICmp { .. } => "icmp",
+            InstrKind::FCmp { .. } => "fcmp",
+            InstrKind::Alloca { .. } => "alloca",
+            InstrKind::Load { .. } => "load",
+            InstrKind::Store { .. } => "store",
             InstrKind::GetElementPtr { .. } => "getelementptr",
-            InstrKind::Trunc { .. }         => "trunc",
-            InstrKind::ZExt { .. }          => "zext",
-            InstrKind::SExt { .. }          => "sext",
-            InstrKind::FPTrunc { .. }       => "fptrunc",
-            InstrKind::FPExt { .. }         => "fpext",
-            InstrKind::FPToUI { .. }        => "fptoui",
-            InstrKind::FPToSI { .. }        => "fptosi",
-            InstrKind::UIToFP { .. }        => "uitofp",
-            InstrKind::SIToFP { .. }        => "sitofp",
-            InstrKind::PtrToInt { .. }      => "ptrtoint",
-            InstrKind::IntToPtr { .. }      => "inttoptr",
-            InstrKind::BitCast { .. }       => "bitcast",
+            InstrKind::Trunc { .. } => "trunc",
+            InstrKind::ZExt { .. } => "zext",
+            InstrKind::SExt { .. } => "sext",
+            InstrKind::FPTrunc { .. } => "fptrunc",
+            InstrKind::FPExt { .. } => "fpext",
+            InstrKind::FPToUI { .. } => "fptoui",
+            InstrKind::FPToSI { .. } => "fptosi",
+            InstrKind::UIToFP { .. } => "uitofp",
+            InstrKind::SIToFP { .. } => "sitofp",
+            InstrKind::PtrToInt { .. } => "ptrtoint",
+            InstrKind::IntToPtr { .. } => "inttoptr",
+            InstrKind::BitCast { .. } => "bitcast",
             InstrKind::AddrSpaceCast { .. } => "addrspacecast",
-            InstrKind::Select { .. }        => "select",
-            InstrKind::Phi { .. }           => "phi",
-            InstrKind::ExtractValue { .. }  => "extractvalue",
-            InstrKind::InsertValue { .. }   => "insertvalue",
+            InstrKind::Select { .. } => "select",
+            InstrKind::Phi { .. } => "phi",
+            InstrKind::ExtractValue { .. } => "extractvalue",
+            InstrKind::InsertValue { .. } => "insertvalue",
             InstrKind::ExtractElement { .. } => "extractelement",
             InstrKind::InsertElement { .. } => "insertelement",
             InstrKind::ShuffleVector { .. } => "shufflevector",
-            InstrKind::Call { .. }          => "call",
-            InstrKind::Ret { .. }           => "ret",
-            InstrKind::Br { .. }            => "br",
-            InstrKind::CondBr { .. }        => "br",
-            InstrKind::Switch { .. }        => "switch",
-            InstrKind::Unreachable          => "unreachable",
+            InstrKind::Call { .. } => "call",
+            InstrKind::Ret { .. } => "ret",
+            InstrKind::Br { .. } => "br",
+            InstrKind::CondBr { .. } => "br",
+            InstrKind::Switch { .. } => "switch",
+            InstrKind::Unreachable => "unreachable",
         }
     }
 
@@ -287,7 +457,7 @@ impl InstrKind {
             | InstrKind::URem { lhs, rhs }
             | InstrKind::SRem { lhs, rhs }
             | InstrKind::And { lhs, rhs }
-            | InstrKind::Or  { lhs, rhs }
+            | InstrKind::Or { lhs, rhs }
             | InstrKind::Xor { lhs, rhs }
             | InstrKind::Shl { lhs, rhs, .. }
             | InstrKind::LShr { lhs, rhs, .. }
@@ -302,9 +472,7 @@ impl InstrKind {
 
             InstrKind::FNeg { operand, .. } => vec![*operand],
 
-            InstrKind::Alloca { num_elements, .. } => {
-                num_elements.into_iter().copied().collect()
-            }
+            InstrKind::Alloca { num_elements, .. } => num_elements.iter().copied().collect(),
             InstrKind::Load { ptr, .. } => vec![*ptr],
             InstrKind::Store { val, ptr, .. } => vec![*val, *ptr],
             InstrKind::GetElementPtr { ptr, indices, .. } => {
@@ -327,12 +495,14 @@ impl InstrKind {
             | InstrKind::BitCast { val, .. }
             | InstrKind::AddrSpaceCast { val, .. } => vec![*val],
 
-            InstrKind::Select { cond, then_val, else_val } => {
+            InstrKind::Select {
+                cond,
+                then_val,
+                else_val,
+            } => {
                 vec![*cond, *then_val, *else_val]
             }
-            InstrKind::Phi { incoming, .. } => {
-                incoming.iter().map(|(v, _)| *v).collect()
-            }
+            InstrKind::Phi { incoming, .. } => incoming.iter().map(|(v, _)| *v).collect(),
             InstrKind::ExtractValue { aggregate, .. } => vec![*aggregate],
             InstrKind::InsertValue { aggregate, val, .. } => vec![*aggregate, *val],
             InstrKind::ExtractElement { vec, idx } => vec![*vec, *idx],
@@ -343,7 +513,7 @@ impl InstrKind {
                 v.extend_from_slice(args);
                 v
             }
-            InstrKind::Ret { val } => val.into_iter().copied().collect(),
+            InstrKind::Ret { val } => val.iter().copied().collect(),
             InstrKind::Br { .. } | InstrKind::Unreachable => vec![],
             InstrKind::CondBr { cond, .. } => vec![*cond],
             InstrKind::Switch { val, cases, .. } => {
@@ -360,7 +530,11 @@ impl InstrKind {
     pub fn successors(&self) -> Vec<BlockId> {
         match self {
             InstrKind::Br { dest } => vec![*dest],
-            InstrKind::CondBr { then_dest, else_dest, .. } => {
+            InstrKind::CondBr {
+                then_dest,
+                else_dest,
+                ..
+            } => {
                 vec![*then_dest, *else_dest]
             }
             InstrKind::Switch { default, cases, .. } => {

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -11,17 +11,17 @@ pub mod types;
 pub mod value;
 
 // Re-export key types at crate root for ergonomic use.
-pub use context::{
-    Context, TypeId, FunctionId, BlockId, InstrId, ArgId, ConstId, GlobalId, ValueRef,
-};
-pub use types::{TypeData, FloatKind, StructType, FunctionType};
-pub use value::{ConstantData, Argument, GlobalVariable, Linkage};
-pub use instruction::{
-    Instruction, InstrKind, IntArithFlags, FastMathFlags, ExactFlag,
-    IntPredicate, FloatPredicate, TailCallKind,
-};
 pub use basic_block::BasicBlock;
-pub use function::Function;
-pub use module::Module;
 pub use builder::Builder;
+pub use context::{
+    ArgId, BlockId, ConstId, Context, FunctionId, GlobalId, InstrId, TypeId, ValueRef,
+};
+pub use function::Function;
+pub use instruction::{
+    ExactFlag, FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
+    TailCallKind,
+};
+pub use module::Module;
 pub use printer::Printer;
+pub use types::{FloatKind, FunctionType, StructType, TypeData};
+pub use value::{Argument, ConstantData, GlobalVariable, Linkage};

--- a/src/llvm-ir/src/module.rs
+++ b/src/llvm-ir/src/module.rs
@@ -1,9 +1,9 @@
 //! Module: top-level container for globals, functions, and metadata.
 
-use std::collections::HashMap;
 use crate::context::{FunctionId, GlobalId, TypeId};
 use crate::function::Function;
 use crate::value::GlobalVariable;
+use std::collections::HashMap;
 
 /// Top-level IR module.
 pub struct Module {

--- a/src/llvm-ir/src/printer.rs
+++ b/src/llvm-ir/src/printer.rs
@@ -1,13 +1,13 @@
 //! LLVM IR text format printer (`.ll` file emitter).
 
-use std::fmt::Write as FmtWrite;
-use crate::context::{Context, TypeId, ConstId, InstrId, BlockId, ValueRef};
-use crate::types::{TypeData, FloatKind, StructType};
-use crate::value::ConstantData;
-use crate::instruction::{InstrKind, FastMathFlags};
 use crate::basic_block::BasicBlock;
+use crate::context::{BlockId, ConstId, Context, InstrId, TypeId, ValueRef};
 use crate::function::Function;
+use crate::instruction::{FastMathFlags, InstrKind};
 use crate::module::Module;
+use crate::types::{FloatKind, StructType, TypeData};
+use crate::value::ConstantData;
+use std::fmt::Write as FmtWrite;
 
 pub struct Printer<'a> {
     ctx: &'a Context,
@@ -87,11 +87,13 @@ impl<'a> Printer<'a> {
 
     fn write_type(&self, out: &mut String, ty: TypeId) {
         match self.ctx.get_type(ty) {
-            TypeData::Void     => out.push_str("void"),
-            TypeData::Integer(bits) => { write!(out, "i{}", bits).unwrap(); }
-            TypeData::Float(kind)   => out.push_str(float_kind_str(*kind)),
-            TypeData::Pointer  => out.push_str("ptr"),
-            TypeData::Label    => out.push_str("label"),
+            TypeData::Void => out.push_str("void"),
+            TypeData::Integer(bits) => {
+                write!(out, "i{}", bits).unwrap();
+            }
+            TypeData::Float(kind) => out.push_str(float_kind_str(*kind)),
+            TypeData::Pointer => out.push_str("ptr"),
+            TypeData::Label => out.push_str("label"),
             TypeData::Metadata => out.push_str("metadata"),
             TypeData::Array { element, len } => {
                 let elem = *element;
@@ -100,7 +102,11 @@ impl<'a> Printer<'a> {
                 self.write_type(out, elem);
                 out.push(']');
             }
-            TypeData::Vector { element, len, scalable } => {
+            TypeData::Vector {
+                element,
+                len,
+                scalable,
+            } => {
                 let elem = *element;
                 let l = *len;
                 let sc = *scalable;
@@ -125,11 +131,15 @@ impl<'a> Printer<'a> {
                 self.write_type(out, ft.ret);
                 out.push_str(" (");
                 for (i, &p) in ft.params.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     self.write_type(out, p);
                 }
                 if ft.variadic {
-                    if !ft.params.is_empty() { out.push_str(", "); }
+                    if !ft.params.is_empty() {
+                        out.push_str(", ");
+                    }
                     out.push_str("...");
                 }
                 out.push(')');
@@ -138,14 +148,20 @@ impl<'a> Printer<'a> {
     }
 
     fn write_struct_body(&self, out: &mut String, st: &StructType) {
-        if st.packed { out.push('<'); }
+        if st.packed {
+            out.push('<');
+        }
         out.push_str("{ ");
         for (i, &f) in st.fields.iter().enumerate() {
-            if i > 0 { out.push_str(", "); }
+            if i > 0 {
+                out.push_str(", ");
+            }
             self.write_type(out, f);
         }
         out.push_str(" }");
-        if st.packed { out.push('>'); }
+        if st.packed {
+            out.push('>');
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -162,7 +178,9 @@ impl<'a> Printer<'a> {
 
     fn write_const_value(&self, out: &mut String, id: ConstId) {
         match self.ctx.get_const(id) {
-            ConstantData::Int { val, .. } => { write!(out, "{}", *val as i64).unwrap(); }
+            ConstantData::Int { val, .. } => {
+                write!(out, "{}", *val as i64).unwrap();
+            }
             ConstantData::IntWide { words, .. } => {
                 // Emit as hex for simplicity.
                 out.push_str("0x");
@@ -184,14 +202,16 @@ impl<'a> Printer<'a> {
                     }
                 }
             }
-            ConstantData::Null(_)            => out.push_str("null"),
-            ConstantData::Undef(_)           => out.push_str("undef"),
-            ConstantData::Poison(_)          => out.push_str("poison"),
+            ConstantData::Null(_) => out.push_str("null"),
+            ConstantData::Undef(_) => out.push_str("undef"),
+            ConstantData::Poison(_) => out.push_str("poison"),
             ConstantData::ZeroInitializer(_) => out.push_str("zeroinitializer"),
             ConstantData::Array { elements, .. } => {
                 out.push('[');
                 for (i, &e) in elements.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     self.write_const_with_type(out, e);
                 }
                 out.push(']');
@@ -199,7 +219,9 @@ impl<'a> Printer<'a> {
             ConstantData::Struct { fields, .. } => {
                 out.push_str("{ ");
                 for (i, &f) in fields.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     self.write_const_with_type(out, f);
                 }
                 out.push_str(" }");
@@ -207,7 +229,9 @@ impl<'a> Printer<'a> {
             ConstantData::Vector { elements, .. } => {
                 out.push('<');
                 for (i, &e) in elements.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     self.write_const_with_type(out, e);
                 }
                 out.push('>');
@@ -248,16 +272,18 @@ impl<'a> Printer<'a> {
                 }
             }
             ValueRef::Constant(id) => self.write_const_value(out, id),
-            ValueRef::Global(id) => { write!(out, "@g{}", id.0).unwrap(); }
+            ValueRef::Global(id) => {
+                write!(out, "@g{}", id.0).unwrap();
+            }
         }
     }
 
     fn type_of_vref(&self, vref: ValueRef, func: &Function) -> TypeId {
         match vref {
             ValueRef::Instruction(id) => func.instr(id).ty,
-            ValueRef::Argument(id)    => func.arg(id).ty,
-            ValueRef::Constant(id)    => self.ctx.type_of_const(id),
-            ValueRef::Global(_)       => self.ctx.ptr_ty,
+            ValueRef::Argument(id) => func.arg(id).ty,
+            ValueRef::Constant(id) => self.ctx.type_of_const(id),
+            ValueRef::Global(_) => self.ctx.ptr_ty,
         }
     }
 
@@ -285,7 +311,9 @@ impl<'a> Printer<'a> {
             self.write_type(out, ret);
             write!(out, " @{}(", func.name).unwrap();
             for (i, arg) in func.args.iter().enumerate() {
-                if i > 0 { out.push_str(", "); }
+                if i > 0 {
+                    out.push_str(", ");
+                }
                 self.write_type(out, arg.ty);
                 if !arg.name.is_empty() {
                     write!(out, " %{}", arg.name).unwrap();
@@ -294,13 +322,17 @@ impl<'a> Printer<'a> {
             // If there are fewer args than param types (anonymous decl args), fill in.
             let n_printed = func.args.len();
             if n_printed < params.len() {
-                for i in n_printed..params.len() {
-                    if i > 0 { out.push_str(", "); }
-                    self.write_type(out, params[i]);
+                for (i, &param_ty) in params.iter().enumerate().skip(n_printed) {
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
+                    self.write_type(out, param_ty);
                 }
             }
             if variadic {
-                if !func.args.is_empty() || !params.is_empty() { out.push_str(", "); }
+                if !func.args.is_empty() || !params.is_empty() {
+                    out.push_str(", ");
+                }
                 out.push_str("...");
             }
         } else {
@@ -347,52 +379,85 @@ impl<'a> Printer<'a> {
         // Emit fast-math flags helper.
         fn fmf_str(f: &FastMathFlags) -> String {
             let mut s = String::new();
-            if f.fast    { s.push_str("fast "); return s; }
-            if f.nnan    { s.push_str("nnan "); }
-            if f.ninf    { s.push_str("ninf "); }
-            if f.nsz     { s.push_str("nsz "); }
-            if f.arcp    { s.push_str("arcp "); }
-            if f.contract{ s.push_str("contract "); }
-            if f.afn     { s.push_str("afn "); }
-            if f.reassoc { s.push_str("reassoc "); }
+            if f.fast {
+                s.push_str("fast ");
+                return s;
+            }
+            if f.nnan {
+                s.push_str("nnan ");
+            }
+            if f.ninf {
+                s.push_str("ninf ");
+            }
+            if f.nsz {
+                s.push_str("nsz ");
+            }
+            if f.arcp {
+                s.push_str("arcp ");
+            }
+            if f.contract {
+                s.push_str("contract ");
+            }
+            if f.afn {
+                s.push_str("afn ");
+            }
+            if f.reassoc {
+                s.push_str("reassoc ");
+            }
             s
         }
 
         match &instr.kind {
             InstrKind::Add { flags, lhs, rhs } => {
                 out.push_str("add ");
-                if flags.nuw { out.push_str("nuw "); }
-                if flags.nsw { out.push_str("nsw "); }
+                if flags.nuw {
+                    out.push_str("nuw ");
+                }
+                if flags.nsw {
+                    out.push_str("nsw ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::Sub { flags, lhs, rhs } => {
                 out.push_str("sub ");
-                if flags.nuw { out.push_str("nuw "); }
-                if flags.nsw { out.push_str("nsw "); }
+                if flags.nuw {
+                    out.push_str("nuw ");
+                }
+                if flags.nsw {
+                    out.push_str("nsw ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::Mul { flags, lhs, rhs } => {
                 out.push_str("mul ");
-                if flags.nuw { out.push_str("nuw "); }
-                if flags.nsw { out.push_str("nsw "); }
+                if flags.nuw {
+                    out.push_str("nuw ");
+                }
+                if flags.nsw {
+                    out.push_str("nsw ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::UDiv { exact, lhs, rhs } => {
                 out.push_str("udiv ");
-                if *exact { out.push_str("exact "); }
+                if *exact {
+                    out.push_str("exact ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::SDiv { exact, lhs, rhs } => {
                 out.push_str("sdiv ");
-                if *exact { out.push_str("exact "); }
+                if *exact {
+                    out.push_str("exact ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
@@ -429,22 +494,30 @@ impl<'a> Printer<'a> {
             }
             InstrKind::Shl { flags, lhs, rhs } => {
                 out.push_str("shl ");
-                if flags.nuw { out.push_str("nuw "); }
-                if flags.nsw { out.push_str("nsw "); }
+                if flags.nuw {
+                    out.push_str("nuw ");
+                }
+                if flags.nsw {
+                    out.push_str("nsw ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::LShr { exact, lhs, rhs } => {
                 out.push_str("lshr ");
-                if *exact { out.push_str("exact "); }
+                if *exact {
+                    out.push_str("exact ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
             InstrKind::AShr { exact, lhs, rhs } => {
                 out.push_str("ashr ");
-                if *exact { out.push_str("exact "); }
+                if *exact {
+                    out.push_str("exact ");
+                }
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
@@ -489,13 +562,22 @@ impl<'a> Printer<'a> {
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
-            InstrKind::FCmp { flags, pred, lhs, rhs } => {
+            InstrKind::FCmp {
+                flags,
+                pred,
+                lhs,
+                rhs,
+            } => {
                 write!(out, "fcmp {}{} ", fmf_str(flags), pred.as_str()).unwrap();
                 self.write_typed_value(out, *lhs, func);
                 out.push_str(", ");
                 self.write_value(out, *rhs, func);
             }
-            InstrKind::Alloca { alloc_ty, num_elements, align } => {
+            InstrKind::Alloca {
+                alloc_ty,
+                num_elements,
+                align,
+            } => {
                 out.push_str("alloca ");
                 self.write_type(out, *alloc_ty);
                 if let Some(ne) = num_elements {
@@ -506,8 +588,15 @@ impl<'a> Printer<'a> {
                     write!(out, ", align {}", a).unwrap();
                 }
             }
-            InstrKind::Load { ty, ptr, align, volatile } => {
-                if *volatile { out.push_str("volatile "); }
+            InstrKind::Load {
+                ty,
+                ptr,
+                align,
+                volatile,
+            } => {
+                if *volatile {
+                    out.push_str("volatile ");
+                }
                 out.push_str("load ");
                 self.write_type(out, *ty);
                 out.push_str(", ");
@@ -516,8 +605,15 @@ impl<'a> Printer<'a> {
                     write!(out, ", align {}", a).unwrap();
                 }
             }
-            InstrKind::Store { val, ptr, align, volatile } => {
-                if *volatile { out.push_str("volatile "); }
+            InstrKind::Store {
+                val,
+                ptr,
+                align,
+                volatile,
+            } => {
+                if *volatile {
+                    out.push_str("volatile ");
+                }
                 out.push_str("store ");
                 self.write_typed_value(out, *val, func);
                 out.push_str(", ");
@@ -526,9 +622,16 @@ impl<'a> Printer<'a> {
                     write!(out, ", align {}", a).unwrap();
                 }
             }
-            InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices } => {
+            InstrKind::GetElementPtr {
+                inbounds,
+                base_ty,
+                ptr,
+                indices,
+            } => {
                 out.push_str("getelementptr ");
-                if *inbounds { out.push_str("inbounds "); }
+                if *inbounds {
+                    out.push_str("inbounds ");
+                }
                 self.write_type(out, *base_ty);
                 out.push_str(", ");
                 self.write_typed_value(out, *ptr, func);
@@ -556,7 +659,11 @@ impl<'a> Printer<'a> {
                 out.push_str(" to ");
                 self.write_type(out, *to);
             }
-            InstrKind::Select { cond, then_val, else_val } => {
+            InstrKind::Select {
+                cond,
+                then_val,
+                else_val,
+            } => {
                 out.push_str("select ");
                 self.write_typed_value(out, *cond, func);
                 out.push_str(", ");
@@ -569,7 +676,11 @@ impl<'a> Printer<'a> {
                 self.write_type(out, *ty);
                 let inc = incoming.clone();
                 for (i, (val, block)) in inc.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); } else { out.push(' '); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    } else {
+                        out.push(' ');
+                    }
                     out.push_str("[ ");
                     self.write_value(out, *val, func);
                     out.push_str(", %");
@@ -584,7 +695,11 @@ impl<'a> Printer<'a> {
                     write!(out, ", {}", i).unwrap();
                 }
             }
-            InstrKind::InsertValue { aggregate, val, indices } => {
+            InstrKind::InsertValue {
+                aggregate,
+                val,
+                indices,
+            } => {
                 out.push_str("insertvalue ");
                 self.write_typed_value(out, *aggregate, func);
                 out.push_str(", ");
@@ -614,17 +729,24 @@ impl<'a> Printer<'a> {
                 self.write_typed_value(out, *v2, func);
                 out.push_str(", <");
                 for (i, &m) in mask.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     write!(out, "i32 {}", m).unwrap();
                 }
                 out.push('>');
             }
-            InstrKind::Call { tail, callee_ty, callee, args } => {
+            InstrKind::Call {
+                tail,
+                callee_ty,
+                callee,
+                args,
+            } => {
                 match tail {
-                    crate::instruction::TailCallKind::Tail    => out.push_str("tail "),
+                    crate::instruction::TailCallKind::Tail => out.push_str("tail "),
                     crate::instruction::TailCallKind::MustTail => out.push_str("musttail "),
-                    crate::instruction::TailCallKind::NoTail  => out.push_str("notail "),
-                    crate::instruction::TailCallKind::None    => {}
+                    crate::instruction::TailCallKind::NoTail => out.push_str("notail "),
+                    crate::instruction::TailCallKind::None => {}
                 }
                 out.push_str("call ");
                 // Print return type from callee_ty.
@@ -637,7 +759,9 @@ impl<'a> Printer<'a> {
                 out.push('(');
                 let call_args = args.clone();
                 for (i, &arg) in call_args.iter().enumerate() {
-                    if i > 0 { out.push_str(", "); }
+                    if i > 0 {
+                        out.push_str(", ");
+                    }
                     self.write_typed_value(out, arg, func);
                 }
                 out.push(')');
@@ -652,7 +776,11 @@ impl<'a> Printer<'a> {
             InstrKind::Br { dest } => {
                 write!(out, "br label %{}", func.block(*dest).name).unwrap();
             }
-            InstrKind::CondBr { cond, then_dest, else_dest } => {
+            InstrKind::CondBr {
+                cond,
+                then_dest,
+                else_dest,
+            } => {
                 out.push_str("br ");
                 self.write_typed_value(out, *cond, func);
                 write!(
@@ -660,17 +788,22 @@ impl<'a> Printer<'a> {
                     ", label %{}, label %{}",
                     func.block(*then_dest).name,
                     func.block(*else_dest).name
-                ).unwrap();
+                )
+                .unwrap();
             }
-            InstrKind::Switch { val, default, cases } => {
+            InstrKind::Switch {
+                val,
+                default,
+                cases,
+            } => {
                 out.push_str("switch ");
                 self.write_typed_value(out, *val, func);
-                write!(out, ", label %{} [\n", func.block(*default).name).unwrap();
+                writeln!(out, ", label %{} [", func.block(*default).name).unwrap();
                 let sw_cases = cases.clone();
                 for (case_val, dest) in &sw_cases {
                     out.push_str("    ");
                     self.write_typed_value(out, *case_val, func);
-                    write!(out, ", label %{}\n", func.block(*dest).name).unwrap();
+                    writeln!(out, ", label %{}", func.block(*dest).name).unwrap();
                 }
                 out.push_str("  ]");
             }
@@ -684,11 +817,11 @@ impl<'a> Printer<'a> {
 
 fn float_kind_str(kind: FloatKind) -> &'static str {
     match kind {
-        FloatKind::Half   => "half",
+        FloatKind::Half => "half",
         FloatKind::BFloat => "bfloat",
         FloatKind::Single => "float",
         FloatKind::Double => "double",
-        FloatKind::Fp128  => "fp128",
+        FloatKind::Fp128 => "fp128",
         FloatKind::X86Fp80 => "x86_fp80",
     }
 }
@@ -696,11 +829,11 @@ fn float_kind_str(kind: FloatKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::Context;
-    use crate::module::Module;
-    use crate::function::Function;
     use crate::basic_block::BasicBlock;
-    use crate::instruction::{Instruction, InstrKind, IntArithFlags};
+    use crate::context::Context;
+    use crate::function::Function;
+    use crate::instruction::{InstrKind, Instruction, IntArithFlags};
+    use crate::module::Module;
     use crate::value::Linkage;
 
     #[test]
@@ -708,8 +841,16 @@ mod tests {
         let mut ctx = Context::new();
         let fn_ty = ctx.mk_fn_type(ctx.i32_ty, vec![ctx.i32_ty, ctx.i32_ty], false);
         let args = vec![
-            crate::value::Argument { name: "a".into(), ty: ctx.i32_ty, index: 0 },
-            crate::value::Argument { name: "b".into(), ty: ctx.i32_ty, index: 1 },
+            crate::value::Argument {
+                name: "a".into(),
+                ty: ctx.i32_ty,
+                index: 0,
+            },
+            crate::value::Argument {
+                name: "b".into(),
+                ty: ctx.i32_ty,
+                index: 1,
+            },
         ];
         let mut func = Function::new("add", fn_ty, args, Linkage::External);
 
@@ -720,7 +861,11 @@ mod tests {
         let add_instr = Instruction::new(
             Some("result".into()),
             ctx.i32_ty,
-            InstrKind::Add { flags: IntArithFlags::default(), lhs: a_ref, rhs: b_ref },
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs: a_ref,
+                rhs: b_ref,
+            },
         );
         let iid = func.alloc_instr(add_instr);
         bb.append_instr(iid);
@@ -728,7 +873,9 @@ mod tests {
         let ret_instr = Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Instruction(iid)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Instruction(iid)),
+            },
         );
         let rid = func.alloc_instr(ret_instr);
         bb.set_terminator(rid);

--- a/src/llvm-ir/src/types.rs
+++ b/src/llvm-ir/src/types.rs
@@ -8,8 +8,15 @@ pub enum TypeData {
     Integer(u32),
     Float(FloatKind),
     Pointer,
-    Array { element: TypeId, len: u64 },
-    Vector { element: TypeId, len: u32, scalable: bool },
+    Array {
+        element: TypeId,
+        len: u64,
+    },
+    Vector {
+        element: TypeId,
+        len: u32,
+        scalable: bool,
+    },
     Struct(StructType),
     Function(FunctionType),
     Label,
@@ -57,8 +64,16 @@ mod tests {
     #[test]
     fn struct_type_eq() {
         let ctx = Context::new();
-        let s1 = StructType { name: None, fields: vec![ctx.i32_ty, ctx.i64_ty], packed: false };
-        let s2 = StructType { name: None, fields: vec![ctx.i32_ty, ctx.i64_ty], packed: false };
+        let s1 = StructType {
+            name: None,
+            fields: vec![ctx.i32_ty, ctx.i64_ty],
+            packed: false,
+        };
+        let s2 = StructType {
+            name: None,
+            fields: vec![ctx.i32_ty, ctx.i64_ty],
+            packed: false,
+        };
         assert_eq!(s1, s2);
     }
 }

--- a/src/llvm-ir/src/value.rs
+++ b/src/llvm-ir/src/value.rs
@@ -1,6 +1,6 @@
 //! SSA values: constants, instruction results, function arguments, and globals.
 
-use crate::context::{TypeId, ConstId, GlobalId};
+use crate::context::{ConstId, GlobalId, TypeId};
 
 /// Constant value stored in the Context constant pool.
 #[derive(Clone, Debug, PartialEq)]
@@ -27,7 +27,11 @@ pub enum ConstantData {
     Vector { ty: TypeId, elements: Vec<ConstId> },
     /// Reference to a global symbol (global variable or function).
     /// `name` is the LLVM IR name (without `@`), used for printing.
-    GlobalRef { ty: TypeId, id: GlobalId, name: String },
+    GlobalRef {
+        ty: TypeId,
+        id: GlobalId,
+        name: String,
+    },
 }
 
 /// A function argument (SSA value produced by function entry).

--- a/src/llvm-ir/tests/roundtrip.rs
+++ b/src/llvm-ir/tests/roundtrip.rs
@@ -1,9 +1,6 @@
 //! Round-trip test: build IR → print → parse → print → assert text equality.
 
-use llvm_ir::{
-    Context, Module,
-    Builder, Printer, Linkage, IntPredicate,
-};
+use llvm_ir::{Builder, Context, IntPredicate, Linkage, Module, Printer};
 
 /// Build a simple add function and check that the printer emits expected text.
 #[test]
@@ -31,8 +28,16 @@ fn roundtrip_add() {
     let p = Printer::new(b.ctx);
     let ir = p.print_module(b.module);
 
-    assert!(ir.contains("define i32 @add("), "missing function header in:\n{}", ir);
-    assert!(ir.contains("%sum = add i32 %a, %b"), "missing add in:\n{}", ir);
+    assert!(
+        ir.contains("define i32 @add("),
+        "missing function header in:\n{}",
+        ir
+    );
+    assert!(
+        ir.contains("%sum = add i32 %a, %b"),
+        "missing add in:\n{}",
+        ir
+    );
     assert!(ir.contains("ret i32 %sum"), "missing ret in:\n{}", ir);
 }
 
@@ -51,7 +56,7 @@ fn roundtrip_cond_br() {
         false,
         Linkage::External,
     );
-    let entry   = b.add_block("entry");
+    let entry = b.add_block("entry");
     let then_bb = b.add_block("ret_x");
     let else_bb = b.add_block("ret_y");
 
@@ -98,8 +103,8 @@ fn roundtrip_memory() {
     let p_ref = b.get_arg(0);
     let q_ref = b.get_arg(1);
     let tmp = b.build_load("tmp", b.ctx.i32_ty, p_ref);
-    let qv  = b.build_load("qv",  b.ctx.i32_ty, q_ref);
-    b.build_store(qv,  p_ref);
+    let qv = b.build_load("qv", b.ctx.i32_ty, q_ref);
+    b.build_store(qv, p_ref);
     b.build_store(tmp, q_ref);
     b.build_ret_void();
 

--- a/src/llvm-target-arm/src/abi.rs
+++ b/src/llvm-target-arm/src/abi.rs
@@ -1,7 +1,7 @@
 //! AArch64 calling convention support (AAPCS64).
 
-use llvm_codegen::isel::PReg;
 use crate::regs::{ARG_REGS, RET_REG};
+use llvm_codegen::isel::PReg;
 
 // Re-export for convenience.
 pub use crate::regs::RET_REG as AAPCS64_INT_RET;

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -7,15 +7,12 @@
 //! Each AArch64 instruction is exactly 4 bytes.  Branches are patched in a
 //! second pass once all block offsets are known.
 
-use std::collections::HashMap;
+use crate::{instructions::*, regs::reg_enc};
 use llvm_codegen::{
     emit::{Emitter, ObjectFormat, Reloc, Section},
-    isel::{MachineFunction, MInstr, MOperand, PReg},
+    isel::{MInstr, MOperand, MachineFunction, PReg},
 };
-use crate::{
-    instructions::*,
-    regs::reg_enc,
-};
+use std::collections::HashMap;
 
 /// AArch64 code emitter.
 pub struct AArch64Emitter {
@@ -76,7 +73,7 @@ impl Emitter for AArch64Emitter {
         }
 
         let section_name = match self.format {
-            ObjectFormat::Elf   => ".text",
+            ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
         };
 
@@ -107,7 +104,9 @@ impl EncodeCtx {
     fn emit4(&mut self, word: u32) {
         self.code.extend_from_slice(&word.to_le_bytes());
     }
-    fn pos(&self) -> usize { self.code.len() }
+    fn pos(&self) -> usize {
+        self.code.len()
+    }
 }
 
 // ── instruction encoding ─────────────────────────────────────────────────
@@ -115,10 +114,16 @@ impl EncodeCtx {
 fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
     // Helper to extract PReg from operand.
     let preg = |op: &MOperand| -> Option<PReg> {
-        match op { MOperand::PReg(r) => Some(*r), _ => None }
+        match op {
+            MOperand::PReg(r) => Some(*r),
+            _ => None,
+        }
     };
     let imm = |op: &MOperand| -> Option<i64> {
-        match op { MOperand::Imm(v) => Some(*v), _ => None }
+        match op {
+            MOperand::Imm(v) => Some(*v),
+            _ => None,
+        }
     };
 
     match instr.opcode {
@@ -174,15 +179,21 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             if let (Some(dst), Some(val)) = (instr.dst, instr.operands.first().and_then(imm)) {
                 let rd = reg_enc(PReg(dst.0 as u8)) as u32;
                 let val_u64 = val as u64;
-                let chunk0 = ((val_u64      ) & 0xFFFF) as u32;
+                let chunk0 = ((val_u64) & 0xFFFF) as u32;
                 let chunk1 = ((val_u64 >> 16) & 0xFFFF) as u32;
                 let chunk2 = ((val_u64 >> 32) & 0xFFFF) as u32;
                 let chunk3 = ((val_u64 >> 48) & 0xFFFF) as u32;
                 // Always emit MOVZ for chunk0 (clears the register).
                 ctx.emit4(0xD2800000 | (chunk0 << 5) | rd);
-                if chunk1 != 0 { ctx.emit4(0xF2A00000 | (chunk1 << 5) | rd); }
-                if chunk2 != 0 { ctx.emit4(0xF2C00000 | (chunk2 << 5) | rd); }
-                if chunk3 != 0 { ctx.emit4(0xF2E00000 | (chunk3 << 5) | rd); }
+                if chunk1 != 0 {
+                    ctx.emit4(0xF2A00000 | (chunk1 << 5) | rd);
+                }
+                if chunk2 != 0 {
+                    ctx.emit4(0xF2C00000 | (chunk2 << 5) | rd);
+                }
+                if chunk3 != 0 {
+                    ctx.emit4(0xF2E00000 | (chunk3 << 5) | rd);
+                }
             } else {
                 ctx.emit4(0xD503201F);
             }
@@ -297,17 +308,13 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
 
         // ── B_COND (b.cond offset) — 0x54000000 | (imm19<<5) | cond ─────
         B_COND => {
-            if let (Some(cc_op), Some(MOperand::Block(target))) =
+            if let (Some(MOperand::Imm(cc)), Some(MOperand::Block(target))) =
                 (instr.operands.first(), instr.operands.get(1))
             {
-                if let MOperand::Imm(cc) = cc_op {
-                    let hw_cond = cc_to_hw(*cc);
-                    let patch_pos = ctx.pos();
-                    ctx.emit4(0x54000000 | hw_cond as u32); // placeholder
-                    ctx.branch_patches.push((patch_pos, *target));
-                } else {
-                    ctx.emit4(0xD503201F);
-                }
+                let hw_cond = cc_to_hw(*cc);
+                let patch_pos = ctx.pos();
+                ctx.emit4(0x54000000 | hw_cond as u32); // placeholder
+                ctx.branch_patches.push((patch_pos, *target));
             } else {
                 ctx.emit4(0xD503201F);
             }
@@ -392,10 +399,12 @@ fn encode_rrr3(ctx: &mut EncodeCtx, instr: &MInstr, base: u32) {
     if let (Some(dst), Some(rn_preg), Some(rm_preg)) = (
         instr.dst,
         instr.operands.first().and_then(|op| match op {
-            MOperand::PReg(r) => Some(*r), _ => None,
+            MOperand::PReg(r) => Some(*r),
+            _ => None,
         }),
         instr.operands.get(1).and_then(|op| match op {
-            MOperand::PReg(r) => Some(*r), _ => None,
+            MOperand::PReg(r) => Some(*r),
+            _ => None,
         }),
     ) {
         let rd = reg_enc(PReg(dst.0 as u8)) as u32;
@@ -411,7 +420,11 @@ fn encode_rrr3(ctx: &mut EncodeCtx, instr: &MInstr, base: u32) {
 fn get_dst_src(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
     let dst = instr.dst.map(|v| PReg(v.0 as u8));
     let src = instr.operands.iter().find_map(|op| {
-        if let MOperand::PReg(r) = op { Some(*r) } else { None }
+        if let MOperand::PReg(r) = op {
+            Some(*r)
+        } else {
+            None
+        }
     });
     (dst, src)
 }
@@ -419,7 +432,11 @@ fn get_dst_src(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
 /// Extract two PReg operands from `instr.operands`.
 fn get_two_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
     let mut it = instr.operands.iter().filter_map(|op| {
-        if let MOperand::PReg(r) = op { Some(*r) } else { None }
+        if let MOperand::PReg(r) = op {
+            Some(*r)
+        } else {
+            None
+        }
     });
     (it.next(), it.next())
 }
@@ -431,17 +448,17 @@ fn get_two_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
 ///   HI=8, LS=9, GE=10, LT=11, GT=12, LE=13, AL=14, NV=15
 fn cc_to_hw(cc: i64) -> u8 {
     match cc {
-        CC_EQ => 0,   // EQ (Z=1)
-        CC_NE => 1,   // NE (Z=0)
-        CC_LT => 11,  // LT (N!=V)
-        CC_LE => 13,  // LE (Z=1 or N!=V)
-        CC_GT => 12,  // GT (Z=0 and N=V)
-        CC_GE => 10,  // GE (N=V)
-        CC_LO => 3,   // LO/CC (C=0)
-        CC_LS => 9,   // LS (C=0 or Z=1)
-        CC_HI => 8,   // HI (C=1 and Z=0)
-        CC_HS => 2,   // HS/CS (C=1)
-        _     => 0,
+        CC_EQ => 0,  // EQ (Z=1)
+        CC_NE => 1,  // NE (Z=0)
+        CC_LT => 11, // LT (N!=V)
+        CC_LE => 13, // LE (Z=1 or N!=V)
+        CC_GT => 12, // GT (Z=0 and N=V)
+        CC_GE => 10, // GE (N=V)
+        CC_LO => 3,  // LO/CC (C=0)
+        CC_LS => 9,  // LS (C=0 or Z=1)
+        CC_HI => 8,  // HI (C=1 and Z=0)
+        CC_HS => 2,  // HS/CS (C=1)
+        _ => 0,
     }
 }
 
@@ -450,16 +467,18 @@ fn cc_to_hw(cc: i64) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::regs::{X0, X1, X2};
     use llvm_codegen::{
         emit::emit_object,
-        isel::{MachineFunction, MInstr, VReg},
+        isel::{MInstr, MachineFunction, VReg},
     };
-    use crate::regs::{X0, X1, X2};
 
     fn single_block_mf(name: &str, instrs: Vec<MInstr>) -> MachineFunction {
         let mut mf = MachineFunction::new(name.into());
         let b = mf.add_block("entry");
-        for i in instrs { mf.push(b, i); }
+        for i in instrs {
+            mf.push(b, i);
+        }
         mf
     }
 
@@ -477,8 +496,11 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // RET = 0xD65F03C0 in little-endian: [0xC0, 0x03, 0x5F, 0xD6]
-        assert_eq!(&sec.data[0..4], &[0xC0, 0x03, 0x5F, 0xD6],
-            "RET must encode as 0xD65F03C0");
+        assert_eq!(
+            &sec.data[0..4],
+            &[0xC0, 0x03, 0x5F, 0xD6],
+            "RET must encode as 0xD65F03C0"
+        );
     }
 
     #[test]
@@ -512,7 +534,10 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        assert_eq!(word, 0x8B020020, "add x0, x1, x2 should encode as 0x8B020020");
+        assert_eq!(
+            word, 0x8B020020,
+            "add x0, x1, x2 should encode as 0x8B020020"
+        );
     }
 
     #[test]
@@ -532,8 +557,16 @@ mod tests {
         let b_word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // Branch target is 1 instruction forward from the branch instruction.
         // offset = (4 - 0) / 4 = 1; imm26 = 1; B = 0x14000001.
-        assert_eq!(b_word & 0xFC000000, 0x14000000, "unconditional branch base bits");
-        assert_eq!(b_word & 0x03FFFFFF, 1, "branch offset should be 1 instruction forward");
+        assert_eq!(
+            b_word & 0xFC000000,
+            0x14000000,
+            "unconditional branch base bits"
+        );
+        assert_eq!(
+            b_word & 0x03FFFFFF,
+            1,
+            "branch offset should be 1 instruction forward"
+        );
     }
 
     #[test]
@@ -557,7 +590,10 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::MachO);
         let sec = e.emit_function(&mf);
         // RET = 0xD65F03C0; byte 0 = 0xC0
-        assert!(sec.data.contains(&0xC0), "RET byte 0 (0xC0) must be in code");
+        assert!(
+            sec.data.contains(&0xC0),
+            "RET byte 0 (0xC0) must be in code"
+        );
     }
 
     #[test]
@@ -580,31 +616,46 @@ mod tests {
         let sec = e.emit_function(&mf);
 
         // Must emit exactly 4 instructions (4 × 4 bytes = 16 bytes).
-        assert_eq!(sec.data.len(), 16,
-            "MOV_WIDE with a full 64-bit value must emit 4 instructions (16 bytes)");
+        assert_eq!(
+            sec.data.len(),
+            16,
+            "MOV_WIDE with a full 64-bit value must emit 4 instructions (16 bytes)"
+        );
 
         // First instruction: MOVZ X0, #0x5678 — 0xD280_ACF0
         let w0 = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        assert_eq!(w0 & 0xFFE0_001F, 0xD280_0000,
-            "first word must be MOVZ (opcode 0xD280_0000 with chunk in bits[20:5])");
+        assert_eq!(
+            w0 & 0xFFE0_001F,
+            0xD280_0000,
+            "first word must be MOVZ (opcode 0xD280_0000 with chunk in bits[20:5])"
+        );
         assert_eq!((w0 >> 5) & 0xFFFF, 0x5678, "chunk0 must be 0x5678");
 
         // Second instruction: MOVK X0, #0x1234, lsl 16 — base 0xF2A0_0000
         let w1 = u32::from_le_bytes([sec.data[4], sec.data[5], sec.data[6], sec.data[7]]);
-        assert_eq!(w1 & 0xFFE0_001F, 0xF2A0_0000,
-            "second word must be MOVK lsl 16 (0xF2A0_0000)");
+        assert_eq!(
+            w1 & 0xFFE0_001F,
+            0xF2A0_0000,
+            "second word must be MOVK lsl 16 (0xF2A0_0000)"
+        );
         assert_eq!((w1 >> 5) & 0xFFFF, 0x1234, "chunk1 must be 0x1234");
 
         // Third instruction: MOVK X0, #0xCAFE, lsl 32 — base 0xF2C0_0000
         let w2 = u32::from_le_bytes([sec.data[8], sec.data[9], sec.data[10], sec.data[11]]);
-        assert_eq!(w2 & 0xFFE0_001F, 0xF2C0_0000,
-            "third word must be MOVK lsl 32 (0xF2C0_0000)");
+        assert_eq!(
+            w2 & 0xFFE0_001F,
+            0xF2C0_0000,
+            "third word must be MOVK lsl 32 (0xF2C0_0000)"
+        );
         assert_eq!((w2 >> 5) & 0xFFFF, 0xCAFE, "chunk2 must be 0xCAFE");
 
         // Fourth instruction: MOVK X0, #0xDEAD, lsl 48 — base 0xF2E0_0000
         let w3 = u32::from_le_bytes([sec.data[12], sec.data[13], sec.data[14], sec.data[15]]);
-        assert_eq!(w3 & 0xFFE0_001F, 0xF2E0_0000,
-            "fourth word must be MOVK lsl 48 (0xF2E0_0000)");
+        assert_eq!(
+            w3 & 0xFFE0_001F,
+            0xF2E0_0000,
+            "fourth word must be MOVK lsl 48 (0xF2E0_0000)"
+        );
         assert_eq!((w3 >> 5) & 0xFFFF, 0xDEAD, "chunk3 must be 0xDEAD");
     }
 
@@ -623,7 +674,10 @@ mod tests {
         let mf = single_block_mf("mov_wide_32_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
-        assert_eq!(sec.data.len(), 8,
-            "MOV_WIDE 0x1_2345 must emit exactly 2 instructions (8 bytes)");
+        assert_eq!(
+            sec.data.len(),
+            8,
+            "MOV_WIDE 0x1_2345 must emit exactly 2 instructions (8 bytes)"
+        );
     }
 }

--- a/src/llvm-target-arm/src/instructions.rs
+++ b/src/llvm-target-arm/src/instructions.rs
@@ -5,96 +5,96 @@ use llvm_codegen::isel::MOpcode;
 // ── data movement ──────────────────────────────────────────────────────────
 
 /// `mov xd, xn` (implemented as `orr xd, xzr, xn`)
-pub const MOV_RR:   MOpcode = MOpcode(0x00);
+pub const MOV_RR: MOpcode = MOpcode(0x00);
 /// `movz xd, #imm16` (16-bit zero-extending immediate)
-pub const MOV_IMM:  MOpcode = MOpcode(0x01);
+pub const MOV_IMM: MOpcode = MOpcode(0x01);
 /// `movz xd, #lo16; movk xd, #hi16, lsl 16` (64-bit immediate via two instructions)
 pub const MOV_WIDE: MOpcode = MOpcode(0x02);
 /// Move VReg source into a fixed physical register destination.
 /// Layout: `operands[0]` = `PReg` (destination, ABI-fixed), `operands[1]` = `VReg`/`PReg` (source).
-pub const MOV_PR:   MOpcode = MOpcode(0x03);
+pub const MOV_PR: MOpcode = MOpcode(0x03);
 
 // ── integer arithmetic ─────────────────────────────────────────────────────
 
 /// `add xd, xn, xm`
-pub const ADD_RR:   MOpcode = MOpcode(0x10);
+pub const ADD_RR: MOpcode = MOpcode(0x10);
 /// `sub xd, xn, xm`
-pub const SUB_RR:   MOpcode = MOpcode(0x11);
+pub const SUB_RR: MOpcode = MOpcode(0x11);
 /// `mul xd, xn, xm` (= `madd xd, xn, xm, xzr`)
-pub const MUL_RR:   MOpcode = MOpcode(0x12);
+pub const MUL_RR: MOpcode = MOpcode(0x12);
 /// `sdiv xd, xn, xm` (signed division)
-pub const SDIV_RR:  MOpcode = MOpcode(0x13);
+pub const SDIV_RR: MOpcode = MOpcode(0x13);
 /// `udiv xd, xn, xm` (unsigned division)
-pub const UDIV_RR:  MOpcode = MOpcode(0x14);
+pub const UDIV_RR: MOpcode = MOpcode(0x14);
 /// `neg xd, xn` (= `sub xd, xzr, xn`)
-pub const NEG_R:    MOpcode = MOpcode(0x15);
+pub const NEG_R: MOpcode = MOpcode(0x15);
 
 // ── bitwise ────────────────────────────────────────────────────────────────
 
 /// `and xd, xn, xm`
-pub const AND_RR:   MOpcode = MOpcode(0x20);
+pub const AND_RR: MOpcode = MOpcode(0x20);
 /// `orr xd, xn, xm`
-pub const ORR_RR:   MOpcode = MOpcode(0x21);
+pub const ORR_RR: MOpcode = MOpcode(0x21);
 /// `eor xd, xn, xm`
-pub const EOR_RR:   MOpcode = MOpcode(0x22);
+pub const EOR_RR: MOpcode = MOpcode(0x22);
 /// `lslv xd, xn, xm` (logical shift left by register)
-pub const LSL_RR:   MOpcode = MOpcode(0x23);
+pub const LSL_RR: MOpcode = MOpcode(0x23);
 /// `lsrv xd, xn, xm` (logical shift right by register)
-pub const LSR_RR:   MOpcode = MOpcode(0x24);
+pub const LSR_RR: MOpcode = MOpcode(0x24);
 /// `asrv xd, xn, xm` (arithmetic shift right by register)
-pub const ASR_RR:   MOpcode = MOpcode(0x25);
+pub const ASR_RR: MOpcode = MOpcode(0x25);
 
 // ── comparisons ────────────────────────────────────────────────────────────
 
 /// `cmp xn, xm` (= `subs xzr, xn, xm` — sets flags, discards result)
-pub const CMP_RR:   MOpcode = MOpcode(0x30);
+pub const CMP_RR: MOpcode = MOpcode(0x30);
 /// `cset xd, cond` — condition code stored as `Imm(CC_*)` in first operand.
-pub const CSET:     MOpcode = MOpcode(0x31);
+pub const CSET: MOpcode = MOpcode(0x31);
 
 // ── control flow ───────────────────────────────────────────────────────────
 
 /// `b offset` — unconditional branch
-pub const B:        MOpcode = MOpcode(0x40);
+pub const B: MOpcode = MOpcode(0x40);
 /// `b.cond offset` — conditional branch; condition stored as `Imm(CC_*)`.
-pub const B_COND:   MOpcode = MOpcode(0x41);
+pub const B_COND: MOpcode = MOpcode(0x41);
 /// `bl offset` — branch and link (call)
-pub const BL:       MOpcode = MOpcode(0x42);
+pub const BL: MOpcode = MOpcode(0x42);
 /// `blr xn` — branch and link to register (indirect call)
-pub const BLR:      MOpcode = MOpcode(0x43);
+pub const BLR: MOpcode = MOpcode(0x43);
 /// `ret x30` — return via link register
-pub const RET:      MOpcode = MOpcode(0x44);
+pub const RET: MOpcode = MOpcode(0x44);
 
 // ── memory ─────────────────────────────────────────────────────────────────
 
 /// `ldr xd, [xn, #off]`
-pub const LDR:      MOpcode = MOpcode(0x50);
+pub const LDR: MOpcode = MOpcode(0x50);
 /// `str xs, [xn, #off]`
-pub const STR:      MOpcode = MOpcode(0x51);
+pub const STR: MOpcode = MOpcode(0x51);
 
 // ── sign-extension ─────────────────────────────────────────────────────────
 
 /// `sxtw xd, wn` (sign-extend 32-bit to 64-bit)
-pub const SXTW:     MOpcode = MOpcode(0x60);
+pub const SXTW: MOpcode = MOpcode(0x60);
 /// `sxtb xd, xn` (sign-extend 8-bit to 64-bit)
-pub const SXTB:     MOpcode = MOpcode(0x61);
+pub const SXTB: MOpcode = MOpcode(0x61);
 /// `sxth xd, xn` (sign-extend 16-bit to 64-bit)
-pub const SXTH:     MOpcode = MOpcode(0x62);
+pub const SXTH: MOpcode = MOpcode(0x62);
 
 // ── miscellaneous ──────────────────────────────────────────────────────────
 
 /// `nop`
-pub const NOP:      MOpcode = MOpcode(0x70);
+pub const NOP: MOpcode = MOpcode(0x70);
 
 // ── condition codes (used as Imm operands with B_COND / CSET) ────────────
 //
 // These map to AArch64 condition codes as defined in the ISA.
-pub const CC_EQ: i64 = 0;  // EQ — equal (Z=1)
-pub const CC_NE: i64 = 1;  // NE — not equal (Z=0)
-pub const CC_LT: i64 = 2;  // LT — signed less than
-pub const CC_LE: i64 = 3;  // LE — signed less than or equal
-pub const CC_GT: i64 = 4;  // GT — signed greater than
-pub const CC_GE: i64 = 5;  // GE — signed greater than or equal
-pub const CC_LO: i64 = 6;  // LO — unsigned lower (C=0)
-pub const CC_LS: i64 = 7;  // LS — unsigned lower or same (C=0 or Z=1)
-pub const CC_HI: i64 = 8;  // HI — unsigned higher (C=1 and Z=0)
-pub const CC_HS: i64 = 9;  // HS — unsigned higher or same (C=1)
+pub const CC_EQ: i64 = 0; // EQ — equal (Z=1)
+pub const CC_NE: i64 = 1; // NE — not equal (Z=0)
+pub const CC_LT: i64 = 2; // LT — signed less than
+pub const CC_LE: i64 = 3; // LE — signed less than or equal
+pub const CC_GT: i64 = 4; // GT — signed greater than
+pub const CC_GE: i64 = 5; // GE — signed greater than or equal
+pub const CC_LO: i64 = 6; // LO — unsigned lower (C=0)
+pub const CC_LS: i64 = 7; // LS — unsigned lower or same (C=0 or Z=1)
+pub const CC_HI: i64 = 8; // HI — unsigned higher (C=1 and Z=0)
+pub const CC_HS: i64 = 9; // HS — unsigned higher or same (C=1)

--- a/src/llvm-target-arm/src/lower.rs
+++ b/src/llvm-target-arm/src/lower.rs
@@ -4,17 +4,17 @@
 //! translated to one or more machine instructions using virtual registers.
 //! Phi-destruction (parallel copy insertion) is also handled here.
 
-use std::collections::HashMap;
-use llvm_codegen::isel::{IselBackend, MachineFunction, MInstr, PReg, VReg};
-use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind,
-    IntPredicate, Module, TypeData, ValueRef,
-};
 use crate::{
     abi::{classify_aapcs64_args, ArgLocation, INT_RET},
     instructions::*,
     regs::{ALLOCATABLE, CALLEE_SAVED},
 };
+use llvm_codegen::isel::{IselBackend, MInstr, MachineFunction, PReg, VReg};
+use llvm_ir::{
+    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
+    TypeData, ValueRef,
+};
+use std::collections::HashMap;
 
 /// AArch64 instruction-selection backend.
 pub struct AArch64Backend;
@@ -130,8 +130,8 @@ fn const_to_imm(cd: &ConstantData) -> i64 {
 
 fn pred_to_cc(pred: IntPredicate) -> i64 {
     match pred {
-        IntPredicate::Eq  => CC_EQ,
-        IntPredicate::Ne  => CC_NE,
+        IntPredicate::Eq => CC_EQ,
+        IntPredicate::Ne => CC_NE,
         IntPredicate::Slt => CC_LT,
         IntPredicate::Sle => CC_LE,
         IntPredicate::Sgt => CC_GT,
@@ -178,18 +178,31 @@ fn lower_instr(
             let dst = new_dst!();
             let l = res!($lhs);
             let r = res!($rhs);
-            mf.push(mblock, MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r));
+            mf.push(
+                mblock,
+                MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r),
+            );
         }};
     }
 
     match &instr.kind {
         // ── arithmetic ─────────────────────────────────────────────────────
         // AArch64 has 3-address instructions: dst = op(lhs, rhs)
-        Add { lhs, rhs, .. }  => { emit_binop3!(ADD_RR,  *lhs, *rhs); }
-        Sub { lhs, rhs, .. }  => { emit_binop3!(SUB_RR,  *lhs, *rhs); }
-        Mul { lhs, rhs, .. }  => { emit_binop3!(MUL_RR,  *lhs, *rhs); }
-        SDiv { lhs, rhs, .. } => { emit_binop3!(SDIV_RR, *lhs, *rhs); }
-        UDiv { lhs, rhs, .. } => { emit_binop3!(UDIV_RR, *lhs, *rhs); }
+        Add { lhs, rhs, .. } => {
+            emit_binop3!(ADD_RR, *lhs, *rhs);
+        }
+        Sub { lhs, rhs, .. } => {
+            emit_binop3!(SUB_RR, *lhs, *rhs);
+        }
+        Mul { lhs, rhs, .. } => {
+            emit_binop3!(MUL_RR, *lhs, *rhs);
+        }
+        SDiv { lhs, rhs, .. } => {
+            emit_binop3!(SDIV_RR, *lhs, *rhs);
+        }
+        UDiv { lhs, rhs, .. } => {
+            emit_binop3!(UDIV_RR, *lhs, *rhs);
+        }
 
         SRem { lhs, rhs, .. } => {
             // AArch64 has no SREM instruction.
@@ -198,10 +211,28 @@ fn lower_instr(
             let l = res!(*lhs);
             let r = res!(*rhs);
             let quot = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(SDIV_RR).with_dst(quot).with_vreg(l).with_vreg(r));
+            mf.push(
+                mblock,
+                MInstr::new(SDIV_RR)
+                    .with_dst(quot)
+                    .with_vreg(l)
+                    .with_vreg(r),
+            );
             let prod = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(MUL_RR).with_dst(prod).with_vreg(quot).with_vreg(r));
-            mf.push(mblock, MInstr::new(SUB_RR).with_dst(dst).with_vreg(l).with_vreg(prod));
+            mf.push(
+                mblock,
+                MInstr::new(MUL_RR)
+                    .with_dst(prod)
+                    .with_vreg(quot)
+                    .with_vreg(r),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(SUB_RR)
+                    .with_dst(dst)
+                    .with_vreg(l)
+                    .with_vreg(prod),
+            );
         }
 
         URem { lhs, rhs, .. } => {
@@ -211,22 +242,52 @@ fn lower_instr(
             let l = res!(*lhs);
             let r = res!(*rhs);
             let quot = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(UDIV_RR).with_dst(quot).with_vreg(l).with_vreg(r));
+            mf.push(
+                mblock,
+                MInstr::new(UDIV_RR)
+                    .with_dst(quot)
+                    .with_vreg(l)
+                    .with_vreg(r),
+            );
             let prod = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(MUL_RR).with_dst(prod).with_vreg(quot).with_vreg(r));
-            mf.push(mblock, MInstr::new(SUB_RR).with_dst(dst).with_vreg(l).with_vreg(prod));
+            mf.push(
+                mblock,
+                MInstr::new(MUL_RR)
+                    .with_dst(prod)
+                    .with_vreg(quot)
+                    .with_vreg(r),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(SUB_RR)
+                    .with_dst(dst)
+                    .with_vreg(l)
+                    .with_vreg(prod),
+            );
         }
 
         // ── bitwise ────────────────────────────────────────────────────────
-        And { lhs, rhs }      => { emit_binop3!(AND_RR, *lhs, *rhs); }
-        Or  { lhs, rhs }      => { emit_binop3!(ORR_RR, *lhs, *rhs); }
-        Xor { lhs, rhs }      => { emit_binop3!(EOR_RR, *lhs, *rhs); }
+        And { lhs, rhs } => {
+            emit_binop3!(AND_RR, *lhs, *rhs);
+        }
+        Or { lhs, rhs } => {
+            emit_binop3!(ORR_RR, *lhs, *rhs);
+        }
+        Xor { lhs, rhs } => {
+            emit_binop3!(EOR_RR, *lhs, *rhs);
+        }
 
         // ── shifts ─────────────────────────────────────────────────────────
         // AArch64 shift-by-register instructions (LSLV/LSRV/ASRV) are 3-address.
-        Shl  { lhs, rhs, .. } => { emit_binop3!(LSL_RR, *lhs, *rhs); }
-        LShr { lhs, rhs, .. } => { emit_binop3!(LSR_RR, *lhs, *rhs); }
-        AShr { lhs, rhs, .. } => { emit_binop3!(ASR_RR, *lhs, *rhs); }
+        Shl { lhs, rhs, .. } => {
+            emit_binop3!(LSL_RR, *lhs, *rhs);
+        }
+        LShr { lhs, rhs, .. } => {
+            emit_binop3!(LSR_RR, *lhs, *rhs);
+        }
+        AShr { lhs, rhs, .. } => {
+            emit_binop3!(ASR_RR, *lhs, *rhs);
+        }
 
         // ── comparisons ────────────────────────────────────────────────────
         ICmp { pred, lhs, rhs } => {
@@ -245,9 +306,13 @@ fn lower_instr(
         }
 
         // ── select ─────────────────────────────────────────────────────────
-        Select { cond, then_val, else_val } => {
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             let dst = new_dst!();
-            let c  = res!(*cond);
+            let c = res!(*cond);
             let tv = res!(*then_val);
             let fv = res!(*else_val);
             // Compare condition to zero, then conditionally select.
@@ -259,7 +324,10 @@ fn lower_instr(
             let scratch = mf.fresh_vreg();
             mf.push(mblock, MInstr::new(CSET).with_dst(scratch).with_imm(CC_NE));
             // neg scratch: scratch = 0 → 0, 1 → -1 (all ones).
-            mf.push(mblock, MInstr::new(NEG_R).with_dst(scratch).with_vreg(scratch));
+            mf.push(
+                mblock,
+                MInstr::new(NEG_R).with_dst(scratch).with_vreg(scratch),
+            );
             // dst = (tv & scratch) | (fv & ~scratch)
             // We don't have NOT, so use: fv & (neg scratch ^ -1) = fv xor scratch... too complex.
             // Simple fallback: dst = fv; if cond != 0 => dst = tv.
@@ -275,10 +343,34 @@ fn lower_instr(
             // MOV_IMM (MOVZ) only loads a 16-bit zero-extended immediate and
             // would produce 0xFFFF instead of all-ones.
             mf.push(mblock, MInstr::new(MOV_WIDE).with_dst(allones).with_imm(-1));
-            mf.push(mblock, MInstr::new(EOR_RR).with_dst(notmask).with_vreg(scratch).with_vreg(allones));
-            mf.push(mblock, MInstr::new(AND_RR).with_dst(tmp1).with_vreg(fv).with_vreg(notmask));
-            mf.push(mblock, MInstr::new(AND_RR).with_dst(tmp2).with_vreg(tv).with_vreg(scratch));
-            mf.push(mblock, MInstr::new(ORR_RR).with_dst(dst).with_vreg(tmp1).with_vreg(tmp2));
+            mf.push(
+                mblock,
+                MInstr::new(EOR_RR)
+                    .with_dst(notmask)
+                    .with_vreg(scratch)
+                    .with_vreg(allones),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(AND_RR)
+                    .with_dst(tmp1)
+                    .with_vreg(fv)
+                    .with_vreg(notmask),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(AND_RR)
+                    .with_dst(tmp2)
+                    .with_vreg(tv)
+                    .with_vreg(scratch),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(ORR_RR)
+                    .with_dst(dst)
+                    .with_vreg(tmp1)
+                    .with_vreg(tmp2),
+            );
         }
 
         // ── phi ────────────────────────────────────────────────────────────
@@ -288,11 +380,17 @@ fn lower_instr(
         }
 
         // ── casts ──────────────────────────────────────────────────────────
-        ZExt { val, .. } | Trunc { val, .. } | BitCast { val, .. }
-        | PtrToInt { val, .. } | IntToPtr { val, .. }
-        | FPTrunc { val, .. } | FPExt { val, .. }
-        | FPToUI { val, .. } | FPToSI { val, .. }
-        | UIToFP { val, .. } | SIToFP { val, .. }
+        ZExt { val, .. }
+        | Trunc { val, .. }
+        | BitCast { val, .. }
+        | PtrToInt { val, .. }
+        | IntToPtr { val, .. }
+        | FPTrunc { val, .. }
+        | FPExt { val, .. }
+        | FPToUI { val, .. }
+        | FPToSI { val, .. }
+        | UIToFP { val, .. }
+        | SIToFP { val, .. }
         | AddrSpaceCast { val, .. } => {
             let dst = new_dst!();
             let src = res!(*val);
@@ -303,7 +401,8 @@ fn lower_instr(
             let dst = new_dst!();
             let src = res!(*val);
             // Select the correct sign-extension opcode based on source bit width.
-            let src_bits = func.type_of_value(*val)
+            let src_bits = func
+                .type_of_value(*val)
                 .map(|tid| match ctx.get_type(tid) {
                     TypeData::Integer(bits) => *bits,
                     _ => 32,
@@ -363,8 +462,11 @@ fn lower_instr(
         }
 
         // ── aggregate / vector ops (not yet supported) ─────────────────────
-        ExtractValue { .. } | InsertValue { .. } | ExtractElement { .. }
-        | InsertElement { .. } | ShuffleVector { .. } => {
+        ExtractValue { .. }
+        | InsertValue { .. }
+        | ExtractElement { .. }
+        | InsertElement { .. }
+        | ShuffleVector { .. } => {
             let dst = new_dst!();
             mf.push(mblock, MInstr::new(MOV_IMM).with_dst(dst).with_imm(0));
         }
@@ -401,7 +503,11 @@ fn lower_terminator(
             mf.push(mblock, MInstr::new(B).with_block(dest.0 as usize));
         }
 
-        CondBr { cond, then_dest, else_dest } => {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => {
             let c = resolve(ctx, mf, mblock, vmap, *cond);
             // Each successor edge gets its own trampoline block so that phi
             // copies for one edge cannot overwrite values needed by the other.
@@ -416,17 +522,29 @@ fn lower_terminator(
             let zv = mf.fresh_vreg();
             mf.push(mblock, MInstr::new(MOV_IMM).with_dst(zv).with_imm(0));
             mf.push(mblock, MInstr::new(CMP_RR).with_vreg(c).with_vreg(zv));
-            mf.push(mblock, MInstr::new(B_COND).with_imm(CC_NE).with_block(then_edge));
+            mf.push(
+                mblock,
+                MInstr::new(B_COND).with_imm(CC_NE).with_block(then_edge),
+            );
             mf.push(mblock, MInstr::new(B).with_block(else_edge));
         }
 
-        Switch { val, default, cases } => {
+        Switch {
+            val,
+            default,
+            cases,
+        } => {
             let v = resolve(ctx, mf, mblock, vmap, *val);
             for (case_val, case_dest) in cases {
                 let cv = resolve(ctx, mf, mblock, vmap, *case_val);
                 emit_phi_copies(ctx, func, mf, mblock, mblock, *case_dest, vmap);
                 mf.push(mblock, MInstr::new(CMP_RR).with_vreg(v).with_vreg(cv));
-                mf.push(mblock, MInstr::new(B_COND).with_imm(CC_EQ).with_block(case_dest.0 as usize));
+                mf.push(
+                    mblock,
+                    MInstr::new(B_COND)
+                        .with_imm(CC_EQ)
+                        .with_block(case_dest.0 as usize),
+                );
             }
             emit_phi_copies(ctx, func, mf, mblock, mblock, *default, vmap);
             mf.push(mblock, MInstr::new(B).with_block(default.0 as usize));
@@ -470,9 +588,10 @@ fn emit_phi_copies(
                     None => continue,
                 };
                 let src_vreg = resolve(ctx, mf, emit_to_mblock, vmap, *incoming_val);
-                mf.push(emit_to_mblock, MInstr::new(MOV_RR)
-                    .with_dst(phi_vreg)
-                    .with_vreg(src_vreg));
+                mf.push(
+                    emit_to_mblock,
+                    MInstr::new(MOV_RR).with_dst(phi_vreg).with_vreg(src_vreg),
+                );
             }
         }
     }
@@ -570,9 +689,15 @@ mod tests {
         let (ctx, module) = make_div_fn(true);
         let mut be = AArch64Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_udiv = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == UDIV_RR));
-        let has_sdiv = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == SDIV_RR));
-        assert!(has_udiv,  "UDiv must emit UDIV_RR (unsigned div)");
+        let has_udiv = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == UDIV_RR));
+        let has_sdiv = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == SDIV_RR));
+        assert!(has_udiv, "UDiv must emit UDIV_RR (unsigned div)");
         assert!(!has_sdiv, "UDiv must NOT emit SDIV_RR (signed div)");
     }
 
@@ -581,8 +706,14 @@ mod tests {
         let (ctx, module) = make_div_fn(false);
         let mut be = AArch64Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_sdiv = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == SDIV_RR));
-        let has_udiv = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == UDIV_RR));
+        let has_sdiv = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == SDIV_RR));
+        let has_udiv = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == UDIV_RR));
         assert!(has_sdiv, "SDiv must emit SDIV_RR (signed div)");
         assert!(!has_udiv, "SDiv must NOT emit UDIV_RR (unsigned div)");
     }
@@ -613,9 +744,10 @@ mod tests {
         let (ctx, module) = make_sext_fn(8);
         let mut be = AArch64Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_sxtb = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == SXTB)
-        });
+        let has_sxtb = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == SXTB));
         assert!(has_sxtb, "sext from i8 must use SXTB");
     }
 
@@ -624,9 +756,10 @@ mod tests {
         let (ctx, module) = make_sext_fn(32);
         let mut be = AArch64Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_sxtw = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == SXTW)
-        });
+        let has_sxtw = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == SXTW));
         assert!(has_sxtw, "sext from i32 must use SXTW");
     }
 
@@ -643,14 +776,14 @@ mod tests {
             false,
             Linkage::External,
         );
-        let entry    = b.add_block("entry");
-        let then_bb  = b.add_block("then_bb");
-        let else_bb  = b.add_block("else_bb");
+        let entry = b.add_block("entry");
+        let then_bb = b.add_block("then_bb");
+        let else_bb = b.add_block("else_bb");
         let merge_bb = b.add_block("merge");
 
         b.position_at_end(entry);
-        let a    = b.get_arg(0);
-        let bv   = b.get_arg(1);
+        let a = b.get_arg(0);
+        let bv = b.get_arg(1);
         let cond = b.get_arg(2);
         b.build_cond_br(cond, then_bb, else_bb);
 
@@ -683,7 +816,8 @@ mod tests {
             mf.blocks.len() > ir_block_count,
             "CondBr must create trampoline edge blocks for phi copies; \
              expected > {} machine blocks, got {}",
-            ir_block_count, mf.blocks.len()
+            ir_block_count,
+            mf.blocks.len()
         );
     }
 
@@ -706,9 +840,9 @@ mod tests {
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let cond = b.get_arg(0);
-        let tv   = b.get_arg(1);
-        let fv   = b.get_arg(2);
-        let sel  = b.build_select("sel", cond, tv, fv);
+        let tv = b.get_arg(1);
+        let fv = b.get_arg(2);
+        let sel = b.build_select("sel", cond, tv, fv);
         b.build_ret(sel);
 
         let mut be = AArch64Backend;
@@ -716,12 +850,15 @@ mod tests {
 
         // The Select lowering must emit at least one MOV_WIDE instruction
         // (for the all-ones mask used as ~scratch).
-        let has_mov_wide = mf.blocks.iter().any(|bl| {
-            bl.instrs.iter().any(|i| i.opcode == MOV_WIDE)
-        });
-        assert!(has_mov_wide,
+        let has_mov_wide = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == MOV_WIDE));
+        assert!(
+            has_mov_wide,
             "Select lowering must use MOV_WIDE to materialise the all-ones mask, \
-             not MOV_IMM which only loads 16 bits");
+             not MOV_IMM which only loads 16 bits"
+        );
     }
 
     #[test]
@@ -752,20 +889,27 @@ mod tests {
         // There must be at least one instruction that has a dst VReg that
         // is different from all VRegs used only as sources — a proxy for
         // "the load result is defined somewhere".
-        let total_dsts: usize = mf.blocks.iter()
+        let total_dsts: usize = mf
+            .blocks
+            .iter()
             .flat_map(|bl| bl.instrs.iter())
             .filter(|i| i.dst.is_some())
             .count();
-        assert!(total_dsts > 0,
-            "Load lowering must emit an instruction with a non-None dst VReg");
+        assert!(
+            total_dsts > 0,
+            "Load lowering must emit an instruction with a non-None dst VReg"
+        );
 
         // Confirm no NOP appears as the sole instruction for the load
         // (NOP has no dst, so it cannot define the result VReg).
-        let only_nops = mf.blocks.iter().all(|bl| {
-            bl.instrs.iter().all(|i| i.opcode == NOP)
-        });
-        assert!(!only_nops,
-            "Load lowering must not produce only NOPs — the result must be defined");
+        let only_nops = mf
+            .blocks
+            .iter()
+            .all(|bl| bl.instrs.iter().all(|i| i.opcode == NOP));
+        assert!(
+            !only_nops,
+            "Load lowering must not produce only NOPs — the result must be defined"
+        );
     }
 
     #[test]
@@ -796,6 +940,9 @@ mod tests {
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
         // The function body should compile without panicking.
-        assert!(!mf.blocks.is_empty(), "store function must produce at least one block");
+        assert!(
+            !mf.blocks.is_empty(),
+            "store function must produce at least one block"
+        );
     }
 }

--- a/src/llvm-target-arm/src/regs.rs
+++ b/src/llvm-target-arm/src/regs.rs
@@ -8,25 +8,25 @@ use llvm_codegen::isel::PReg;
 // X31 is context-dependent: XZR (zero register) in most instructions,
 // SP (stack pointer) in load/store addressing.
 
-pub const X0:  PReg = PReg(0);
-pub const X1:  PReg = PReg(1);
-pub const X2:  PReg = PReg(2);
-pub const X3:  PReg = PReg(3);
-pub const X4:  PReg = PReg(4);
-pub const X5:  PReg = PReg(5);
-pub const X6:  PReg = PReg(6);
-pub const X7:  PReg = PReg(7);
-pub const X8:  PReg = PReg(8);
-pub const X9:  PReg = PReg(9);
+pub const X0: PReg = PReg(0);
+pub const X1: PReg = PReg(1);
+pub const X2: PReg = PReg(2);
+pub const X3: PReg = PReg(3);
+pub const X4: PReg = PReg(4);
+pub const X5: PReg = PReg(5);
+pub const X6: PReg = PReg(6);
+pub const X7: PReg = PReg(7);
+pub const X8: PReg = PReg(8);
+pub const X9: PReg = PReg(9);
 pub const X10: PReg = PReg(10);
 pub const X11: PReg = PReg(11);
 pub const X12: PReg = PReg(12);
 pub const X13: PReg = PReg(13);
 pub const X14: PReg = PReg(14);
 pub const X15: PReg = PReg(15);
-pub const X16: PReg = PReg(16);  // IP0 (intra-procedure-call scratch)
-pub const X17: PReg = PReg(17);  // IP1
-pub const X18: PReg = PReg(18);  // platform register (reserved on some ABIs)
+pub const X16: PReg = PReg(16); // IP0 (intra-procedure-call scratch)
+pub const X17: PReg = PReg(17); // IP1
+pub const X18: PReg = PReg(18); // platform register (reserved on some ABIs)
 pub const X19: PReg = PReg(19);
 pub const X20: PReg = PReg(20);
 pub const X21: PReg = PReg(21);
@@ -37,17 +37,16 @@ pub const X25: PReg = PReg(25);
 pub const X26: PReg = PReg(26);
 pub const X27: PReg = PReg(27);
 pub const X28: PReg = PReg(28);
-pub const X29: PReg = PReg(29);  // frame pointer
-pub const X30: PReg = PReg(30);  // link register
-pub const XZR: PReg = PReg(31);  // zero register (read: 0, write: discard)
+pub const X29: PReg = PReg(29); // frame pointer
+pub const X30: PReg = PReg(30); // link register
+pub const XZR: PReg = PReg(31); // zero register (read: 0, write: discard)
 
 /// Registers available for the register allocator.
 /// Caller-saved (X0–X18) minus X18 (platform reserved), plus a subset of
 /// callee-saved. We expose X0–X15 as the primary allocation pool.
 pub const ALLOCATABLE: &[PReg] = &[
-    X0, X1, X2, X3, X4, X5, X6, X7,
-    X8, X9, X10, X11, X12, X13, X14, X15,
-    X19, X20, X21, X22, X23, X24, X25, X26, X27, X28,
+    X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X14, X15, X19, X20, X21, X22, X23,
+    X24, X25, X26, X27, X28,
 ];
 
 /// Registers that must be preserved across calls (AAPCS64).
@@ -60,24 +59,52 @@ pub const ARG_REGS: &[PReg] = &[X0, X1, X2, X3, X4, X5, X6, X7];
 pub const RET_REG: PReg = X0;
 
 /// 5-bit register encoding (low 5 bits; always 0–31 for AArch64).
-pub fn reg_enc(r: PReg) -> u8 { r.0 & 0x1F }
+pub fn reg_enc(r: PReg) -> u8 {
+    r.0 & 0x1F
+}
 
 /// Whether a register is in the "upper" range (X16+).  Some instruction
 /// variants or compact encodings have restrictions on these.
-pub fn is_extended(r: PReg) -> bool { r.0 >= 16 }
+pub fn is_extended(r: PReg) -> bool {
+    r.0 >= 16
+}
 
 /// Human-readable register name.
 pub fn reg_name(r: PReg) -> &'static str {
     match r.0 {
-        0  => "x0",  1  => "x1",  2  => "x2",  3  => "x3",
-        4  => "x4",  5  => "x5",  6  => "x6",  7  => "x7",
-        8  => "x8",  9  => "x9",  10 => "x10", 11 => "x11",
-        12 => "x12", 13 => "x13", 14 => "x14", 15 => "x15",
-        16 => "x16", 17 => "x17", 18 => "x18", 19 => "x19",
-        20 => "x20", 21 => "x21", 22 => "x22", 23 => "x23",
-        24 => "x24", 25 => "x25", 26 => "x26", 27 => "x27",
-        28 => "x28", 29 => "x29", 30 => "x30", 31 => "xzr",
-        _  => "??",
+        0 => "x0",
+        1 => "x1",
+        2 => "x2",
+        3 => "x3",
+        4 => "x4",
+        5 => "x5",
+        6 => "x6",
+        7 => "x7",
+        8 => "x8",
+        9 => "x9",
+        10 => "x10",
+        11 => "x11",
+        12 => "x12",
+        13 => "x13",
+        14 => "x14",
+        15 => "x15",
+        16 => "x16",
+        17 => "x17",
+        18 => "x18",
+        19 => "x19",
+        20 => "x20",
+        21 => "x21",
+        22 => "x22",
+        23 => "x23",
+        24 => "x24",
+        25 => "x25",
+        26 => "x26",
+        27 => "x27",
+        28 => "x28",
+        29 => "x29",
+        30 => "x30",
+        31 => "xzr",
+        _ => "??",
     }
 }
 
@@ -104,8 +131,8 @@ mod tests {
 
     #[test]
     fn reg_enc_low5_bits() {
-        assert_eq!(reg_enc(X0),  0);
-        assert_eq!(reg_enc(X7),  7);
+        assert_eq!(reg_enc(X0), 0);
+        assert_eq!(reg_enc(X7), 7);
         assert_eq!(reg_enc(XZR), 31);
         assert_eq!(reg_enc(XZR), 31);
     }
@@ -114,8 +141,16 @@ mod tests {
     fn allocatable_and_callee_saved_overlap_correctly() {
         // X19-X28 must appear in BOTH ALLOCATABLE and CALLEE_SAVED.
         for r in &[X19, X20, X21, X22, X23, X24, X25, X26, X27, X28] {
-            assert!(ALLOCATABLE.contains(r), "{} missing from ALLOCATABLE", reg_name(*r));
-            assert!(CALLEE_SAVED.contains(r), "{} missing from CALLEE_SAVED", reg_name(*r));
+            assert!(
+                ALLOCATABLE.contains(r),
+                "{} missing from ALLOCATABLE",
+                reg_name(*r)
+            );
+            assert!(
+                CALLEE_SAVED.contains(r),
+                "{} missing from CALLEE_SAVED",
+                reg_name(*r)
+            );
         }
     }
 }

--- a/src/llvm-target-x86/src/abi.rs
+++ b/src/llvm-target-x86/src/abi.rs
@@ -1,7 +1,7 @@
 //! x86_64 calling-convention support (System V AMD64 and Windows x64).
 
+use crate::regs::{R8, R9, RAX, RCX, RDI, RDX, RSI};
 use llvm_codegen::isel::PReg;
-use crate::regs::{RAX, RCX, RDX, RSI, RDI, R8, R9};
 
 // ── System V AMD64 ABI ─────────────────────────────────────────────────────
 
@@ -66,7 +66,7 @@ pub fn classify_win64_args(n_args: usize) -> Vec<ArgLocation> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::regs::{RDI, RSI, RDX, RCX, R8, R9};
+    use crate::regs::{R8, R9, RCX, RDI, RDX, RSI};
 
     #[test]
     fn sysv_first_six_in_registers() {

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -8,15 +8,15 @@
 //! opcodes fall through to a single `NOP` (`0x90`) so the output is always
 //! syntactically valid machine code.
 
-use std::collections::HashMap;
-use llvm_codegen::{
-    emit::{Emitter, ObjectFormat, Reloc, Section},
-    isel::{MachineFunction, MInstr, MOperand, PReg},
-};
 use crate::{
     instructions::*,
     regs::{is_extended, reg_enc},
 };
+use llvm_codegen::{
+    emit::{Emitter, ObjectFormat, Reloc, Section},
+    isel::{MInstr, MOperand, MachineFunction, PReg},
+};
+use std::collections::HashMap;
 
 /// x86_64 code emitter.
 pub struct X86Emitter {
@@ -52,7 +52,7 @@ impl Emitter for X86Emitter {
         }
 
         let section_name = match self.format {
-            ObjectFormat::Elf   => ".text",
+            ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
         };
 
@@ -80,10 +80,18 @@ struct EncodeCtx {
 }
 
 impl EncodeCtx {
-    fn emit(&mut self, b: u8) { self.code.push(b); }
-    fn emit32(&mut self, v: i32) { self.code.extend_from_slice(&v.to_le_bytes()); }
-    fn emit64(&mut self, v: i64) { self.code.extend_from_slice(&v.to_le_bytes()); }
-    fn pos(&self) -> usize { self.code.len() }
+    fn emit(&mut self, b: u8) {
+        self.code.push(b);
+    }
+    fn emit32(&mut self, v: i32) {
+        self.code.extend_from_slice(&v.to_le_bytes());
+    }
+    fn emit64(&mut self, v: i64) {
+        self.code.extend_from_slice(&v.to_le_bytes());
+    }
+    fn pos(&self) -> usize {
+        self.code.len()
+    }
 }
 
 // ── REX prefix helpers ───────────────────────────────────────────────────
@@ -93,10 +101,11 @@ fn maybe_rex(ctx: &mut EncodeCtx, w: bool, r: PReg, rm: PReg) {
     let r_ext = is_extended(r);
     let b_ext = is_extended(rm);
     if w || r_ext || b_ext {
-        ctx.emit(0x40
-            | (if w     { 0x08 } else { 0 })
-            | (if r_ext { 0x04 } else { 0 })
-            | (if b_ext { 0x01 } else { 0 }));
+        ctx.emit(
+            0x40 | (if w { 0x08 } else { 0 })
+                | (if r_ext { 0x04 } else { 0 })
+                | (if b_ext { 0x01 } else { 0 }),
+        );
     }
 }
 
@@ -110,15 +119,23 @@ fn modrm_rr(r: PReg, rm: PReg) -> u8 {
 fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
     // Helper to extract PReg from operand.
     let preg = |op: &MOperand| -> Option<PReg> {
-        match op { MOperand::PReg(r) => Some(*r), _ => None }
+        match op {
+            MOperand::PReg(r) => Some(*r),
+            _ => None,
+        }
     };
     let imm = |op: &MOperand| -> Option<i64> {
-        match op { MOperand::Imm(v) => Some(*v), _ => None }
+        match op {
+            MOperand::Imm(v) => Some(*v),
+            _ => None,
+        }
     };
 
     match instr.opcode {
         // ── NOP ────────────────────────────────────────────────────────────
-        NOP => { ctx.emit(0x90); }
+        NOP => {
+            ctx.emit(0x90);
+        }
 
         // ── MOV reg, reg (REX.W 0x89 /r) ─────────────────────────────────
         MOV_RR => {
@@ -224,13 +241,19 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         }
 
         // ── AND reg, reg (REX.W 0x21 /r) ─────────────────────────────────
-        AND_RR => { encode_rrr(ctx, instr, 0x21); }
+        AND_RR => {
+            encode_rrr(ctx, instr, 0x21);
+        }
 
         // ── OR reg, reg (REX.W 0x09 /r) ──────────────────────────────────
-        OR_RR  => { encode_rrr(ctx, instr, 0x09); }
+        OR_RR => {
+            encode_rrr(ctx, instr, 0x09);
+        }
 
         // ── XOR reg, reg (REX.W 0x31 /r) ─────────────────────────────────
-        XOR_RR => { encode_rrr(ctx, instr, 0x31); }
+        XOR_RR => {
+            encode_rrr(ctx, instr, 0x31);
+        }
 
         // ── NOT reg (REX.W 0xF7 /2) ──────────────────────────────────────
         NOT_R => {
@@ -245,13 +268,19 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         }
 
         // ── SHL reg, CL (REX.W 0xD3 /4) ─────────────────────────────────
-        SHL_RR => { encode_shift_cl(ctx, instr, 4); }
+        SHL_RR => {
+            encode_shift_cl(ctx, instr, 4);
+        }
 
         // ── SHR reg, CL (REX.W 0xD3 /5) ─────────────────────────────────
-        SHR_RR => { encode_shift_cl(ctx, instr, 5); }
+        SHR_RR => {
+            encode_shift_cl(ctx, instr, 5);
+        }
 
         // ── SAR reg, CL (REX.W 0xD3 /7) ─────────────────────────────────
-        SAR_RR => { encode_shift_cl(ctx, instr, 7); }
+        SAR_RR => {
+            encode_shift_cl(ctx, instr, 7);
+        }
 
         // ── CMP reg, reg (REX.W 0x39 /r) ─────────────────────────────────
         CMP_RR => {
@@ -293,7 +322,8 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
                 ctx.emit(0xC0 | reg_enc(r));
                 // Zero-extend the 8-bit result to 64 bits via MOVZX r64, r8.
                 maybe_rex(ctx, true, r, r);
-                ctx.emit(0x0F); ctx.emit(0xB6);
+                ctx.emit(0x0F);
+                ctx.emit(0xB6);
                 ctx.emit(modrm_rr(r, r));
             } else {
                 ctx.emit(0x90);
@@ -314,18 +344,14 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
 
         // ── JCC rel32 (0x0F 0x8x rel32) ──────────────────────────────────
         JCC => {
-            if let (Some(cc_op), Some(MOperand::Block(target))) =
+            if let (Some(MOperand::Imm(cc)), Some(MOperand::Block(target))) =
                 (instr.operands.first(), instr.operands.get(1))
             {
-                if let MOperand::Imm(cc) = cc_op {
-                    ctx.emit(0x0F);
-                    ctx.emit(jcc_opcode(*cc));
-                    let patch_pos = ctx.pos();
-                    ctx.emit32(0);
-                    ctx.branch_patches.push((patch_pos, *target));
-                } else {
-                    ctx.emit(0x90);
-                }
+                ctx.emit(0x0F);
+                ctx.emit(jcc_opcode(*cc));
+                let patch_pos = ctx.pos();
+                ctx.emit32(0);
+                ctx.branch_patches.push((patch_pos, *target));
             } else {
                 ctx.emit(0x90);
             }
@@ -337,7 +363,9 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
                 MOperand::PReg(r) => Some(*r),
                 _ => None,
             }) {
-                if is_extended(src) { ctx.emit(0x41); }
+                if is_extended(src) {
+                    ctx.emit(0x41);
+                }
                 ctx.emit(0xFF);
                 ctx.emit(0xC0 | (2 << 3) | reg_enc(src));
             } else {
@@ -346,12 +374,16 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         }
 
         // ── RET (0xC3) ────────────────────────────────────────────────────
-        RET => { ctx.emit(0xC3); }
+        RET => {
+            ctx.emit(0xC3);
+        }
 
         // ── PUSH reg (REX? 0x50+rd) ───────────────────────────────────────
         PUSH_R => {
             if let Some(src) = instr.operands.first().and_then(preg) {
-                if is_extended(src) { ctx.emit(0x41); }
+                if is_extended(src) {
+                    ctx.emit(0x41);
+                }
                 ctx.emit(0x50 | reg_enc(src));
             } else {
                 ctx.emit(0x90);
@@ -362,7 +394,9 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         POP_R => {
             if let Some(dst) = instr.dst {
                 let r = PReg(dst.0 as u8);
-                if is_extended(r) { ctx.emit(0x41); }
+                if is_extended(r) {
+                    ctx.emit(0x41);
+                }
                 ctx.emit(0x58 | reg_enc(r));
             } else {
                 ctx.emit(0x90);
@@ -418,7 +452,9 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         }
 
         // ── unsupported: emit NOP ─────────────────────────────────────────
-        _ => { ctx.emit(0x90); }
+        _ => {
+            ctx.emit(0x90);
+        }
     }
 }
 
@@ -453,7 +489,11 @@ fn encode_shift_cl(ctx: &mut EncodeCtx, instr: &MInstr, ext: u8) {
 fn get_dst_src(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
     let dst = instr.dst.map(|v| PReg(v.0 as u8));
     let src = instr.operands.iter().find_map(|op| {
-        if let MOperand::PReg(r) = op { Some(*r) } else { None }
+        if let MOperand::PReg(r) = op {
+            Some(*r)
+        } else {
+            None
+        }
     });
     (dst, src)
 }
@@ -461,7 +501,11 @@ fn get_dst_src(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
 /// Extract two PReg operands from `instr.operands`.
 fn get_two_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
     let mut it = instr.operands.iter().filter_map(|op| {
-        if let MOperand::PReg(r) = op { Some(*r) } else { None }
+        if let MOperand::PReg(r) = op {
+            Some(*r)
+        } else {
+            None
+        }
     });
     (it.next(), it.next())
 }
@@ -469,34 +513,34 @@ fn get_two_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
 /// Map a CC_* constant to the SETcc opcode byte (second byte of 0x0F 0x9x).
 fn setcc_opcode(cc: i64) -> u8 {
     match cc {
-        CC_EQ  => 0x94, // SETE
-        CC_NE  => 0x95, // SETNE
-        CC_LT  => 0x9C, // SETL
-        CC_LE  => 0x9E, // SETLE
-        CC_GT  => 0x9F, // SETG
-        CC_GE  => 0x9D, // SETGE
+        CC_EQ => 0x94,  // SETE
+        CC_NE => 0x95,  // SETNE
+        CC_LT => 0x9C,  // SETL
+        CC_LE => 0x9E,  // SETLE
+        CC_GT => 0x9F,  // SETG
+        CC_GE => 0x9D,  // SETGE
         CC_ULT => 0x92, // SETB
         CC_ULE => 0x96, // SETBE
         CC_UGT => 0x97, // SETA
         CC_UGE => 0x93, // SETAE
-        _      => 0x94,
+        _ => 0x94,
     }
 }
 
 /// Map a CC_* constant to the Jcc opcode byte (second byte of 0x0F 0x8x).
 fn jcc_opcode(cc: i64) -> u8 {
     match cc {
-        CC_EQ  => 0x84, // JE
-        CC_NE  => 0x85, // JNE
-        CC_LT  => 0x8C, // JL
-        CC_LE  => 0x8E, // JLE
-        CC_GT  => 0x8F, // JG
-        CC_GE  => 0x8D, // JGE
+        CC_EQ => 0x84,  // JE
+        CC_NE => 0x85,  // JNE
+        CC_LT => 0x8C,  // JL
+        CC_LE => 0x8E,  // JLE
+        CC_GT => 0x8F,  // JG
+        CC_GE => 0x8D,  // JGE
         CC_ULT => 0x82, // JB
         CC_ULE => 0x86, // JBE
         CC_UGT => 0x87, // JA
         CC_UGE => 0x83, // JAE
-        _      => 0x84,
+        _ => 0x84,
     }
 }
 
@@ -505,16 +549,18 @@ fn jcc_opcode(cc: i64) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::regs::{RAX, RDI, RSI};
     use llvm_codegen::{
         emit::emit_object,
-        isel::{MachineFunction, MInstr, VReg},
+        isel::{MInstr, MachineFunction, VReg},
     };
-    use crate::regs::{RAX, RDI, RSI};
 
     fn single_block_mf(name: &str, instrs: Vec<MInstr>) -> MachineFunction {
         let mut mf = MachineFunction::new(name.into());
         let b = mf.add_block("entry");
-        for i in instrs { mf.push(b, i); }
+        for i in instrs {
+            mf.push(b, i);
+        }
         mf
     }
 
@@ -583,7 +629,10 @@ mod tests {
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // First 4 bytes: bare REX(0x40), 0x0F, SETE(0x94), ModRM(0xC6 = 11_000_110 for RSI)
-        assert_eq!(sec.data[0], 0x40, "bare REX must be emitted for SETCC into RSI");
+        assert_eq!(
+            sec.data[0], 0x40,
+            "bare REX must be emitted for SETCC into RSI"
+        );
         assert_eq!(sec.data[1], 0x0F, "escape prefix");
         assert_eq!(sec.data[2], 0x94, "SETE opcode byte");
         assert_eq!(sec.data[3], 0xC6, "ModRM(11 000 110) for RSI");
@@ -604,7 +653,10 @@ mod tests {
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // First byte must be 0x0F (no REX prefix for RAX).
-        assert_eq!(sec.data[0], 0x0F, "no REX prefix should be emitted for SETCC into RAX");
+        assert_eq!(
+            sec.data[0], 0x0F,
+            "no REX prefix should be emitted for SETCC into RAX"
+        );
     }
 
     #[test]
@@ -622,8 +674,11 @@ mod tests {
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // REX.W=0x48, F7, ModRM(11 110 001) = 0xF1 (digit /6 = 110b, rcx=001b)
-        assert_eq!(&sec.data[0..3], &[0x48, 0xF7, 0xF1],
-            "div rcx should encode as REX.W + 0xF7 + ModRM(/6)");
+        assert_eq!(
+            &sec.data[0..3],
+            &[0x48, 0xF7, 0xF1],
+            "div rcx should encode as REX.W + 0xF7 + ModRM(/6)"
+        );
     }
 
     #[test]
@@ -641,8 +696,11 @@ mod tests {
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // REX.W=0x48, F7, ModRM(11 111 001) = 0xF9 (digit /7 = 111b, rcx=001b)
-        assert_eq!(&sec.data[0..3], &[0x48, 0xF7, 0xF9],
-            "idiv rcx should encode as REX.W + 0xF7 + ModRM(/7)");
+        assert_eq!(
+            &sec.data[0..3],
+            &[0x48, 0xF7, 0xF9],
+            "idiv rcx should encode as REX.W + 0xF7 + ModRM(/7)"
+        );
     }
 
     #[test]
@@ -661,16 +719,19 @@ mod tests {
         let mf = single_block_mf("mov_pr_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
-        assert_eq!(&sec.data[0..3], &[0x48, 0x89, 0xF0],
-            "mov rax, rsi should be REX.W + 0x89 + ModRM(11 110 000)");
+        assert_eq!(
+            &sec.data[0..3],
+            &[0x48, 0x89, 0xF0],
+            "mov rax, rsi should be REX.W + 0x89 + ModRM(11 110 000)"
+        );
     }
 
     #[test]
     fn mov_pr_emits_non_nop_for_extended_reg() {
         // MOV_PR: mov r8, rdi (R8 is an extended register, needs REX.B)
         // Expected: REX.WB(0x49) + 0x89 + ModRM(11_111_000=0xF8)
-        use llvm_codegen::isel::MOperand;
         use crate::regs::{R8, RDI};
+        use llvm_codegen::isel::MOperand;
         let mi = MInstr {
             opcode: MOV_PR,
             dst: None,
@@ -682,8 +743,11 @@ mod tests {
         let mut e = X86Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         // REX.W + REX.B = 0x49, opcode = 0x89, ModRM(11 111 000) = 0xF8
-        assert_eq!(&sec.data[0..3], &[0x49, 0x89, 0xF8],
-            "mov r8, rdi should use REX.WB");
+        assert_eq!(
+            &sec.data[0..3],
+            &[0x49, 0x89, 0xF8],
+            "mov r8, rdi should use REX.WB"
+        );
     }
 
     #[test]
@@ -703,7 +767,10 @@ mod tests {
         assert_eq!(sec.data.len(), 6);
         assert_eq!(sec.data[0], 0xE9, "JMP opcode");
         let rel = i32::from_le_bytes([sec.data[1], sec.data[2], sec.data[3], sec.data[4]]);
-        assert_eq!(rel, 0, "JMP should jump 0 bytes forward (to adjacent block)");
+        assert_eq!(
+            rel, 0,
+            "JMP should jump 0 bytes forward (to adjacent block)"
+        );
         assert_eq!(sec.data[5], 0xC3, "RET opcode");
     }
 

--- a/src/llvm-target-x86/src/instructions.rs
+++ b/src/llvm-target-x86/src/instructions.rs
@@ -4,98 +4,98 @@ use llvm_codegen::isel::MOpcode;
 
 // ── data movement ──────────────────────────────────────────────────────────
 /// `mov dst, src`   (64-bit reg → reg)
-pub const MOV_RR:    MOpcode = MOpcode(0x00);
+pub const MOV_RR: MOpcode = MOpcode(0x00);
 /// `mov dst, imm64` (64-bit immediate)
-pub const MOV_RI:    MOpcode = MOpcode(0x01);
+pub const MOV_RI: MOpcode = MOpcode(0x01);
 /// Sign-extend 32-bit source to 64-bit destination (`movsxd`)
-pub const MOVSX_32:  MOpcode = MOpcode(0x02);
+pub const MOVSX_32: MOpcode = MOpcode(0x02);
 /// Sign-extend 8-bit source to 64-bit destination (`movsx`)
-pub const MOVSX_8:   MOpcode = MOpcode(0x03);
+pub const MOVSX_8: MOpcode = MOpcode(0x03);
 /// Zero-extend 8-bit source to 64-bit destination (`movzx`)
-pub const MOVZX_8:   MOpcode = MOpcode(0x04);
+pub const MOVZX_8: MOpcode = MOpcode(0x04);
 /// Sign-extend 16-bit source to 64-bit destination (`movsx`)
-pub const MOVSX_16:  MOpcode = MOpcode(0x06);
+pub const MOVSX_16: MOpcode = MOpcode(0x06);
 /// Move VReg source into a fixed physical register destination.
 /// Layout: `operands[0]` = `PReg` (destination, ABI-fixed), `operands[1]` = `VReg`/`PReg` (source).
 /// Used by `emit_mov_to_preg`; unlike `MOV_RR` there is no `dst` field so the
 /// physical register in `operands[0]` survives register allocation unchanged.
-pub const MOV_PR:    MOpcode = MOpcode(0x05);
+pub const MOV_PR: MOpcode = MOpcode(0x05);
 
 // ── integer arithmetic ─────────────────────────────────────────────────────
-pub const ADD_RR:    MOpcode = MOpcode(0x10);
-pub const ADD_RI:    MOpcode = MOpcode(0x11);
-pub const SUB_RR:    MOpcode = MOpcode(0x12);
-pub const SUB_RI:    MOpcode = MOpcode(0x13);
+pub const ADD_RR: MOpcode = MOpcode(0x10);
+pub const ADD_RI: MOpcode = MOpcode(0x11);
+pub const SUB_RR: MOpcode = MOpcode(0x12);
+pub const SUB_RI: MOpcode = MOpcode(0x13);
 /// `imul dst, src`  (2-operand: dst *= src)
-pub const IMUL_RR:   MOpcode = MOpcode(0x14);
+pub const IMUL_RR: MOpcode = MOpcode(0x14);
 /// `imul dst, src, imm`  (3-operand)
-pub const IMUL_RRI:  MOpcode = MOpcode(0x15);
+pub const IMUL_RRI: MOpcode = MOpcode(0x15);
 /// `idiv src`  (signed: rdx:rax ÷ src → rax=quot, rdx=rem; requires CQO first)
-pub const IDIV_R:    MOpcode = MOpcode(0x16);
+pub const IDIV_R: MOpcode = MOpcode(0x16);
 /// `neg dst`
-pub const NEG_R:     MOpcode = MOpcode(0x17);
+pub const NEG_R: MOpcode = MOpcode(0x17);
 /// `cqo` — sign-extend rax into rdx:rax before idiv
-pub const CQO:       MOpcode = MOpcode(0x18);
+pub const CQO: MOpcode = MOpcode(0x18);
 /// `div src`  (unsigned: rdx:rax ÷ src → rax=quot, rdx=rem; requires `xor rdx, rdx` first)
-pub const DIV_R:     MOpcode = MOpcode(0x19);
+pub const DIV_R: MOpcode = MOpcode(0x19);
 
 // ── bitwise ────────────────────────────────────────────────────────────────
-pub const AND_RR:    MOpcode = MOpcode(0x20);
-pub const AND_RI:    MOpcode = MOpcode(0x21);
-pub const OR_RR:     MOpcode = MOpcode(0x22);
-pub const OR_RI:     MOpcode = MOpcode(0x23);
-pub const XOR_RR:    MOpcode = MOpcode(0x24);
-pub const XOR_RI:    MOpcode = MOpcode(0x25);
-pub const NOT_R:     MOpcode = MOpcode(0x26);
+pub const AND_RR: MOpcode = MOpcode(0x20);
+pub const AND_RI: MOpcode = MOpcode(0x21);
+pub const OR_RR: MOpcode = MOpcode(0x22);
+pub const OR_RI: MOpcode = MOpcode(0x23);
+pub const XOR_RR: MOpcode = MOpcode(0x24);
+pub const XOR_RI: MOpcode = MOpcode(0x25);
+pub const NOT_R: MOpcode = MOpcode(0x26);
 
 // ── shifts ─────────────────────────────────────────────────────────────────
 /// `shl dst, cl`  (logical left shift by register)
-pub const SHL_RR:    MOpcode = MOpcode(0x30);
+pub const SHL_RR: MOpcode = MOpcode(0x30);
 /// `shl dst, imm8`
-pub const SHL_RI:    MOpcode = MOpcode(0x31);
+pub const SHL_RI: MOpcode = MOpcode(0x31);
 /// `shr dst, cl`  (logical right shift by register)
-pub const SHR_RR:    MOpcode = MOpcode(0x32);
+pub const SHR_RR: MOpcode = MOpcode(0x32);
 /// `shr dst, imm8`
-pub const SHR_RI:    MOpcode = MOpcode(0x33);
+pub const SHR_RI: MOpcode = MOpcode(0x33);
 /// `sar dst, cl`  (arithmetic right shift by register)
-pub const SAR_RR:    MOpcode = MOpcode(0x34);
+pub const SAR_RR: MOpcode = MOpcode(0x34);
 /// `sar dst, imm8`
-pub const SAR_RI:    MOpcode = MOpcode(0x35);
+pub const SAR_RI: MOpcode = MOpcode(0x35);
 
 // ── comparisons ────────────────────────────────────────────────────────────
-pub const CMP_RR:    MOpcode = MOpcode(0x40);
-pub const CMP_RI:    MOpcode = MOpcode(0x41);
-pub const TEST_RR:   MOpcode = MOpcode(0x42);
+pub const CMP_RR: MOpcode = MOpcode(0x40);
+pub const CMP_RI: MOpcode = MOpcode(0x41);
+pub const TEST_RR: MOpcode = MOpcode(0x42);
 /// `setcc dst`  — condition code stored as `Imm(CC_*)` in first operand.
-pub const SETCC:     MOpcode = MOpcode(0x43);
+pub const SETCC: MOpcode = MOpcode(0x43);
 
 // ── control flow ───────────────────────────────────────────────────────────
-pub const JMP:          MOpcode = MOpcode(0x50);
+pub const JMP: MOpcode = MOpcode(0x50);
 /// `jcc target`  — condition code stored as `Imm(CC_*)`, target as `Block`.
-pub const JCC:          MOpcode = MOpcode(0x51);
+pub const JCC: MOpcode = MOpcode(0x51);
 /// `call rel32`
-pub const CALL_DIRECT:  MOpcode = MOpcode(0x52);
+pub const CALL_DIRECT: MOpcode = MOpcode(0x52);
 /// `call *reg`
-pub const CALL_R:       MOpcode = MOpcode(0x53);
-pub const RET:          MOpcode = MOpcode(0x54);
+pub const CALL_R: MOpcode = MOpcode(0x53);
+pub const RET: MOpcode = MOpcode(0x54);
 
 // ── stack ──────────────────────────────────────────────────────────────────
-pub const PUSH_R:    MOpcode = MOpcode(0x60);
-pub const POP_R:     MOpcode = MOpcode(0x61);
+pub const PUSH_R: MOpcode = MOpcode(0x60);
+pub const POP_R: MOpcode = MOpcode(0x61);
 
 // ── miscellaneous ──────────────────────────────────────────────────────────
-pub const NOP:       MOpcode = MOpcode(0x70);
+pub const NOP: MOpcode = MOpcode(0x70);
 /// `lea dst, [base + imm]`  — imm stored as `Imm` operand.
-pub const LEA_RI:    MOpcode = MOpcode(0x71);
+pub const LEA_RI: MOpcode = MOpcode(0x71);
 
 // ── condition codes (used as Imm operands with JCC / SETCC) ────────────────
-pub const CC_EQ:  i64 = 0;  // je  / jz
-pub const CC_NE:  i64 = 1;  // jne / jnz
-pub const CC_LT:  i64 = 2;  // jl  (signed)
-pub const CC_LE:  i64 = 3;  // jle (signed)
-pub const CC_GT:  i64 = 4;  // jg  (signed)
-pub const CC_GE:  i64 = 5;  // jge (signed)
-pub const CC_ULT: i64 = 6;  // jb  (unsigned below)
-pub const CC_ULE: i64 = 7;  // jbe (unsigned below-or-equal)
-pub const CC_UGT: i64 = 8;  // ja  (unsigned above)
-pub const CC_UGE: i64 = 9;  // jae (unsigned above-or-equal)
+pub const CC_EQ: i64 = 0; // je  / jz
+pub const CC_NE: i64 = 1; // jne / jnz
+pub const CC_LT: i64 = 2; // jl  (signed)
+pub const CC_LE: i64 = 3; // jle (signed)
+pub const CC_GT: i64 = 4; // jg  (signed)
+pub const CC_GE: i64 = 5; // jge (signed)
+pub const CC_ULT: i64 = 6; // jb  (unsigned below)
+pub const CC_ULE: i64 = 7; // jbe (unsigned below-or-equal)
+pub const CC_UGT: i64 = 8; // ja  (unsigned above)
+pub const CC_UGE: i64 = 9; // jae (unsigned above-or-equal)

--- a/src/llvm-target-x86/src/lib.rs
+++ b/src/llvm-target-x86/src/lib.rs
@@ -6,5 +6,5 @@ pub mod instructions;
 pub mod lower;
 pub mod regs;
 
-pub use lower::X86Backend;
 pub use encode::X86Emitter;
+pub use lower::X86Backend;

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -4,17 +4,17 @@
 //! translated to one or more machine instructions using virtual registers.
 //! Phi-destruction (parallel copy insertion) is also handled here.
 
-use std::collections::HashMap;
-use llvm_codegen::isel::{IselBackend, MachineFunction, MInstr, PReg, VReg};
-use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind,
-    IntPredicate, Module, TypeData, ValueRef,
-};
 use crate::{
     abi::{classify_sysv_args, ArgLocation, SYSV_INT_RET},
     instructions::*,
     regs::{ALLOCATABLE, CALLEE_SAVED, RCX, RDX},
 };
+use llvm_codegen::isel::{IselBackend, MInstr, MachineFunction, PReg, VReg};
+use llvm_ir::{
+    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
+    TypeData, ValueRef,
+};
+use std::collections::HashMap;
 
 /// x86_64 instruction-selection backend.
 pub struct X86Backend;
@@ -130,8 +130,8 @@ fn const_to_imm(cd: &ConstantData) -> i64 {
 
 fn pred_to_cc(pred: IntPredicate) -> i64 {
     match pred {
-        IntPredicate::Eq  => CC_EQ,
-        IntPredicate::Ne  => CC_NE,
+        IntPredicate::Eq => CC_EQ,
+        IntPredicate::Ne => CC_NE,
         IntPredicate::Slt => CC_LT,
         IntPredicate::Sle => CC_LE,
         IntPredicate::Sgt => CC_GT,
@@ -195,16 +195,22 @@ fn lower_instr(
             emit_mov_to_preg(mf, mblock, RCX, r);
             let mut shift_mi = MInstr::new($op).with_dst(dst);
             shift_mi.phys_uses = vec![RCX];
-            shift_mi.clobbers  = vec![RCX];
+            shift_mi.clobbers = vec![RCX];
             mf.push(mblock, shift_mi);
         }};
     }
 
     match &instr.kind {
         // ── arithmetic ─────────────────────────────────────────────────────
-        Add { lhs, rhs, .. }  => { emit_binop!(ADD_RR, *lhs, *rhs); }
-        Sub { lhs, rhs, .. }  => { emit_binop!(SUB_RR, *lhs, *rhs); }
-        Mul { lhs, rhs, .. }  => { emit_binop!(IMUL_RR, *lhs, *rhs); }
+        Add { lhs, rhs, .. } => {
+            emit_binop!(ADD_RR, *lhs, *rhs);
+        }
+        Sub { lhs, rhs, .. } => {
+            emit_binop!(SUB_RR, *lhs, *rhs);
+        }
+        Mul { lhs, rhs, .. } => {
+            emit_binop!(IMUL_RR, *lhs, *rhs);
+        }
 
         SDiv { lhs, rhs, .. } => {
             let dst = new_dst!();
@@ -263,16 +269,28 @@ fn lower_instr(
         }
 
         // ── bitwise ────────────────────────────────────────────────────────
-        And { lhs, rhs } => { emit_binop!(AND_RR, *lhs, *rhs); }
-        Or  { lhs, rhs } => { emit_binop!(OR_RR,  *lhs, *rhs); }
-        Xor { lhs, rhs } => { emit_binop!(XOR_RR, *lhs, *rhs); }
+        And { lhs, rhs } => {
+            emit_binop!(AND_RR, *lhs, *rhs);
+        }
+        Or { lhs, rhs } => {
+            emit_binop!(OR_RR, *lhs, *rhs);
+        }
+        Xor { lhs, rhs } => {
+            emit_binop!(XOR_RR, *lhs, *rhs);
+        }
 
         // ── shifts ─────────────────────────────────────────────────────────
         // x86 variable shifts require the count in CL (low byte of RCX).
         // emit_shift! (defined above) loads rhs into RCX then emits the shift.
-        Shl  { lhs, rhs, .. } => { emit_shift!(SHL_RR, *lhs, *rhs); }
-        LShr { lhs, rhs, .. } => { emit_shift!(SHR_RR, *lhs, *rhs); }
-        AShr { lhs, rhs, .. } => { emit_shift!(SAR_RR, *lhs, *rhs); }
+        Shl { lhs, rhs, .. } => {
+            emit_shift!(SHL_RR, *lhs, *rhs);
+        }
+        LShr { lhs, rhs, .. } => {
+            emit_shift!(SHR_RR, *lhs, *rhs);
+        }
+        AShr { lhs, rhs, .. } => {
+            emit_shift!(SAR_RR, *lhs, *rhs);
+        }
 
         // ── comparisons ────────────────────────────────────────────────────
         ICmp { pred, lhs, rhs } => {
@@ -291,9 +309,13 @@ fn lower_instr(
         }
 
         // ── select ─────────────────────────────────────────────────────────
-        Select { cond, then_val, else_val } => {
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             let dst = new_dst!();
-            let c  = res!(*cond);
+            let c = res!(*cond);
             let tv = res!(*then_val);
             let fv = res!(*else_val);
             // dst = fv; test cond; setne tmp; if cond != 0 → dst = tv.
@@ -307,16 +329,40 @@ fn lower_instr(
             let scratch = mf.fresh_vreg();
             mf.push(mblock, MInstr::new(SETCC).with_dst(scratch).with_imm(CC_NE));
             // Negate scratch: scratch = 0 - scratch (0→0, 1→-1 = all-ones).
-            mf.push(mblock, MInstr::new(NEG_R).with_dst(scratch).with_vreg(scratch));
+            mf.push(
+                mblock,
+                MInstr::new(NEG_R).with_dst(scratch).with_vreg(scratch),
+            );
             // dst = (fv & ~scratch) | (tv & scratch)
             let tmp1 = mf.fresh_vreg();
             let tmp2 = mf.fresh_vreg();
             mf.push(mblock, MInstr::new(MOV_RR).with_dst(tmp1).with_vreg(fv));
-            mf.push(mblock, MInstr::new(AND_RR).with_dst(tmp1).with_vreg(tmp1).with_vreg(scratch));
-            mf.push(mblock, MInstr::new(NOT_R).with_dst(scratch).with_vreg(scratch));
+            mf.push(
+                mblock,
+                MInstr::new(AND_RR)
+                    .with_dst(tmp1)
+                    .with_vreg(tmp1)
+                    .with_vreg(scratch),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(NOT_R).with_dst(scratch).with_vreg(scratch),
+            );
             mf.push(mblock, MInstr::new(MOV_RR).with_dst(tmp2).with_vreg(tv));
-            mf.push(mblock, MInstr::new(AND_RR).with_dst(tmp2).with_vreg(tmp2).with_vreg(scratch));
-            mf.push(mblock, MInstr::new(OR_RR).with_dst(dst).with_vreg(tmp1).with_vreg(tmp2));
+            mf.push(
+                mblock,
+                MInstr::new(AND_RR)
+                    .with_dst(tmp2)
+                    .with_vreg(tmp2)
+                    .with_vreg(scratch),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(OR_RR)
+                    .with_dst(dst)
+                    .with_vreg(tmp1)
+                    .with_vreg(tmp2),
+            );
         }
 
         // ── phi ────────────────────────────────────────────────────────────
@@ -326,11 +372,17 @@ fn lower_instr(
         }
 
         // ── casts ──────────────────────────────────────────────────────────
-        ZExt { val, .. } | Trunc { val, .. } | BitCast { val, .. }
-        | PtrToInt { val, .. } | IntToPtr { val, .. }
-        | FPTrunc { val, .. } | FPExt { val, .. }
-        | FPToUI { val, .. } | FPToSI { val, .. }
-        | UIToFP { val, .. } | SIToFP { val, .. }
+        ZExt { val, .. }
+        | Trunc { val, .. }
+        | BitCast { val, .. }
+        | PtrToInt { val, .. }
+        | IntToPtr { val, .. }
+        | FPTrunc { val, .. }
+        | FPExt { val, .. }
+        | FPToUI { val, .. }
+        | FPToSI { val, .. }
+        | UIToFP { val, .. }
+        | SIToFP { val, .. }
         | AddrSpaceCast { val, .. } => {
             let dst = new_dst!();
             let src = res!(*val);
@@ -341,13 +393,20 @@ fn lower_instr(
             let dst = new_dst!();
             let src = res!(*val);
             // Select the correct sign-extension opcode based on source bit width.
-            let src_bits = func.type_of_value(*val)
+            let src_bits = func
+                .type_of_value(*val)
                 .map(|tid| match ctx.get_type(tid) {
                     TypeData::Integer(bits) => *bits,
                     _ => 32,
                 })
                 .unwrap_or(32);
-            let opcode = if src_bits <= 8 { MOVSX_8 } else if src_bits <= 16 { MOVSX_16 } else { MOVSX_32 };
+            let opcode = if src_bits <= 8 {
+                MOVSX_8
+            } else if src_bits <= 16 {
+                MOVSX_16
+            } else {
+                MOVSX_32
+            };
             mf.push(mblock, MInstr::new(opcode).with_dst(dst).with_vreg(src));
         }
 
@@ -391,8 +450,11 @@ fn lower_instr(
         }
 
         // ── aggregate / vector ops (not yet supported) ─────────────────────
-        ExtractValue { .. } | InsertValue { .. } | ExtractElement { .. }
-        | InsertElement { .. } | ShuffleVector { .. } => {
+        ExtractValue { .. }
+        | InsertValue { .. }
+        | ExtractElement { .. }
+        | InsertElement { .. }
+        | ShuffleVector { .. } => {
             let dst = new_dst!();
             mf.push(mblock, MInstr::new(MOV_RI).with_dst(dst).with_imm(0));
         }
@@ -429,7 +491,11 @@ fn lower_terminator(
             mf.push(mblock, MInstr::new(JMP).with_block(dest.0 as usize));
         }
 
-        CondBr { cond, then_dest, else_dest } => {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => {
             let c = resolve(ctx, mf, mblock, vmap, *cond);
             // Each successor edge gets its own trampoline block so that phi
             // copies for one edge cannot overwrite values needed by the other.
@@ -441,21 +507,29 @@ fn lower_terminator(
             emit_phi_copies(ctx, func, mf, mblock, else_edge, *else_dest, vmap);
             mf.push(else_edge, MInstr::new(JMP).with_block(else_dest.0 as usize));
             mf.push(mblock, MInstr::new(TEST_RR).with_vreg(c).with_vreg(c));
-            mf.push(mblock, MInstr::new(JCC)
-                .with_imm(CC_NE)
-                .with_block(then_edge));
+            mf.push(
+                mblock,
+                MInstr::new(JCC).with_imm(CC_NE).with_block(then_edge),
+            );
             mf.push(mblock, MInstr::new(JMP).with_block(else_edge));
         }
 
-        Switch { val, default, cases } => {
+        Switch {
+            val,
+            default,
+            cases,
+        } => {
             let v = resolve(ctx, mf, mblock, vmap, *val);
             for (case_val, case_dest) in cases {
                 let cv = resolve(ctx, mf, mblock, vmap, *case_val);
                 emit_phi_copies(ctx, func, mf, mblock, mblock, *case_dest, vmap);
                 mf.push(mblock, MInstr::new(CMP_RR).with_vreg(v).with_vreg(cv));
-                mf.push(mblock, MInstr::new(JCC)
-                    .with_imm(CC_EQ)
-                    .with_block(case_dest.0 as usize));
+                mf.push(
+                    mblock,
+                    MInstr::new(JCC)
+                        .with_imm(CC_EQ)
+                        .with_block(case_dest.0 as usize),
+                );
             }
             emit_phi_copies(ctx, func, mf, mblock, mblock, *default, vmap);
             mf.push(mblock, MInstr::new(JMP).with_block(default.0 as usize));
@@ -499,9 +573,10 @@ fn emit_phi_copies(
                     None => continue,
                 };
                 let src_vreg = resolve(ctx, mf, emit_to_mblock, vmap, *incoming_val);
-                mf.push(emit_to_mblock, MInstr::new(MOV_RR)
-                    .with_dst(phi_vreg)
-                    .with_vreg(src_vreg));
+                mf.push(
+                    emit_to_mblock,
+                    MInstr::new(MOV_RR).with_dst(phi_vreg).with_vreg(src_vreg),
+                );
             }
         }
     }
@@ -566,9 +641,10 @@ mod tests {
         let (ctx, module) = make_add_fn();
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_ret = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == RET)
-        });
+        let has_ret = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == RET));
         assert!(has_ret, "machine function must contain a RET");
     }
 
@@ -614,13 +690,15 @@ mod tests {
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
-        let has_cmp = mf.blocks.iter().any(|bl| {
-            bl.instrs.iter().any(|i| i.opcode == CMP_RR)
-        });
-        let has_setcc = mf.blocks.iter().any(|bl| {
-            bl.instrs.iter().any(|i| i.opcode == SETCC)
-        });
-        assert!(has_cmp,   "should emit CMP");
+        let has_cmp = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == CMP_RR));
+        let has_setcc = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == SETCC));
+        assert!(has_cmp, "should emit CMP");
         assert!(has_setcc, "should emit SETCC");
     }
 
@@ -681,20 +759,28 @@ mod tests {
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
         // There must be a SHL_RR in the function.
-        let shl_instr = mf.blocks.iter().flat_map(|b| b.instrs.iter())
+        let shl_instr = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
             .find(|i| i.opcode == SHL_RR)
             .expect("should emit SHL_RR");
 
         // SHL_RR must declare RCX as a physical use (shift reads CL).
-        assert!(shl_instr.phys_uses.contains(&RCX),
-            "SHL_RR must have RCX in phys_uses (CL holds the shift amount)");
+        assert!(
+            shl_instr.phys_uses.contains(&RCX),
+            "SHL_RR must have RCX in phys_uses (CL holds the shift amount)"
+        );
 
         // There must be a MOV_PR targeting RCX somewhere in the function.
         let has_mov_to_rcx = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| {
-            i.opcode == MOV_PR && i.operands.first() == Some(&llvm_codegen::isel::MOperand::PReg(RCX))
+            i.opcode == MOV_PR
+                && i.operands.first() == Some(&llvm_codegen::isel::MOperand::PReg(RCX))
         });
-        assert!(has_mov_to_rcx,
-            "a MOV_PR loading the shift count into RCX must be emitted before SHL_RR");
+        assert!(
+            has_mov_to_rcx,
+            "a MOV_PR loading the shift count into RCX must be emitted before SHL_RR"
+        );
     }
 
     #[test]
@@ -703,9 +789,15 @@ mod tests {
         let (ctx, module) = make_div_fn(true);
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_div_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
-        let has_idiv_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
-        assert!(has_div_r,  "UDiv must emit DIV_R (unsigned div)");
+        let has_div_r = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
+        let has_idiv_r = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
+        assert!(has_div_r, "UDiv must emit DIV_R (unsigned div)");
         assert!(!has_idiv_r, "UDiv must NOT emit IDIV_R (signed div)");
     }
 
@@ -715,10 +807,16 @@ mod tests {
         let (ctx, module) = make_div_fn(false);
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_idiv_r = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
-        let has_div_r  = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
+        let has_idiv_r = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == IDIV_R));
+        let has_div_r = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == DIV_R));
         assert!(has_idiv_r, "SDiv must emit IDIV_R (signed div)");
-        assert!(!has_div_r,  "SDiv must NOT emit DIV_R (unsigned div)");
+        assert!(!has_div_r, "SDiv must NOT emit DIV_R (unsigned div)");
     }
 
     #[test]
@@ -727,8 +825,8 @@ mod tests {
         // physical register destination survives register allocation.
         // Verify: the instruction has dst=None, opcode=MOV_PR,
         //         operands[0]=PReg(preg), operands[1]=VReg(src).
-        use llvm_codegen::isel::{MachineFunction, MOperand};
         use crate::regs::RAX;
+        use llvm_codegen::isel::{MOperand, MachineFunction};
 
         let mut mf = MachineFunction::new("f".into());
         let b = mf.add_block("entry");
@@ -736,11 +834,25 @@ mod tests {
         super::emit_mov_to_preg(&mut mf, b, RAX, src);
 
         let instr = &mf.blocks[b].instrs[0];
-        assert_eq!(instr.opcode, MOV_PR, "emit_mov_to_preg must use MOV_PR opcode");
-        assert!(instr.dst.is_none(), "dst must be None (destination is a fixed PReg)");
+        assert_eq!(
+            instr.opcode, MOV_PR,
+            "emit_mov_to_preg must use MOV_PR opcode"
+        );
+        assert!(
+            instr.dst.is_none(),
+            "dst must be None (destination is a fixed PReg)"
+        );
         assert_eq!(instr.operands.len(), 2);
-        assert_eq!(instr.operands[0], MOperand::PReg(RAX), "operands[0] must be the fixed PReg");
-        assert_eq!(instr.operands[1], MOperand::VReg(src), "operands[1] must be the source VReg");
+        assert_eq!(
+            instr.operands[0],
+            MOperand::PReg(RAX),
+            "operands[0] must be the fixed PReg"
+        );
+        assert_eq!(
+            instr.operands[1],
+            MOperand::VReg(src),
+            "operands[1] must be the source VReg"
+        );
     }
 
     #[test]
@@ -752,13 +864,16 @@ mod tests {
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
         // Find the ADD_RR instruction.
-        let add_instr = mf.blocks.iter()
+        let add_instr = mf
+            .blocks
+            .iter()
             .flat_map(|b| b.instrs.iter())
             .find(|i| i.opcode == ADD_RR);
         let add_instr = add_instr.expect("should have an ADD_RR instruction");
 
         assert_eq!(
-            add_instr.operands.len(), 1,
+            add_instr.operands.len(),
+            1,
             "ADD_RR must carry only the RHS operand, not a self-reference (issue #34)"
         );
     }
@@ -789,10 +904,14 @@ mod tests {
         let (ctx, module) = make_sext_fn(8);
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_movsx8 = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == MOVSX_8)
-        });
-        assert!(has_movsx8, "sext from i8 must use MOVSX_8 (0F BE), not MOVSXD (63)");
+        let has_movsx8 = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == MOVSX_8));
+        assert!(
+            has_movsx8,
+            "sext from i8 must use MOVSX_8 (0F BE), not MOVSXD (63)"
+        );
     }
 
     #[test]
@@ -800,10 +919,14 @@ mod tests {
         let (ctx, module) = make_sext_fn(16);
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_movsx16 = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == MOVSX_16)
-        });
-        assert!(has_movsx16, "sext from i16 must use MOVSX_16 (0F BF), not MOVSXD (63)");
+        let has_movsx16 = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == MOVSX_16));
+        assert!(
+            has_movsx16,
+            "sext from i16 must use MOVSX_16 (0F BF), not MOVSXD (63)"
+        );
     }
 
     #[test]
@@ -811,9 +934,10 @@ mod tests {
         let (ctx, module) = make_sext_fn(32);
         let mut be = X86Backend;
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_movsx32 = mf.blocks.iter().any(|b| {
-            b.instrs.iter().any(|i| i.opcode == MOVSX_32)
-        });
+        let has_movsx32 = mf
+            .blocks
+            .iter()
+            .any(|b| b.instrs.iter().any(|i| i.opcode == MOVSX_32));
         assert!(has_movsx32, "sext from i32 must use MOVSX_32 (movsxd, 63)");
     }
 
@@ -847,14 +971,14 @@ mod tests {
             Linkage::External,
         );
         // entry: br i1 %cond, label %then_bb, label %else_bb
-        let entry    = b.add_block("entry");
-        let then_bb  = b.add_block("then_bb");
-        let else_bb  = b.add_block("else_bb");
+        let entry = b.add_block("entry");
+        let then_bb = b.add_block("then_bb");
+        let else_bb = b.add_block("else_bb");
         let merge_bb = b.add_block("merge");
 
         b.position_at_end(entry);
-        let a    = b.get_arg(0);
-        let bv   = b.get_arg(1);
+        let a = b.get_arg(0);
+        let bv = b.get_arg(1);
         let cond = b.get_arg(2);
         b.build_cond_br(cond, then_bb, else_bb);
 
@@ -892,7 +1016,8 @@ mod tests {
             mf.blocks.len() > ir_block_count,
             "CondBr must create trampoline edge blocks for phi copies; \
              expected > {} machine blocks, got {}",
-            ir_block_count, mf.blocks.len()
+            ir_block_count,
+            mf.blocks.len()
         );
     }
 
@@ -909,11 +1034,17 @@ mod tests {
 
         // entry is machine block 0; find its JCC and JMP targets.
         let entry_block = &mf.blocks[0];
-        let branch_targets: Vec<usize> = entry_block.instrs.iter()
+        let branch_targets: Vec<usize> = entry_block
+            .instrs
+            .iter()
             .filter_map(|i| {
                 if i.opcode == JCC || i.opcode == JMP {
                     i.operands.iter().find_map(|op| {
-                        if let MOperand::Block(b) = op { Some(*b) } else { None }
+                        if let MOperand::Block(b) = op {
+                            Some(*b)
+                        } else {
+                            None
+                        }
                     })
                 } else {
                     None
@@ -929,7 +1060,8 @@ mod tests {
             assert!(
                 target >= ir_block_count,
                 "CondBr must branch to trampoline blocks (index >= {}), got target {}",
-                ir_block_count, target
+                ir_block_count,
+                target
             );
         }
     }

--- a/src/llvm-target-x86/src/regs.rs
+++ b/src/llvm-target-x86/src/regs.rs
@@ -12,8 +12,8 @@ pub const RSP: PReg = PReg(4);
 pub const RBP: PReg = PReg(5);
 pub const RSI: PReg = PReg(6);
 pub const RDI: PReg = PReg(7);
-pub const R8:  PReg = PReg(8);
-pub const R9:  PReg = PReg(9);
+pub const R8: PReg = PReg(8);
+pub const R9: PReg = PReg(9);
 pub const R10: PReg = PReg(10);
 pub const R11: PReg = PReg(11);
 pub const R12: PReg = PReg(12);
@@ -31,19 +31,35 @@ pub const CALLEE_SAVED: &[PReg] = &[RBX, RBP, R12, R13, R14, R15];
 /// Return the 64-bit register name in AT&T / Intel syntax.
 pub fn reg_name(r: PReg) -> &'static str {
     match r.0 {
-        0  => "rax",  1  => "rcx",  2  => "rdx",  3  => "rbx",
-        4  => "rsp",  5  => "rbp",  6  => "rsi",  7  => "rdi",
-        8  => "r8",   9  => "r9",   10 => "r10",  11 => "r11",
-        12 => "r12",  13 => "r13",  14 => "r14",  15 => "r15",
-        _  => "??",
+        0 => "rax",
+        1 => "rcx",
+        2 => "rdx",
+        3 => "rbx",
+        4 => "rsp",
+        5 => "rbp",
+        6 => "rsi",
+        7 => "rdi",
+        8 => "r8",
+        9 => "r9",
+        10 => "r10",
+        11 => "r11",
+        12 => "r12",
+        13 => "r13",
+        14 => "r14",
+        15 => "r15",
+        _ => "??",
     }
 }
 
 /// Whether a register requires the REX prefix (R8–R15).
-pub fn is_extended(r: PReg) -> bool { r.0 >= 8 }
+pub fn is_extended(r: PReg) -> bool {
+    r.0 >= 8
+}
 
 /// The 3-bit encoding used in the ModRM reg/rm fields (low 3 bits).
-pub fn reg_enc(r: PReg) -> u8 { r.0 & 7 }
+pub fn reg_enc(r: PReg) -> u8 {
+    r.0 & 7
+}
 
 #[cfg(test)]
 mod tests {
@@ -65,8 +81,8 @@ mod tests {
     #[test]
     fn reg_enc_low3_bits() {
         assert_eq!(reg_enc(RAX), 0);
-        assert_eq!(reg_enc(R8),  0); // R8 = 8 & 7 = 0
-        assert_eq!(reg_enc(R9),  1);
+        assert_eq!(reg_enc(R8), 0); // R8 = 8 & 7 = 0
+        assert_eq!(reg_enc(R9), 1);
         assert_eq!(reg_enc(RDI), 7);
     }
 

--- a/src/llvm-transforms/src/const_prop.rs
+++ b/src/llvm-transforms/src/const_prop.rs
@@ -12,19 +12,23 @@
 //! constants) require a second pass; use `PassManager::run_until_fixed_point`
 //! when that is needed.
 
-use std::collections::{HashMap, HashSet};
-use llvm_ir::{Context, Function, InstrId, InstrKind, ValueRef};
-use crate::pass::FunctionPass;
 use crate::constant_fold::try_fold;
+use crate::pass::FunctionPass;
+use llvm_ir::{Context, Function, InstrId, InstrKind, ValueRef};
+use std::collections::{HashMap, HashSet};
 
 /// Constant propagation / constant folding pass.
 pub struct ConstProp;
 
 impl FunctionPass for ConstProp {
-    fn name(&self) -> &'static str { "const-prop" }
+    fn name(&self) -> &'static str {
+        "const-prop"
+    }
 
     fn run_on_function(&mut self, ctx: &mut Context, func: &mut Function) -> bool {
-        if func.blocks.is_empty() { return false; }
+        if func.blocks.is_empty() {
+            return false;
+        }
 
         // Map InstrId → its constant replacement (ValueRef::Constant).
         let mut subst: HashMap<InstrId, ValueRef> = HashMap::new();
@@ -84,89 +88,245 @@ pub(crate) fn subst_kind(kind: InstrKind, subst: &HashMap<InstrId, ValueRef>) ->
 
     match kind {
         // --- Integer arithmetic ---
-        InstrKind::Add  { flags, lhs, rhs } => InstrKind::Add  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Sub  { flags, lhs, rhs } => InstrKind::Sub  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Mul  { flags, lhs, rhs } => InstrKind::Mul  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::UDiv { exact, lhs, rhs } => InstrKind::UDiv { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::SDiv { exact, lhs, rhs } => InstrKind::SDiv { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::URem { lhs, rhs }        => InstrKind::URem { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::SRem { lhs, rhs }        => InstrKind::SRem { lhs: s(lhs), rhs: s(rhs) },
+        InstrKind::Add { flags, lhs, rhs } => InstrKind::Add {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Sub { flags, lhs, rhs } => InstrKind::Sub {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Mul { flags, lhs, rhs } => InstrKind::Mul {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::UDiv { exact, lhs, rhs } => InstrKind::UDiv {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::SDiv { exact, lhs, rhs } => InstrKind::SDiv {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::URem { lhs, rhs } => InstrKind::URem {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::SRem { lhs, rhs } => InstrKind::SRem {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
         // --- Bitwise ---
-        InstrKind::And  { lhs, rhs }        => InstrKind::And  { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Or   { lhs, rhs }        => InstrKind::Or   { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Xor  { lhs, rhs }        => InstrKind::Xor  { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Shl  { flags, lhs, rhs } => InstrKind::Shl  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::LShr { exact, lhs, rhs } => InstrKind::LShr { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::AShr { exact, lhs, rhs } => InstrKind::AShr { exact, lhs: s(lhs), rhs: s(rhs) },
+        InstrKind::And { lhs, rhs } => InstrKind::And {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Or { lhs, rhs } => InstrKind::Or {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Xor { lhs, rhs } => InstrKind::Xor {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Shl { flags, lhs, rhs } => InstrKind::Shl {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::LShr { exact, lhs, rhs } => InstrKind::LShr {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::AShr { exact, lhs, rhs } => InstrKind::AShr {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
         // --- Floating-point ---
-        InstrKind::FAdd { flags, lhs, rhs } => InstrKind::FAdd { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FSub { flags, lhs, rhs } => InstrKind::FSub { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FMul { flags, lhs, rhs } => InstrKind::FMul { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FDiv { flags, lhs, rhs } => InstrKind::FDiv { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FRem { flags, lhs, rhs } => InstrKind::FRem { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FNeg { flags, operand }  => InstrKind::FNeg { flags, operand: s(operand) },
+        InstrKind::FAdd { flags, lhs, rhs } => InstrKind::FAdd {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FSub { flags, lhs, rhs } => InstrKind::FSub {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FMul { flags, lhs, rhs } => InstrKind::FMul {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FDiv { flags, lhs, rhs } => InstrKind::FDiv {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FRem { flags, lhs, rhs } => InstrKind::FRem {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FNeg { flags, operand } => InstrKind::FNeg {
+            flags,
+            operand: s(operand),
+        },
         // --- Comparisons ---
-        InstrKind::ICmp { pred, lhs, rhs } =>
-            InstrKind::ICmp { pred, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FCmp { flags, pred, lhs, rhs } =>
-            InstrKind::FCmp { flags, pred, lhs: s(lhs), rhs: s(rhs) },
+        InstrKind::ICmp { pred, lhs, rhs } => InstrKind::ICmp {
+            pred,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FCmp {
+            flags,
+            pred,
+            lhs,
+            rhs,
+        } => InstrKind::FCmp {
+            flags,
+            pred,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
         // --- Memory ---
-        InstrKind::Alloca { alloc_ty, num_elements, align } =>
-            InstrKind::Alloca { alloc_ty, num_elements: num_elements.map(s), align },
-        InstrKind::Load  { ty, ptr, align, volatile } =>
-            InstrKind::Load  { ty, ptr: s(ptr), align, volatile },
-        InstrKind::Store { val, ptr, align, volatile } =>
-            InstrKind::Store { val: s(val), ptr: s(ptr), align, volatile },
-        InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices } =>
-            InstrKind::GetElementPtr {
-                inbounds, base_ty, ptr: s(ptr),
-                indices: indices.into_iter().map(s).collect(),
-            },
+        InstrKind::Alloca {
+            alloc_ty,
+            num_elements,
+            align,
+        } => InstrKind::Alloca {
+            alloc_ty,
+            num_elements: num_elements.map(s),
+            align,
+        },
+        InstrKind::Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Load {
+            ty,
+            ptr: s(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Store {
+            val: s(val),
+            ptr: s(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        } => InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr: s(ptr),
+            indices: indices.into_iter().map(s).collect(),
+        },
         // --- Casts ---
-        InstrKind::Trunc         { val, to } => InstrKind::Trunc         { val: s(val), to },
-        InstrKind::ZExt          { val, to } => InstrKind::ZExt          { val: s(val), to },
-        InstrKind::SExt          { val, to } => InstrKind::SExt          { val: s(val), to },
-        InstrKind::FPTrunc       { val, to } => InstrKind::FPTrunc       { val: s(val), to },
-        InstrKind::FPExt         { val, to } => InstrKind::FPExt         { val: s(val), to },
-        InstrKind::FPToUI        { val, to } => InstrKind::FPToUI        { val: s(val), to },
-        InstrKind::FPToSI        { val, to } => InstrKind::FPToSI        { val: s(val), to },
-        InstrKind::UIToFP        { val, to } => InstrKind::UIToFP        { val: s(val), to },
-        InstrKind::SIToFP        { val, to } => InstrKind::SIToFP        { val: s(val), to },
-        InstrKind::PtrToInt      { val, to } => InstrKind::PtrToInt      { val: s(val), to },
-        InstrKind::IntToPtr      { val, to } => InstrKind::IntToPtr      { val: s(val), to },
-        InstrKind::BitCast       { val, to } => InstrKind::BitCast       { val: s(val), to },
+        InstrKind::Trunc { val, to } => InstrKind::Trunc { val: s(val), to },
+        InstrKind::ZExt { val, to } => InstrKind::ZExt { val: s(val), to },
+        InstrKind::SExt { val, to } => InstrKind::SExt { val: s(val), to },
+        InstrKind::FPTrunc { val, to } => InstrKind::FPTrunc { val: s(val), to },
+        InstrKind::FPExt { val, to } => InstrKind::FPExt { val: s(val), to },
+        InstrKind::FPToUI { val, to } => InstrKind::FPToUI { val: s(val), to },
+        InstrKind::FPToSI { val, to } => InstrKind::FPToSI { val: s(val), to },
+        InstrKind::UIToFP { val, to } => InstrKind::UIToFP { val: s(val), to },
+        InstrKind::SIToFP { val, to } => InstrKind::SIToFP { val: s(val), to },
+        InstrKind::PtrToInt { val, to } => InstrKind::PtrToInt { val: s(val), to },
+        InstrKind::IntToPtr { val, to } => InstrKind::IntToPtr { val: s(val), to },
+        InstrKind::BitCast { val, to } => InstrKind::BitCast { val: s(val), to },
         InstrKind::AddrSpaceCast { val, to } => InstrKind::AddrSpaceCast { val: s(val), to },
         // --- Misc ---
-        InstrKind::Select { cond, then_val, else_val } =>
-            InstrKind::Select { cond: s(cond), then_val: s(then_val), else_val: s(else_val) },
-        InstrKind::Phi { ty, incoming } =>
-            InstrKind::Phi { ty, incoming: incoming.into_iter().map(|(v, b)| (s(v), b)).collect() },
-        InstrKind::ExtractValue { aggregate, indices } =>
-            InstrKind::ExtractValue { aggregate: s(aggregate), indices },
-        InstrKind::InsertValue { aggregate, val, indices } =>
-            InstrKind::InsertValue { aggregate: s(aggregate), val: s(val), indices },
-        InstrKind::ExtractElement { vec, idx } =>
-            InstrKind::ExtractElement { vec: s(vec), idx: s(idx) },
-        InstrKind::InsertElement  { vec, val, idx } =>
-            InstrKind::InsertElement  { vec: s(vec), val: s(val), idx: s(idx) },
-        InstrKind::ShuffleVector  { v1, v2, mask } =>
-            InstrKind::ShuffleVector  { v1: s(v1), v2: s(v2), mask },
+        InstrKind::Select {
+            cond,
+            then_val,
+            else_val,
+        } => InstrKind::Select {
+            cond: s(cond),
+            then_val: s(then_val),
+            else_val: s(else_val),
+        },
+        InstrKind::Phi { ty, incoming } => InstrKind::Phi {
+            ty,
+            incoming: incoming.into_iter().map(|(v, b)| (s(v), b)).collect(),
+        },
+        InstrKind::ExtractValue { aggregate, indices } => InstrKind::ExtractValue {
+            aggregate: s(aggregate),
+            indices,
+        },
+        InstrKind::InsertValue {
+            aggregate,
+            val,
+            indices,
+        } => InstrKind::InsertValue {
+            aggregate: s(aggregate),
+            val: s(val),
+            indices,
+        },
+        InstrKind::ExtractElement { vec, idx } => InstrKind::ExtractElement {
+            vec: s(vec),
+            idx: s(idx),
+        },
+        InstrKind::InsertElement { vec, val, idx } => InstrKind::InsertElement {
+            vec: s(vec),
+            val: s(val),
+            idx: s(idx),
+        },
+        InstrKind::ShuffleVector { v1, v2, mask } => InstrKind::ShuffleVector {
+            v1: s(v1),
+            v2: s(v2),
+            mask,
+        },
         // --- Call ---
-        InstrKind::Call { tail, callee_ty, callee, args } =>
-            InstrKind::Call {
-                tail, callee_ty, callee: s(callee),
-                args: args.into_iter().map(s).collect(),
-            },
+        InstrKind::Call {
+            tail,
+            callee_ty,
+            callee,
+            args,
+        } => InstrKind::Call {
+            tail,
+            callee_ty,
+            callee: s(callee),
+            args: args.into_iter().map(s).collect(),
+        },
         // --- Terminators ---
-        InstrKind::Ret { val }                                => InstrKind::Ret { val: val.map(s) },
-        InstrKind::Br  { dest }                               => InstrKind::Br  { dest },
-        InstrKind::CondBr { cond, then_dest, else_dest }      =>
-            InstrKind::CondBr { cond: s(cond), then_dest, else_dest },
-        InstrKind::Switch { val, default, cases }             =>
-            InstrKind::Switch {
-                val: s(val), default,
-                cases: cases.into_iter().map(|(v, b)| (s(v), b)).collect(),
-            },
+        InstrKind::Ret { val } => InstrKind::Ret { val: val.map(s) },
+        InstrKind::Br { dest } => InstrKind::Br { dest },
+        InstrKind::CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => InstrKind::CondBr {
+            cond: s(cond),
+            then_dest,
+            else_dest,
+        },
+        InstrKind::Switch {
+            val,
+            default,
+            cases,
+        } => InstrKind::Switch {
+            val: s(val),
+            default,
+            cases: cases.into_iter().map(|(v, b)| (s(v), b)).collect(),
+        },
         InstrKind::Unreachable => InstrKind::Unreachable,
     }
 }
@@ -197,7 +357,9 @@ fn rpo(func: &Function) -> Vec<usize> {
             post_order.push(bi);
             continue;
         }
-        if visited.contains(&bi) { continue; }
+        if visited.contains(&bi) {
+            continue;
+        }
         visited.insert(bi);
         // Push post-visit marker first, then successors in reverse so we
         // process them left-to-right.
@@ -229,8 +391,8 @@ fn rpo(func: &Function) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Builder, Context, Linkage, Module, ValueRef};
     use crate::pass::FunctionPass;
+    use llvm_ir::{Builder, Context, Linkage, Module, ValueRef};
 
     // Build: f() -> i32 { ret (2 + 3) }  — the add folds to 5
     fn make_const_add_fn() -> (Context, Module) {
@@ -258,16 +420,24 @@ mod tests {
         assert!(changed);
 
         // After: 'sum' folded away; body is empty.
-        assert_eq!(module.functions[0].blocks[0].body.len(), 0,
-            "folded add must be removed from body");
+        assert_eq!(
+            module.functions[0].blocks[0].body.len(),
+            0,
+            "folded add must be removed from body"
+        );
 
         // The ret terminator should now reference the constant 5 directly.
         let func = &module.functions[0];
         let tid = func.blocks[0].terminator.unwrap();
         if let llvm_ir::InstrKind::Ret { val: Some(v) } = &func.instr(tid).kind {
             if let ValueRef::Constant(cid) = v {
-                assert_eq!(ctx.get_const(*cid),
-                    &llvm_ir::ConstantData::Int { ty: ctx.i32_ty, val: 5 });
+                assert_eq!(
+                    ctx.get_const(*cid),
+                    &llvm_ir::ConstantData::Int {
+                        ty: ctx.i32_ty,
+                        val: 5
+                    }
+                );
             } else {
                 panic!("ret operand should be a constant");
             }
@@ -285,8 +455,8 @@ mod tests {
         b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
         let entry = b.add_block("entry");
         b.position_at_end(entry);
-        let c2  = b.const_int(b.ctx.i32_ty, 2);
-        let c3  = b.const_int(b.ctx.i32_ty, 3);
+        let c2 = b.const_int(b.ctx.i32_ty, 2);
+        let c3 = b.const_int(b.ctx.i32_ty, 3);
         let c10 = b.const_int(b.ctx.i32_ty, 10);
         let sum = b.build_add("sum", c2, c3);
         let prod = b.build_mul("prod", sum, c10);
@@ -296,11 +466,23 @@ mod tests {
         pass.run_on_function(&mut ctx, &mut module.functions[0]);
 
         let func = &module.functions[0];
-        assert_eq!(func.blocks[0].body.len(), 0, "both sum and prod should be folded");
+        assert_eq!(
+            func.blocks[0].body.len(),
+            0,
+            "both sum and prod should be folded"
+        );
         let tid = func.blocks[0].terminator.unwrap();
-        if let llvm_ir::InstrKind::Ret { val: Some(ValueRef::Constant(cid)) } = &func.instr(tid).kind {
-            assert_eq!(ctx.get_const(*cid),
-                &llvm_ir::ConstantData::Int { ty: ctx.i32_ty, val: 50 });
+        if let llvm_ir::InstrKind::Ret {
+            val: Some(ValueRef::Constant(cid)),
+        } = &func.instr(tid).kind
+        {
+            assert_eq!(
+                ctx.get_const(*cid),
+                &llvm_ir::ConstantData::Int {
+                    ty: ctx.i32_ty,
+                    val: 50
+                }
+            );
         } else {
             panic!("expected ret with constant 50");
         }
@@ -319,7 +501,7 @@ mod tests {
         b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
 
         let entry = b.add_block("entry");
-        let exit  = b.add_block("exit");
+        let exit = b.add_block("exit");
 
         b.position_at_end(entry);
         let c2 = b.const_int(b.ctx.i32_ty, 2);
@@ -337,13 +519,25 @@ mod tests {
 
         let func = &module.functions[0];
         // Both `a` and `b` should be folded away.
-        assert_eq!(func.blocks[0].body.len(), 0, "`a` should be folded in entry");
+        assert_eq!(
+            func.blocks[0].body.len(),
+            0,
+            "`a` should be folded in entry"
+        );
         assert_eq!(func.blocks[1].body.len(), 0, "`b` should be folded in exit");
         // ret in exit block should reference constant 15.
         let tid = func.blocks[1].terminator.unwrap();
-        if let llvm_ir::InstrKind::Ret { val: Some(ValueRef::Constant(cid)) } = &func.instr(tid).kind {
-            assert_eq!(ctx.get_const(*cid),
-                &llvm_ir::ConstantData::Int { ty: ctx.i32_ty, val: 15 });
+        if let llvm_ir::InstrKind::Ret {
+            val: Some(ValueRef::Constant(cid)),
+        } = &func.instr(tid).kind
+        {
+            assert_eq!(
+                ctx.get_const(*cid),
+                &llvm_ir::ConstantData::Int {
+                    ty: ctx.i32_ty,
+                    val: 15
+                }
+            );
         } else {
             panic!("expected ret with constant 15");
         }
@@ -357,7 +551,7 @@ mod tests {
         let mut b = Builder::new(&mut ctx, &mut module);
         b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
         let entry = b.add_block("entry");
-        let exit  = b.add_block("exit");
+        let exit = b.add_block("exit");
         b.position_at_end(entry);
         b.build_br(exit);
         b.position_at_end(exit);
@@ -367,7 +561,7 @@ mod tests {
         let func = &module.functions[0];
         let order = rpo(func);
         let entry_pos = order.iter().position(|&i| i == entry.0 as usize).unwrap();
-        let exit_pos  = order.iter().position(|&i| i == exit.0 as usize).unwrap();
+        let exit_pos = order.iter().position(|&i| i == exit.0 as usize).unwrap();
         assert!(entry_pos < exit_pos, "entry must come before exit in RPO");
     }
 }

--- a/src/llvm-transforms/src/constant_fold.rs
+++ b/src/llvm-transforms/src/constant_fold.rs
@@ -8,7 +8,7 @@
 //! The function is pure: it only reads `ctx` and `kind`; new constants are
 //! allocated with `ctx.const_int`.
 
-use llvm_ir::{ConstId, ConstantData, Context, IntPredicate, InstrKind, ValueRef};
+use llvm_ir::{ConstId, ConstantData, Context, InstrKind, IntPredicate, ValueRef};
 
 /// Try to constant-fold `kind`.
 ///
@@ -21,86 +21,100 @@ pub fn try_fold(ctx: &mut Context, kind: &InstrKind) -> Option<ConstId> {
         // --- Binary integer arithmetic ---
         InstrKind::Add { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l.wrapping_add(r)))
         }
         InstrKind::Sub { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l.wrapping_sub(r)))
         }
         InstrKind::Mul { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l.wrapping_mul(r)))
         }
         InstrKind::UDiv { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
-            if r == 0 { return None; }
+            let (_, r) = const_int(ctx, *rhs)?;
+            if r == 0 {
+                return None;
+            }
             Some(ctx.const_int(ty, l / r))
         }
         InstrKind::SDiv { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let bits = int_bit_width(ctx, ty)?;
             let sl = sign_extend(l, bits);
             let sr = sign_extend(r, bits);
-            if sr == 0 { return None; }
+            if sr == 0 {
+                return None;
+            }
             // MIN_INT / -1 overflows → poison; return None.
-            let type_min: i64 = if bits >= 64 { i64::MIN } else { -(1i64 << (bits - 1)) };
-            if sl == type_min && sr == -1 { return None; }
+            let type_min: i64 = if bits >= 64 {
+                i64::MIN
+            } else {
+                -(1i64 << (bits - 1))
+            };
+            if sl == type_min && sr == -1 {
+                return None;
+            }
             Some(ctx.const_int(ty, trunc_bits(sl.wrapping_div(sr) as u64, bits)))
         }
         InstrKind::URem { lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
-            if r == 0 { return None; }
+            let (_, r) = const_int(ctx, *rhs)?;
+            if r == 0 {
+                return None;
+            }
             Some(ctx.const_int(ty, l % r))
         }
         InstrKind::SRem { lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let bits = int_bit_width(ctx, ty)?;
             let sl = sign_extend(l, bits);
             let sr = sign_extend(r, bits);
-            if sr == 0 { return None; }
+            if sr == 0 {
+                return None;
+            }
             Some(ctx.const_int(ty, trunc_bits(sl.wrapping_rem(sr) as u64, bits)))
         }
 
         // --- Bitwise ---
         InstrKind::And { lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l & r))
         }
         InstrKind::Or { lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l | r))
         }
         InstrKind::Xor { lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             Some(ctx.const_int(ty, l ^ r))
         }
 
         // --- Shifts (mask shift amount to bit_width - 1, per LLVM semantics) ---
         InstrKind::Shl { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let mask = shift_mask(ctx, ty)?;
             Some(ctx.const_int(ty, l << (r & mask)))
         }
         InstrKind::LShr { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let mask = shift_mask(ctx, ty)?;
             Some(ctx.const_int(ty, l >> (r & mask)))
         }
         InstrKind::AShr { lhs, rhs, .. } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let mask = shift_mask(ctx, ty)?;
             let bits = int_bit_width(ctx, ty)?;
             let sl = sign_extend(l, bits);
@@ -110,14 +124,18 @@ pub fn try_fold(ctx: &mut Context, kind: &InstrKind) -> Option<ConstId> {
         // --- Integer comparison → i1 result ---
         InstrKind::ICmp { pred, lhs, rhs } => {
             let (ty, l) = const_int(ctx, *lhs)?;
-            let (_, r)  = const_int(ctx, *rhs)?;
+            let (_, r) = const_int(ctx, *rhs)?;
             let bits = int_bit_width(ctx, ty)?;
             let result = icmp_eval(*pred, l, r, bits) as u64;
             Some(ctx.const_int(ctx.i1_ty, result))
         }
 
         // --- Select with constant condition ---
-        InstrKind::Select { cond, then_val, else_val } => {
+        InstrKind::Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             let (_, c) = const_int(ctx, *cond)?;
             let chosen = if c != 0 { then_val } else { else_val };
             match chosen {
@@ -163,7 +181,11 @@ fn sign_extend(val: u64, bits: u32) -> i64 {
 /// Used to bring signed-operation results back to the canonical `u64`
 /// storage format (no bits above position `bits-1` set).
 fn trunc_bits(val: u64, bits: u32) -> u64 {
-    if bits >= 64 { val } else { val & ((1u64 << bits).wrapping_sub(1)) }
+    if bits >= 64 {
+        val
+    } else {
+        val & ((1u64 << bits).wrapping_sub(1))
+    }
 }
 
 /// Extract the integer bit width from a `TypeId`.  Returns `None` for
@@ -191,15 +213,15 @@ fn shift_mask(ctx: &Context, ty: llvm_ir::TypeId) -> Option<u64> {
 
 fn icmp_eval(pred: IntPredicate, l: u64, r: u64, bits: u32) -> bool {
     match pred {
-        IntPredicate::Eq  => l == r,
-        IntPredicate::Ne  => l != r,
-        IntPredicate::Ugt => l >  r,
+        IntPredicate::Eq => l == r,
+        IntPredicate::Ne => l != r,
+        IntPredicate::Ugt => l > r,
         IntPredicate::Uge => l >= r,
-        IntPredicate::Ult => l <  r,
+        IntPredicate::Ult => l < r,
         IntPredicate::Ule => l <= r,
-        IntPredicate::Sgt => sign_extend(l, bits) >  sign_extend(r, bits),
+        IntPredicate::Sgt => sign_extend(l, bits) > sign_extend(r, bits),
         IntPredicate::Sge => sign_extend(l, bits) >= sign_extend(r, bits),
-        IntPredicate::Slt => sign_extend(l, bits) <  sign_extend(r, bits),
+        IntPredicate::Slt => sign_extend(l, bits) < sign_extend(r, bits),
         IntPredicate::Sle => sign_extend(l, bits) <= sign_extend(r, bits),
     }
 }
@@ -207,7 +229,7 @@ fn icmp_eval(pred: IntPredicate, l: u64, r: u64, bits: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Context, IntArithFlags, InstrKind};
+    use llvm_ir::{Context, InstrKind, IntArithFlags};
 
     fn c(ctx: &mut Context, v: u64) -> ValueRef {
         ValueRef::Constant(ctx.const_int(ctx.i32_ty, v))
@@ -222,7 +244,13 @@ mod tests {
             rhs: c(&mut ctx, 4),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result), &ConstantData::Int { ty: ctx.i32_ty, val: 7 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 7
+            }
+        );
     }
 
     #[test]
@@ -262,7 +290,13 @@ mod tests {
             rhs: c(&mut ctx, 7),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result), &ConstantData::Int { ty: ctx.i1_ty, val: 1 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i1_ty,
+                val: 1
+            }
+        );
     }
 
     #[test]
@@ -271,26 +305,56 @@ mod tests {
         // -1 <s 0  →  true
         let neg1 = c(&mut ctx, u64::MAX);
         let zero = c(&mut ctx, 0);
-        let kind = InstrKind::ICmp { pred: IntPredicate::Slt, lhs: neg1, rhs: zero };
+        let kind = InstrKind::ICmp {
+            pred: IntPredicate::Slt,
+            lhs: neg1,
+            rhs: zero,
+        };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result), &ConstantData::Int { ty: ctx.i1_ty, val: 1 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i1_ty,
+                val: 1
+            }
+        );
     }
 
     #[test]
     fn fold_select_constant_cond() {
         let mut ctx = Context::new();
-        let cond_true  = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 1));
+        let cond_true = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 1));
         let cond_false = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 0));
         let then_c = c(&mut ctx, 42);
         let else_c = c(&mut ctx, 99);
 
-        let k1 = InstrKind::Select { cond: cond_true,  then_val: then_c, else_val: else_c };
-        let k2 = InstrKind::Select { cond: cond_false, then_val: then_c, else_val: else_c };
+        let k1 = InstrKind::Select {
+            cond: cond_true,
+            then_val: then_c,
+            else_val: else_c,
+        };
+        let k2 = InstrKind::Select {
+            cond: cond_false,
+            then_val: then_c,
+            else_val: else_c,
+        };
 
         let r1 = try_fold(&mut ctx, &k1).unwrap();
         let r2 = try_fold(&mut ctx, &k2).unwrap();
-        assert_eq!(ctx.get_const(r1), &ConstantData::Int { ty: ctx.i32_ty, val: 42 });
-        assert_eq!(ctx.get_const(r2), &ConstantData::Int { ty: ctx.i32_ty, val: 99 });
+        assert_eq!(
+            ctx.get_const(r1),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 42
+            }
+        );
+        assert_eq!(
+            ctx.get_const(r2),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 99
+            }
+        );
     }
 
     #[test]
@@ -322,8 +386,13 @@ mod tests {
             rhs: c(&mut ctx, 32), // 32 & 31 == 0
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i32_ty, val: 1 }); // 1 << 0 = 1
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 1
+            }
+        ); // 1 << 0 = 1
     }
 
     #[test]
@@ -336,8 +405,13 @@ mod tests {
             rhs: c(&mut ctx, 4),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i32_ty, val: 16 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 16
+            }
+        );
     }
 
     #[test]
@@ -350,8 +424,13 @@ mod tests {
             rhs: c8(&mut ctx, 8), // 8 & 7 == 0
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i8_ty, val: 1 }); // 1 << 0 = 1
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i8_ty,
+                val: 1
+            }
+        ); // 1 << 0 = 1
     }
 
     #[test]
@@ -364,8 +443,13 @@ mod tests {
             rhs: c(&mut ctx, 31),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i32_ty, val: 1 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i32_ty,
+                val: 1
+            }
+        );
     }
 
     #[test]
@@ -378,8 +462,13 @@ mod tests {
             rhs: c8(&mut ctx, 7),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i8_ty, val: 0xFF }); // -1 as i8
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i8_ty,
+                val: 0xFF
+            }
+        ); // -1 as i8
     }
 
     #[test]
@@ -393,8 +482,13 @@ mod tests {
             rhs: c8(&mut ctx, 2),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i8_ty, val: 0 }); // -1 / 2 = 0
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i8_ty,
+                val: 0
+            }
+        ); // -1 / 2 = 0
     }
 
     #[test]
@@ -407,8 +501,13 @@ mod tests {
             rhs: c8(&mut ctx, 0xFE), // -2
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i8_ty, val: 2 });
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i8_ty,
+                val: 2
+            }
+        );
     }
 
     #[test]
@@ -432,8 +531,13 @@ mod tests {
             rhs: c8(&mut ctx, 3),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i8_ty, val: 0xFF }); // -1
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i8_ty,
+                val: 0xFF
+            }
+        ); // -1
     }
 
     #[test]
@@ -447,8 +551,13 @@ mod tests {
             rhs: c8(&mut ctx, 0),
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i1_ty, val: 1 }); // true
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i1_ty,
+                val: 1
+            }
+        ); // true
     }
 
     #[test]
@@ -462,7 +571,12 @@ mod tests {
             rhs: c(&mut ctx, 0xFFFF_FFFF), // -1 as i32
         };
         let result = try_fold(&mut ctx, &kind).unwrap();
-        assert_eq!(ctx.get_const(result),
-            &ConstantData::Int { ty: ctx.i1_ty, val: 1 }); // true
+        assert_eq!(
+            ctx.get_const(result),
+            &ConstantData::Int {
+                ty: ctx.i1_ty,
+                val: 1
+            }
+        ); // true
     }
 }

--- a/src/llvm-transforms/src/dce.rs
+++ b/src/llvm-transforms/src/dce.rs
@@ -7,16 +7,18 @@
 //! Side-effecting instructions (`Store`, `Call`, `Load`, `Alloca`,
 //! terminators) are never removed even if their results are unused.
 
-use std::collections::HashSet;
-use llvm_ir::{Context, Function, InstrId, InstrKind, ValueRef};
-use llvm_analysis::UseDefInfo;
 use crate::pass::FunctionPass;
+use llvm_analysis::UseDefInfo;
+use llvm_ir::{Context, Function, InstrId, InstrKind, ValueRef};
+use std::collections::HashSet;
 
 /// Dead-code elimination pass.
 pub struct DeadCodeElim;
 
 impl FunctionPass for DeadCodeElim {
-    fn name(&self) -> &'static str { "dce" }
+    fn name(&self) -> &'static str {
+        "dce"
+    }
 
     fn run_on_function(&mut self, _ctx: &mut Context, func: &mut Function) -> bool {
         let info = UseDefInfo::compute(func);
@@ -69,18 +71,22 @@ pub fn is_dce_safe(kind: &InstrKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{
-        ArgId, Builder, Context, InstrKind, Linkage, Module, ValueRef,
-    };
     use crate::pass::FunctionPass;
+    use llvm_ir::{ArgId, Builder, Context, InstrKind, Linkage, Module, ValueRef};
 
     // Build:  f(i32 %x) -> i32 { dead = add %x, %x; ret %x }
     fn make_dead_fn() -> (Context, Module) {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("f", b.ctx.i32_ty, vec![b.ctx.i32_ty],
-            vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "f",
+            b.ctx.i32_ty,
+            vec![b.ctx.i32_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let x = b.get_arg(0);
@@ -100,8 +106,11 @@ mod tests {
         let mut pass = DeadCodeElim;
         let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
         assert!(changed);
-        assert_eq!(module.functions[0].blocks[0].body.len(), 0,
-            "add removed; body should be empty");
+        assert_eq!(
+            module.functions[0].blocks[0].body.len(),
+            0,
+            "add removed; body should be empty"
+        );
     }
 
     #[test]
@@ -109,8 +118,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("g", b.ctx.i32_ty, vec![b.ctx.i32_ty, b.ctx.i32_ty],
-            vec!["a".into(), "b".into()], false, Linkage::External);
+        b.add_function(
+            "g",
+            b.ctx.i32_ty,
+            vec![b.ctx.i32_ty, b.ctx.i32_ty],
+            vec!["a".into(), "b".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let a = b.get_arg(0);
@@ -121,7 +136,11 @@ mod tests {
         let mut pass = DeadCodeElim;
         let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
         assert!(!changed);
-        assert_eq!(module.functions[0].blocks[0].body.len(), 1, "sum must remain");
+        assert_eq!(
+            module.functions[0].blocks[0].body.len(),
+            1,
+            "sum must remain"
+        );
     }
 
     #[test]

--- a/src/llvm-transforms/src/inline_pass.rs
+++ b/src/llvm-transforms/src/inline_pass.rs
@@ -29,13 +29,13 @@
 //! - The call is not recursive (callee ≠ caller by name).
 //! - The callee body has at most `size_limit` non-terminator instructions.
 
-use std::collections::HashMap;
-use llvm_ir::{
-    ArgId, BasicBlock, BlockId, Context, FunctionId, InstrId,
-    InstrKind, Instruction, Module, ValueRef,
-};
-use crate::pass::ModulePass;
 use crate::const_prop::subst_kind;
+use crate::pass::ModulePass;
+use llvm_ir::{
+    ArgId, BasicBlock, BlockId, Context, FunctionId, InstrId, InstrKind, Instruction, Module,
+    ValueRef,
+};
+use std::collections::HashMap;
 
 /// Function inlining pass.
 ///
@@ -46,22 +46,22 @@ pub struct Inliner {
 }
 
 impl Default for Inliner {
-    fn default() -> Self { Inliner { size_limit: 50 } }
+    fn default() -> Self {
+        Inliner { size_limit: 50 }
+    }
 }
 
 impl ModulePass for Inliner {
-    fn name(&self) -> &'static str { "inline" }
+    fn name(&self) -> &'static str {
+        "inline"
+    }
 
     fn run_on_module(&mut self, ctx: &mut Context, module: &mut Module) -> bool {
         let mut changed = false;
         // Inline one call site at a time to keep indices stable.
-        loop {
-            if let Some(site) = find_inline_site(ctx, module, self.size_limit) {
-                do_inline(ctx, module, site);
-                changed = true;
-            } else {
-                break;
-            }
+        while let Some(site) = find_inline_site(ctx, module, self.size_limit) {
+            do_inline(ctx, module, site);
+            changed = true;
         }
         changed
     }
@@ -73,26 +73,33 @@ impl ModulePass for Inliner {
 
 struct CallSite {
     caller_id: FunctionId,
-    block_idx: usize,   // index into caller.blocks
-    instr_pos: usize,   // position in block.body
+    block_idx: usize, // index into caller.blocks
+    instr_pos: usize, // position in block.body
     callee_id: FunctionId,
 }
 
 fn find_inline_site(ctx: &Context, module: &Module, size_limit: usize) -> Option<CallSite> {
     for (caller_idx, caller) in module.functions.iter().enumerate() {
-        if caller.is_declaration { continue; }
+        if caller.is_declaration {
+            continue;
+        }
         let caller_id = FunctionId(caller_idx as u32);
 
         for (bi, bb) in caller.blocks.iter().enumerate() {
             for (pos, &iid) in bb.body.iter().enumerate() {
-                if let InstrKind::Call { callee, callee_ty, .. } = &caller.instr(iid).kind {
+                if let InstrKind::Call {
+                    callee, callee_ty, ..
+                } = &caller.instr(iid).kind
+                {
                     // Callee must be a direct call via GlobalId.  In this IR,
                     // direct function calls use ValueRef::Global(GlobalId(i))
                     // where i is the function's index in module.functions.
                     let callee_fid = match callee {
                         ValueRef::Global(gid) => {
                             let fid = FunctionId(gid.0);
-                            if fid.0 as usize >= module.functions.len() { continue; }
+                            if fid.0 as usize >= module.functions.len() {
+                                continue;
+                            }
                             fid
                         }
                         _ => continue,
@@ -100,15 +107,23 @@ fn find_inline_site(ctx: &Context, module: &Module, size_limit: usize) -> Option
                     let callee_fn = &module.functions[callee_fid.0 as usize];
 
                     // Eligibility checks.
-                    if callee_fn.is_declaration { continue; }
-                    if callee_fid == caller_id   { continue; } // no self-recursion
-                    // Skip variadic callees.
+                    if callee_fn.is_declaration {
+                        continue;
+                    }
+                    if callee_fid == caller_id {
+                        continue;
+                    } // no self-recursion
+                      // Skip variadic callees.
                     if let llvm_ir::TypeData::Function(ft) = ctx.get_type(*callee_ty) {
-                        if ft.variadic { continue; }
+                        if ft.variadic {
+                            continue;
+                        }
                     }
                     // Size limit.
                     let body_instrs: usize = callee_fn.blocks.iter().map(|b| b.body.len()).sum();
-                    if body_instrs > size_limit { continue; }
+                    if body_instrs > size_limit {
+                        continue;
+                    }
 
                     return Some(CallSite {
                         caller_id,
@@ -128,7 +143,12 @@ fn find_inline_site(ctx: &Context, module: &Module, size_limit: usize) -> Option
 // ---------------------------------------------------------------------------
 
 fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
-    let CallSite { caller_id, block_idx, instr_pos, callee_id } = site;
+    let CallSite {
+        caller_id,
+        block_idx,
+        instr_pos,
+        callee_id,
+    } = site;
 
     // Extract call arguments and result type before borrowing mutably.
     let (call_args, call_result_ty, call_iid) = {
@@ -152,8 +172,14 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
     };
 
     // Clone callee blocks/instructions into the caller using correct offsets.
-    let callee_clone = clone_callee(ctx, module, callee_id, &call_args,
-                                    instr_offset, block_offset);
+    let callee_clone = clone_callee(
+        ctx,
+        module,
+        callee_id,
+        &call_args,
+        instr_offset,
+        block_offset,
+    );
 
     let caller = &mut module.functions[caller_id.0 as usize];
 
@@ -162,7 +188,7 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
     // post_block gets instructions instr_pos+1..end plus the original terminator.
     let orig_block = &caller.blocks[block_idx];
     let post_body: Vec<InstrId> = orig_block.body[instr_pos + 1..].to_vec();
-    let orig_term  = orig_block.terminator;
+    let orig_term = orig_block.terminator;
 
     // Truncate original block to pre-call body; remove terminator.
     caller.blocks[block_idx].body.truncate(instr_pos);
@@ -193,7 +219,9 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
     let br_to_callee = caller.alloc_instr(Instruction {
         name: None,
         ty: ctx.void_ty,
-        kind: InstrKind::Br { dest: callee_entry_bid },
+        kind: InstrKind::Br {
+            dest: callee_entry_bid,
+        },
     });
     caller.blocks[block_idx].set_terminator(br_to_callee);
 
@@ -205,7 +233,9 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
         let br_iid = caller.alloc_instr(Instruction {
             name: None,
             ty: ctx.void_ty,
-            kind: InstrKind::Br { dest: post_bid_actual },
+            kind: InstrKind::Br {
+                dest: post_bid_actual,
+            },
         });
         caller.blocks[callee_blk_id.0 as usize].terminator = Some(br_iid);
         if let Some(rv) = ret_val {
@@ -219,17 +249,20 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
             return_values[0].1
         } else {
             // Multiple return sites: insert phi at post-block head.
-            let incoming: Vec<(ValueRef, BlockId)> = return_values
-                .iter()
-                .map(|&(b, v)| (v, b))
-                .collect();
+            let incoming: Vec<(ValueRef, BlockId)> =
+                return_values.iter().map(|&(b, v)| (v, b)).collect();
             let phi_name = caller.fresh_name();
             let phi_iid = caller.alloc_instr(Instruction {
                 name: Some(phi_name),
                 ty: call_result_ty,
-                kind: InstrKind::Phi { ty: call_result_ty, incoming },
+                kind: InstrKind::Phi {
+                    ty: call_result_ty,
+                    incoming,
+                },
             });
-            caller.blocks[post_bid_actual.0 as usize].body.insert(0, phi_iid);
+            caller.blocks[post_bid_actual.0 as usize]
+                .body
+                .insert(0, phi_iid);
             ValueRef::Instruction(phi_iid)
         };
 
@@ -344,13 +377,21 @@ fn clone_callee(
         }
     }
 
-    ClonedCallee { blocks: new_blocks, instrs: new_instrs, return_sites }
+    ClonedCallee {
+        blocks: new_blocks,
+        instrs: new_instrs,
+        return_sites,
+    }
 }
 
-fn remap_val(v: ValueRef, instr_map: &HashMap<InstrId, InstrId>, call_args: &[ValueRef]) -> ValueRef {
+fn remap_val(
+    v: ValueRef,
+    instr_map: &HashMap<InstrId, InstrId>,
+    call_args: &[ValueRef],
+) -> ValueRef {
     match v {
         ValueRef::Argument(ArgId(i)) => call_args.get(i as usize).copied().unwrap_or(v),
-        ValueRef::Instruction(iid)   => ValueRef::Instruction(*instr_map.get(&iid).unwrap_or(&iid)),
+        ValueRef::Instruction(iid) => ValueRef::Instruction(*instr_map.get(&iid).unwrap_or(&iid)),
         other => other,
     }
 }
@@ -365,63 +406,240 @@ fn remap_kind(
     let b = |bid: BlockId| *block_map.get(&bid).unwrap_or(&bid);
 
     match kind {
-        InstrKind::Add  { flags, lhs, rhs } => InstrKind::Add  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Sub  { flags, lhs, rhs } => InstrKind::Sub  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Mul  { flags, lhs, rhs } => InstrKind::Mul  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::UDiv { exact, lhs, rhs } => InstrKind::UDiv { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::SDiv { exact, lhs, rhs } => InstrKind::SDiv { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::URem { lhs, rhs }        => InstrKind::URem { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::SRem { lhs, rhs }        => InstrKind::SRem { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::And  { lhs, rhs }        => InstrKind::And  { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Or   { lhs, rhs }        => InstrKind::Or   { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Xor  { lhs, rhs }        => InstrKind::Xor  { lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Shl  { flags, lhs, rhs } => InstrKind::Shl  { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::LShr { exact, lhs, rhs } => InstrKind::LShr { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::AShr { exact, lhs, rhs } => InstrKind::AShr { exact, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FAdd { flags, lhs, rhs } => InstrKind::FAdd { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FSub { flags, lhs, rhs } => InstrKind::FSub { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FMul { flags, lhs, rhs } => InstrKind::FMul { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FDiv { flags, lhs, rhs } => InstrKind::FDiv { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FRem { flags, lhs, rhs } => InstrKind::FRem { flags, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FNeg { flags, operand }  => InstrKind::FNeg { flags, operand: s(operand) },
-        InstrKind::ICmp { pred, lhs, rhs }  => InstrKind::ICmp { pred, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::FCmp { flags, pred, lhs, rhs } => InstrKind::FCmp { flags, pred, lhs: s(lhs), rhs: s(rhs) },
-        InstrKind::Alloca { alloc_ty, num_elements, align } =>
-            InstrKind::Alloca { alloc_ty, num_elements: num_elements.map(s), align },
-        InstrKind::Load  { ty, ptr, align, volatile } => InstrKind::Load  { ty, ptr: s(ptr), align, volatile },
-        InstrKind::Store { val, ptr, align, volatile } => InstrKind::Store { val: s(val), ptr: s(ptr), align, volatile },
-        InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices } =>
-            InstrKind::GetElementPtr { inbounds, base_ty, ptr: s(ptr), indices: indices.into_iter().map(s).collect() },
-        InstrKind::Trunc         { val, to } => InstrKind::Trunc         { val: s(val), to },
-        InstrKind::ZExt          { val, to } => InstrKind::ZExt          { val: s(val), to },
-        InstrKind::SExt          { val, to } => InstrKind::SExt          { val: s(val), to },
-        InstrKind::FPTrunc       { val, to } => InstrKind::FPTrunc       { val: s(val), to },
-        InstrKind::FPExt         { val, to } => InstrKind::FPExt         { val: s(val), to },
-        InstrKind::FPToUI        { val, to } => InstrKind::FPToUI        { val: s(val), to },
-        InstrKind::FPToSI        { val, to } => InstrKind::FPToSI        { val: s(val), to },
-        InstrKind::UIToFP        { val, to } => InstrKind::UIToFP        { val: s(val), to },
-        InstrKind::SIToFP        { val, to } => InstrKind::SIToFP        { val: s(val), to },
-        InstrKind::PtrToInt      { val, to } => InstrKind::PtrToInt      { val: s(val), to },
-        InstrKind::IntToPtr      { val, to } => InstrKind::IntToPtr      { val: s(val), to },
-        InstrKind::BitCast       { val, to } => InstrKind::BitCast       { val: s(val), to },
+        InstrKind::Add { flags, lhs, rhs } => InstrKind::Add {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Sub { flags, lhs, rhs } => InstrKind::Sub {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Mul { flags, lhs, rhs } => InstrKind::Mul {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::UDiv { exact, lhs, rhs } => InstrKind::UDiv {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::SDiv { exact, lhs, rhs } => InstrKind::SDiv {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::URem { lhs, rhs } => InstrKind::URem {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::SRem { lhs, rhs } => InstrKind::SRem {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::And { lhs, rhs } => InstrKind::And {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Or { lhs, rhs } => InstrKind::Or {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Xor { lhs, rhs } => InstrKind::Xor {
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Shl { flags, lhs, rhs } => InstrKind::Shl {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::LShr { exact, lhs, rhs } => InstrKind::LShr {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::AShr { exact, lhs, rhs } => InstrKind::AShr {
+            exact,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FAdd { flags, lhs, rhs } => InstrKind::FAdd {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FSub { flags, lhs, rhs } => InstrKind::FSub {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FMul { flags, lhs, rhs } => InstrKind::FMul {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FDiv { flags, lhs, rhs } => InstrKind::FDiv {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FRem { flags, lhs, rhs } => InstrKind::FRem {
+            flags,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FNeg { flags, operand } => InstrKind::FNeg {
+            flags,
+            operand: s(operand),
+        },
+        InstrKind::ICmp { pred, lhs, rhs } => InstrKind::ICmp {
+            pred,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::FCmp {
+            flags,
+            pred,
+            lhs,
+            rhs,
+        } => InstrKind::FCmp {
+            flags,
+            pred,
+            lhs: s(lhs),
+            rhs: s(rhs),
+        },
+        InstrKind::Alloca {
+            alloc_ty,
+            num_elements,
+            align,
+        } => InstrKind::Alloca {
+            alloc_ty,
+            num_elements: num_elements.map(s),
+            align,
+        },
+        InstrKind::Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Load {
+            ty,
+            ptr: s(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Store {
+            val: s(val),
+            ptr: s(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        } => InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr: s(ptr),
+            indices: indices.into_iter().map(s).collect(),
+        },
+        InstrKind::Trunc { val, to } => InstrKind::Trunc { val: s(val), to },
+        InstrKind::ZExt { val, to } => InstrKind::ZExt { val: s(val), to },
+        InstrKind::SExt { val, to } => InstrKind::SExt { val: s(val), to },
+        InstrKind::FPTrunc { val, to } => InstrKind::FPTrunc { val: s(val), to },
+        InstrKind::FPExt { val, to } => InstrKind::FPExt { val: s(val), to },
+        InstrKind::FPToUI { val, to } => InstrKind::FPToUI { val: s(val), to },
+        InstrKind::FPToSI { val, to } => InstrKind::FPToSI { val: s(val), to },
+        InstrKind::UIToFP { val, to } => InstrKind::UIToFP { val: s(val), to },
+        InstrKind::SIToFP { val, to } => InstrKind::SIToFP { val: s(val), to },
+        InstrKind::PtrToInt { val, to } => InstrKind::PtrToInt { val: s(val), to },
+        InstrKind::IntToPtr { val, to } => InstrKind::IntToPtr { val: s(val), to },
+        InstrKind::BitCast { val, to } => InstrKind::BitCast { val: s(val), to },
         InstrKind::AddrSpaceCast { val, to } => InstrKind::AddrSpaceCast { val: s(val), to },
-        InstrKind::Select { cond, then_val, else_val } =>
-            InstrKind::Select { cond: s(cond), then_val: s(then_val), else_val: s(else_val) },
-        InstrKind::Phi { ty, incoming } =>
-            InstrKind::Phi { ty, incoming: incoming.into_iter().map(|(v, blk)| (s(v), b(blk))).collect() },
-        InstrKind::ExtractValue { aggregate, indices } => InstrKind::ExtractValue { aggregate: s(aggregate), indices },
-        InstrKind::InsertValue  { aggregate, val, indices } => InstrKind::InsertValue { aggregate: s(aggregate), val: s(val), indices },
-        InstrKind::ExtractElement { vec, idx }       => InstrKind::ExtractElement { vec: s(vec), idx: s(idx) },
-        InstrKind::InsertElement  { vec, val, idx }  => InstrKind::InsertElement  { vec: s(vec), val: s(val), idx: s(idx) },
-        InstrKind::ShuffleVector  { v1, v2, mask }   => InstrKind::ShuffleVector  { v1: s(v1), v2: s(v2), mask },
-        InstrKind::Call { tail, callee_ty, callee, args } =>
-            InstrKind::Call { tail, callee_ty, callee: s(callee), args: args.into_iter().map(s).collect() },
-        InstrKind::Ret { val }                           => InstrKind::Ret { val: val.map(s) },
-        InstrKind::Br  { dest }                          => InstrKind::Br  { dest: b(dest) },
-        InstrKind::CondBr { cond, then_dest, else_dest } =>
-            InstrKind::CondBr { cond: s(cond), then_dest: b(then_dest), else_dest: b(else_dest) },
-        InstrKind::Switch { val, default, cases } =>
-            InstrKind::Switch { val: s(val), default: b(default), cases: cases.into_iter().map(|(v, blk)| (s(v), b(blk))).collect() },
+        InstrKind::Select {
+            cond,
+            then_val,
+            else_val,
+        } => InstrKind::Select {
+            cond: s(cond),
+            then_val: s(then_val),
+            else_val: s(else_val),
+        },
+        InstrKind::Phi { ty, incoming } => InstrKind::Phi {
+            ty,
+            incoming: incoming
+                .into_iter()
+                .map(|(v, blk)| (s(v), b(blk)))
+                .collect(),
+        },
+        InstrKind::ExtractValue { aggregate, indices } => InstrKind::ExtractValue {
+            aggregate: s(aggregate),
+            indices,
+        },
+        InstrKind::InsertValue {
+            aggregate,
+            val,
+            indices,
+        } => InstrKind::InsertValue {
+            aggregate: s(aggregate),
+            val: s(val),
+            indices,
+        },
+        InstrKind::ExtractElement { vec, idx } => InstrKind::ExtractElement {
+            vec: s(vec),
+            idx: s(idx),
+        },
+        InstrKind::InsertElement { vec, val, idx } => InstrKind::InsertElement {
+            vec: s(vec),
+            val: s(val),
+            idx: s(idx),
+        },
+        InstrKind::ShuffleVector { v1, v2, mask } => InstrKind::ShuffleVector {
+            v1: s(v1),
+            v2: s(v2),
+            mask,
+        },
+        InstrKind::Call {
+            tail,
+            callee_ty,
+            callee,
+            args,
+        } => InstrKind::Call {
+            tail,
+            callee_ty,
+            callee: s(callee),
+            args: args.into_iter().map(s).collect(),
+        },
+        InstrKind::Ret { val } => InstrKind::Ret { val: val.map(s) },
+        InstrKind::Br { dest } => InstrKind::Br { dest: b(dest) },
+        InstrKind::CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => InstrKind::CondBr {
+            cond: s(cond),
+            then_dest: b(then_dest),
+            else_dest: b(else_dest),
+        },
+        InstrKind::Switch {
+            val,
+            default,
+            cases,
+        } => InstrKind::Switch {
+            val: s(val),
+            default: b(default),
+            cases: cases.into_iter().map(|(v, blk)| (s(v), b(blk))).collect(),
+        },
         InstrKind::Unreachable => InstrKind::Unreachable,
     }
 }
@@ -433,8 +651,8 @@ fn remap_kind(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Builder, Context, Function, GlobalId, InstrKind, Linkage, Module, ValueRef};
     use crate::pass::ModulePass;
+    use llvm_ir::{Builder, Context, Function, GlobalId, InstrKind, Linkage, Module, ValueRef};
 
     // Build:
     //   define i32 @add(i32 %a, i32 %b) { ret (a + b) }
@@ -448,8 +666,14 @@ mod tests {
         // Define @add.
         {
             let mut b = Builder::new(&mut ctx, &mut module);
-            b.add_function("add", b.ctx.i32_ty, vec![b.ctx.i32_ty, b.ctx.i32_ty],
-                vec!["a".into(), "b".into()], false, Linkage::External);
+            b.add_function(
+                "add",
+                b.ctx.i32_ty,
+                vec![b.ctx.i32_ty, b.ctx.i32_ty],
+                vec!["a".into(), "b".into()],
+                false,
+                Linkage::External,
+            );
             let entry = b.add_block("entry");
             b.position_at_end(entry);
             let a = b.get_arg(0);
@@ -466,14 +690,26 @@ mod tests {
         {
             let mut b = Builder::new(&mut ctx, &mut module);
             let i32_ty = b.ctx.i32_ty;
-            b.add_function("caller", i32_ty, vec![i32_ty, i32_ty],
-                vec!["x".into(), "y".into()], false, Linkage::External);
+            b.add_function(
+                "caller",
+                i32_ty,
+                vec![i32_ty, i32_ty],
+                vec!["x".into(), "y".into()],
+                false,
+                Linkage::External,
+            );
             let entry = b.add_block("entry");
             b.position_at_end(entry);
             let x = b.get_arg(0);
             let y = b.get_arg(1);
             // @add is at index 0 → ValueRef::Global(GlobalId(0)) references FunctionId(0).
-            let r = b.build_call("r", i32_ty, add_callee_ty, ValueRef::Global(GlobalId(0)), vec![x, y]);
+            let r = b.build_call(
+                "r",
+                i32_ty,
+                add_callee_ty,
+                ValueRef::Global(GlobalId(0)),
+                vec![x, y],
+            );
             b.build_ret(r);
         }
 
@@ -526,19 +762,29 @@ mod tests {
 
         let caller = &module.functions[1];
         // After inlining a 1-block callee, @caller has: pre-block + 1 callee block + post-block = 3.
-        assert_eq!(caller.blocks.len(), 3,
-            "expected pre + callee_entry + post = 3 blocks after inlining");
+        assert_eq!(
+            caller.blocks.len(),
+            3,
+            "expected pre + callee_entry + post = 3 blocks after inlining"
+        );
 
         // The pre-block (block 0) should end with a Br to the callee entry.
         let pre_term = caller.blocks[0].terminator.unwrap();
-        assert!(matches!(caller.instr(pre_term).kind, InstrKind::Br { .. }),
-            "pre-block should end with unconditional Br");
+        assert!(
+            matches!(caller.instr(pre_term).kind, InstrKind::Br { .. }),
+            "pre-block should end with unconditional Br"
+        );
 
         // No Call instructions should remain in the caller body.
         let has_call = caller.blocks.iter().any(|bb| {
-            bb.body.iter().any(|&iid| matches!(caller.instr(iid).kind, InstrKind::Call { .. }))
+            bb.body
+                .iter()
+                .any(|&iid| matches!(caller.instr(iid).kind, InstrKind::Call { .. }))
         });
-        assert!(!has_call, "call instruction should have been removed after inlining");
+        assert!(
+            !has_call,
+            "call instruction should have been removed after inlining"
+        );
     }
 
     #[test]

--- a/src/llvm-transforms/src/lib.rs
+++ b/src/llvm-transforms/src/lib.rs
@@ -1,14 +1,14 @@
 //! Optimization passes: mem2reg, DCE, constant folding/propagation, and inlining.
 
-pub mod constant_fold;
 pub mod const_prop;
+pub mod constant_fold;
 pub mod dce;
 pub mod inline_pass;
 pub mod mem2reg;
 pub mod pass;
 
-pub use constant_fold::try_fold;
 pub use const_prop::ConstProp;
+pub use constant_fold::try_fold;
 pub use dce::DeadCodeElim;
 pub use inline_pass::Inliner;
 pub use mem2reg::Mem2Reg;

--- a/src/llvm-transforms/src/mem2reg.rs
+++ b/src/llvm-transforms/src/mem2reg.rs
@@ -15,27 +15,33 @@
 //! After the pass, all promoted allocas, their loads, and their stores are
 //! removed.  Non-promotable memory operations are left unchanged.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use llvm_ir::{BlockId, Context, Function, InstrId, InstrKind, Instruction, TypeId, ValueRef};
-use llvm_analysis::{Cfg, DomTree};
-use crate::pass::FunctionPass;
 use crate::const_prop::subst_kind;
+use crate::pass::FunctionPass;
+use llvm_analysis::{Cfg, DomTree};
+use llvm_ir::{BlockId, Context, Function, InstrId, InstrKind, Instruction, TypeId, ValueRef};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// mem2reg pass.
 pub struct Mem2Reg;
 
 impl FunctionPass for Mem2Reg {
-    fn name(&self) -> &'static str { "mem2reg" }
+    fn name(&self) -> &'static str {
+        "mem2reg"
+    }
 
     fn run_on_function(&mut self, ctx: &mut Context, func: &mut Function) -> bool {
-        if func.blocks.is_empty() { return false; }
+        if func.blocks.is_empty() {
+            return false;
+        }
 
         let promotable = find_promotable_allocas(func);
-        if promotable.is_empty() { return false; }
+        if promotable.is_empty() {
+            return false;
+        }
 
         let cfg = Cfg::compute(func);
         let dom = DomTree::compute(func, &cfg);
-        let df  = dom.dominance_frontier(&cfg);
+        let df = dom.dominance_frontier(&cfg);
 
         // Step 2 — insert phi nodes at the IDF of each alloca's def sites.
         let phi_map = insert_phis(ctx, func, &promotable, &df, &cfg);
@@ -62,14 +68,24 @@ impl FunctionPass for Mem2Reg {
         }
 
         rename_dfs(
-            BlockId(0), func, &promotable, &phi_map, &cfg,
-            &dom_children, &mut stacks, &mut subst,
-            &mut instrs_to_remove, &mut phi_updates,
+            BlockId(0),
+            func,
+            &promotable,
+            &phi_map,
+            &cfg,
+            &dom_children,
+            &mut stacks,
+            &mut subst,
+            &mut instrs_to_remove,
+            &mut phi_updates,
         );
 
         // Apply phi incoming-value updates collected during the rename.
         for (phi_iid, pred, new_val) in phi_updates {
-            if let InstrKind::Phi { ref mut incoming, .. } = func.instr_mut(phi_iid).kind {
+            if let InstrKind::Phi {
+                ref mut incoming, ..
+            } = func.instr_mut(phi_iid).kind
+            {
                 for (val, blk) in incoming.iter_mut() {
                     if *blk == pred {
                         *val = new_val;
@@ -108,11 +124,24 @@ impl FunctionPass for Mem2Reg {
 ///   `store val, ptr` (address never captured or passed elsewhere).
 fn find_promotable_allocas(func: &Function) -> HashMap<InstrId, TypeId> {
     let mut result = HashMap::new();
-    let entry = match func.blocks.first() { Some(b) => b, None => return result };
+    let entry = match func.blocks.first() {
+        Some(b) => b,
+        None => return result,
+    };
 
-    let alloca_iids: Vec<InstrId> = entry.body.iter()
+    let alloca_iids: Vec<InstrId> = entry
+        .body
+        .iter()
         .copied()
-        .filter(|&iid| matches!(func.instr(iid).kind, InstrKind::Alloca { num_elements: None, .. }))
+        .filter(|&iid| {
+            matches!(
+                func.instr(iid).kind,
+                InstrKind::Alloca {
+                    num_elements: None,
+                    ..
+                }
+            )
+        })
         .collect();
 
     'outer: for &alloca_iid in &alloca_iids {
@@ -125,11 +154,22 @@ fn find_promotable_allocas(func: &Function) -> HashMap<InstrId, TypeId> {
         for instr in &func.instructions {
             match &instr.kind {
                 // Non-volatile load from the alloca address — OK.
-                InstrKind::Load { ptr: p, volatile: false, .. } if *p == ptr => {}
+                InstrKind::Load {
+                    ptr: p,
+                    volatile: false,
+                    ..
+                } if *p == ptr => {}
                 // Non-volatile store of a non-self value to the alloca address — OK.
-                InstrKind::Store { ptr: p, val, volatile: false, .. } if *p == ptr => {
+                InstrKind::Store {
+                    ptr: p,
+                    val,
+                    volatile: false,
+                    ..
+                } if *p == ptr => {
                     // Don't promote if the alloca's address is stored through itself.
-                    if *val == ptr { continue 'outer; }
+                    if *val == ptr {
+                        continue 'outer;
+                    }
                 }
                 // Any other use of the alloca's address → not promotable.
                 kind if kind.operands().contains(&ptr) => continue 'outer,
@@ -174,11 +214,17 @@ fn insert_phis(
             let phi_iid = func.alloc_instr(Instruction {
                 name: Some(phi_name),
                 ty: alloc_ty,
-                kind: InstrKind::Phi { ty: alloc_ty, incoming },
+                kind: InstrKind::Phi {
+                    ty: alloc_ty,
+                    incoming,
+                },
             });
             // Phi nodes go at the front of the block body.
             func.blocks[block_id.0 as usize].body.insert(0, phi_iid);
-            phi_map.entry(block_id).or_default().push((alloca_iid, phi_iid));
+            phi_map
+                .entry(block_id)
+                .or_default()
+                .push((alloca_iid, phi_iid));
         }
     }
 
@@ -191,7 +237,10 @@ fn find_def_blocks(func: &Function, alloca_iid: InstrId) -> Vec<BlockId> {
     for (bi, bb) in func.blocks.iter().enumerate() {
         for iid in bb.instrs() {
             if let InstrKind::Store { ptr: p, .. } = &func.instr(iid).kind {
-                if *p == ptr { result.push(BlockId(bi as u32)); break; }
+                if *p == ptr {
+                    result.push(BlockId(bi as u32));
+                    break;
+                }
             }
         }
     }
@@ -217,6 +266,7 @@ fn iterated_df(def_blocks: &[BlockId], df: &HashMap<BlockId, Vec<BlockId>>) -> V
 
 /// Rename all loads and stores for the promotable allocas in the subtree
 /// rooted at `block` in the dominator tree.
+#[allow(clippy::too_many_arguments)]
 fn rename_dfs(
     block: BlockId,
     func: &mut Function,
@@ -248,29 +298,34 @@ fn rename_dfs(
             InstrKind::Alloca { .. } if promotable.contains_key(&iid) => {
                 // The alloca itself — nothing to push; removal handled later.
             }
-            InstrKind::Load { ptr, volatile: false, .. } => {
-                if let ValueRef::Instruction(alloca_iid) = ptr {
-                    if let Some(stack) = stacks.get(&alloca_iid) {
-                        let def = *stack.last().unwrap();
-                        subst.insert(iid, def);
-                        instrs_to_remove.insert(iid);
-                    }
+            InstrKind::Load {
+                ptr: ValueRef::Instruction(alloca_iid),
+                volatile: false,
+                ..
+            } => {
+                if let Some(stack) = stacks.get(&alloca_iid) {
+                    let def = *stack.last().unwrap();
+                    subst.insert(iid, def);
+                    instrs_to_remove.insert(iid);
                 }
             }
-            InstrKind::Store { val, ptr, volatile: false, .. } => {
-                if let ValueRef::Instruction(alloca_iid) = ptr {
-                    if stacks.contains_key(&alloca_iid) {
-                        // If the stored value is itself a replaced load, resolve it.
-                        let resolved = if let ValueRef::Instruction(vid) = val {
-                            subst.get(&vid).copied().unwrap_or(val)
-                        } else {
-                            val
-                        };
-                        let stack = stacks.get_mut(&alloca_iid).unwrap();
-                        saved.push((alloca_iid, stack.len()));
-                        stack.push(resolved);
-                        instrs_to_remove.insert(iid);
-                    }
+            InstrKind::Store {
+                val,
+                ptr: ValueRef::Instruction(alloca_iid),
+                volatile: false,
+                ..
+            } => {
+                if stacks.contains_key(&alloca_iid) {
+                    // If the stored value is itself a replaced load, resolve it.
+                    let resolved = if let ValueRef::Instruction(vid) = val {
+                        subst.get(&vid).copied().unwrap_or(val)
+                    } else {
+                        val
+                    };
+                    let stack = stacks.get_mut(&alloca_iid).unwrap();
+                    saved.push((alloca_iid, stack.len()));
+                    stack.push(resolved);
+                    instrs_to_remove.insert(iid);
                 }
             }
             _ => {}
@@ -291,8 +346,16 @@ fn rename_dfs(
     let children = dom_children[block.0 as usize].clone();
     for child in children {
         rename_dfs(
-            child, func, promotable, phi_map, cfg, dom_children,
-            stacks, subst, instrs_to_remove, phi_updates,
+            child,
+            func,
+            promotable,
+            phi_map,
+            cfg,
+            dom_children,
+            stacks,
+            subst,
+            instrs_to_remove,
+            phi_updates,
         );
     }
 
@@ -309,8 +372,8 @@ fn rename_dfs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Builder, Context, Linkage, Module, ValueRef};
     use crate::pass::FunctionPass;
+    use llvm_ir::{Builder, Context, Linkage, Module, ValueRef};
 
     // Build:  f(i32 %x) -> i32 {
     //   entry: %p = alloca i32
@@ -323,8 +386,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("f", b.ctx.i32_ty, vec![b.ctx.i32_ty],
-            vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "f",
+            b.ctx.i32_ty,
+            vec![b.ctx.i32_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let x = b.get_arg(0);
@@ -348,14 +417,20 @@ mod tests {
 
         // After: entry body is empty (all three promoted away).
         let func = &module.functions[0];
-        assert_eq!(func.blocks[0].body.len(), 0,
-            "alloca, store, and load should all be removed");
+        assert_eq!(
+            func.blocks[0].body.len(),
+            0,
+            "alloca, store, and load should all be removed"
+        );
 
         // ret should use %x (ArgId 0) directly.
         let tid = func.blocks[0].terminator.unwrap();
         if let InstrKind::Ret { val: Some(v) } = &func.instr(tid).kind {
-            assert_eq!(*v, ValueRef::Argument(llvm_ir::ArgId(0)),
-                "ret should use arg %x directly after mem2reg");
+            assert_eq!(
+                *v,
+                ValueRef::Argument(llvm_ir::ArgId(0)),
+                "ret should use arg %x directly after mem2reg"
+            );
         } else {
             panic!("terminator should be ret with a value");
         }
@@ -373,12 +448,18 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("f", b.ctx.i32_ty, vec![b.ctx.i1_ty],
-            vec!["cond".into()], false, Linkage::External);
-        let entry  = b.add_block("entry");
+        b.add_function(
+            "f",
+            b.ctx.i32_ty,
+            vec![b.ctx.i1_ty],
+            vec!["cond".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
         let then_b = b.add_block("then");
         let else_b = b.add_block("else");
-        let merge  = b.add_block("merge");
+        let merge = b.add_block("merge");
 
         b.position_at_end(entry);
         let cond = b.get_arg(0);
@@ -419,7 +500,10 @@ mod tests {
         );
         // ret should use the phi result.
         let tid = func.blocks[3].terminator.unwrap();
-        if let InstrKind::Ret { val: Some(ValueRef::Instruction(phi_iid)) } = &func.instr(tid).kind {
+        if let InstrKind::Ret {
+            val: Some(ValueRef::Instruction(phi_iid)),
+        } = &func.instr(tid).kind
+        {
             assert!(
                 matches!(func.instr(*phi_iid).kind, InstrKind::Phi { .. }),
                 "ret should reference the inserted phi"
@@ -444,7 +528,13 @@ mod tests {
         b.position_at_end(entry);
         let p = b.build_alloca("p", b.ctx.i32_ty);
         // Call with p as argument — captures address.
-        b.build_call("", b.ctx.void_ty, callee_ty, ValueRef::Global(llvm_ir::GlobalId(0)), vec![p]);
+        b.build_call(
+            "",
+            b.ctx.void_ty,
+            callee_ty,
+            ValueRef::Global(llvm_ir::GlobalId(0)),
+            vec![p],
+        );
         let c0 = b.const_int(b.ctx.i32_ty, 0);
         b.build_ret(c0);
 

--- a/src/llvm-transforms/src/pass.rs
+++ b/src/llvm-transforms/src/pass.rs
@@ -114,11 +114,13 @@ impl Default for PassManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{BasicBlock, Function, Instruction, InstrKind, Linkage, Module};
+    use llvm_ir::{BasicBlock, Function, InstrKind, Instruction, Linkage, Module};
 
     struct NoOpPass;
     impl FunctionPass for NoOpPass {
-        fn name(&self) -> &'static str { "noop" }
+        fn name(&self) -> &'static str {
+            "noop"
+        }
         fn run_on_function(&mut self, _ctx: &mut Context, _func: &mut Function) -> bool {
             false
         }
@@ -129,7 +131,9 @@ mod tests {
         let mut func = Function::new("f", fn_ty, vec![], Linkage::External);
         let mut bb = BasicBlock::new("entry");
         let iid = func.alloc_instr(Instruction {
-            name: None, ty: ctx.void_ty, kind: InstrKind::Unreachable,
+            name: None,
+            ty: ctx.void_ty,
+            kind: InstrKind::Unreachable,
         });
         bb.set_terminator(iid);
         func.add_block(bb);
@@ -166,7 +170,9 @@ mod tests {
 
         struct PanicPass;
         impl FunctionPass for PanicPass {
-            fn name(&self) -> &'static str { "panic" }
+            fn name(&self) -> &'static str {
+                "panic"
+            }
             fn run_on_function(&mut self, _: &mut Context, _: &mut Function) -> bool {
                 panic!("must not run on a declaration");
             }


### PR DESCRIPTION
## Summary

- Fixed 1 deny-level clippy error (`never_loop` in parser.rs that blocked compilation)
- Fixed ~15 clippy warnings across 13 source files covering 10+ lint categories
- Applied `cargo fmt` across all workspace crates

## Lint fixes

| Lint | File(s) |
|------|---------|
| `never_loop` | `llvm-ir-parser/src/parser.rs` — `while` → `if` for pointer type parsing |
| `needless_return` | `llvm-ir-parser/src/lexer.rs` |
| `should_implement_trait` | `llvm-ir-parser/src/lexer.rs` — `#[allow]` on `Lexer::next()` |
| `write_with_newline` | `llvm-ir/src/printer.rs` — use `writeln!` |
| `needless_range_loop` | `llvm-ir/src/printer.rs`, `llvm-analysis/src/{cfg,dominators,loops}.rs` |
| `let_and_return` | `llvm-ir/src/builder.rs` |
| `into_iter_on_ref` | `llvm-ir/src/instruction.rs` — `.iter()` instead of `.into_iter()` |
| `or_fun_call` | `llvm-bitcode/src/reader.rs` — lazy `ok_or_else` |
| `too_many_arguments` | `llvm-transforms/src/mem2reg.rs` — `#[allow]` on `rename_dfs` |
| `collapsible_match` | `llvm-transforms/src/mem2reg.rs`, `llvm-target-x86/src/encode.rs`, `llvm-target-arm/src/encode.rs` |
| `same_item_push` | `llvm-codegen/src/emit.rs` — `buf.resize()` |
| `while_let_loop` | `llvm-transforms/src/inline_pass.rs` |

## Test plan

- [x] `cargo clippy --all-targets` — clean (no warnings, no errors)
- [x] `cargo fmt --check` — FORMAT OK
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)