### PR TITLE
Finish issue #87: IPCP and dead-arg elimination in O3

### DIFF
--- a/src/llvm-bench/src/lib.rs
+++ b/src/llvm-bench/src/lib.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use llvm_ir::Module;
+    use llvm_ir::{Builder, GlobalId, Linkage, Module, ValueRef};
     use llvm_ir_parser::parser::parse;
+    use llvm_ir::InstrKind;
     use llvm_transforms::{build_pipeline, pass::PassManager, OptLevel};
 
     const FIXTURE: &str = include_str!("../fixtures/sample.ll");
@@ -26,6 +27,92 @@ mod tests {
         instruction_count(&module)
     }
 
+    fn call_arg_pressure(module: &Module) -> usize {
+        module
+            .functions
+            .iter()
+            .flat_map(|f| &f.instructions)
+            .map(|i| match &i.kind {
+                InstrKind::Call { args, .. } => args.len(),
+                _ => 0,
+            })
+            .sum()
+    }
+
+    fn build_ipa_fixture() -> (llvm_ir::Context, Module) {
+        let mut ctx = llvm_ir::Context::new();
+        let mut module = Module::new("ipa");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        let i64_ty = b.ctx.i64_ty;
+        let worker_ty = b
+            .ctx
+            .mk_fn_type(i64_ty, vec![i64_ty, i64_ty, i64_ty, i64_ty], false);
+
+        b.add_function(
+            "worker",
+            i64_ty,
+            vec![i64_ty, i64_ty, i64_ty, i64_ty],
+            vec!["x".into(), "y".into(), "dead1".into(), "dead2".into()],
+            false,
+            Linkage::External,
+        );
+        let w_entry = b.add_block("worker.entry");
+        b.position_at_end(w_entry);
+        let x = b.get_arg(0);
+        let y = b.get_arg(1);
+        let a = b.build_add("a", x, y);
+        b.build_ret(a);
+
+        b.add_function(
+            "driver",
+            i64_ty,
+            vec![i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let d_entry = b.add_block("driver.entry");
+        b.position_at_end(d_entry);
+        let x0 = b.get_arg(0);
+        let c7 = b.const_int(i64_ty, 7);
+        let c100 = b.const_int(i64_ty, 100);
+        let c200 = b.const_int(i64_ty, 200);
+        let c101 = b.const_int(i64_ty, 101);
+        let c201 = b.const_int(i64_ty, 201);
+        let c102 = b.const_int(i64_ty, 102);
+        let c202 = b.const_int(i64_ty, 202);
+        let c1 = b.build_call(
+            "c1",
+            i64_ty,
+            worker_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![x0, c7, c100, c200],
+        );
+        let c2 = b.build_call(
+            "c2",
+            i64_ty,
+            worker_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![c1, c7, c101, c201],
+        );
+        let c3 = b.build_call(
+            "c3",
+            i64_ty,
+            worker_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![c2, c7, c102, c202],
+        );
+        b.build_ret(c3);
+        (ctx, module)
+    }
+
+    fn optimized_call_arg_pressure_from_builder(level: OptLevel) -> usize {
+        let (mut ctx, mut module) = build_ipa_fixture();
+        let mut pm: PassManager = build_pipeline(level);
+        pm.run_until_fixed_point(&mut ctx, &mut module, 8);
+        call_arg_pressure(&module)
+    }
+
     #[test]
     fn sample_ll_o2_reduces_ir_instruction_count_by_at_least_10_percent_vs_o1() {
         let o1 = optimized_instruction_count(OptLevel::O1);
@@ -35,6 +122,18 @@ mod tests {
             "expected >=10% reduction on sample.ll (o1={}, o2={})",
             o1,
             o2
+        );
+    }
+
+    #[test]
+    fn ipa_fixture_o3_reduces_call_arg_pressure_vs_o2() {
+        let o2 = optimized_call_arg_pressure_from_builder(OptLevel::O2);
+        let o3 = optimized_call_arg_pressure_from_builder(OptLevel::O3);
+        assert!(
+            o3 < o2,
+            "expected O3 IPA passes to reduce call-arg pressure (o2={}, o3={})",
+            o2,
+            o3
         );
     }
 }

--- a/src/llvm-transforms/src/dead_arg_elim.rs
+++ b/src/llvm-transforms/src/dead_arg_elim.rs
@@ -1,0 +1,148 @@
+//! Inter-procedural dead argument elimination.
+
+use crate::pass::ModulePass;
+use llvm_ir::{
+    Context, FunctionId, GlobalId, InstrKind, Module, TypeData, ValueRef,
+};
+
+/// Removes trailing unused function parameters and rewrites direct callsites.
+///
+/// This intentionally targets only trailing dead args to avoid argument
+/// reindexing across function bodies.
+pub struct DeadArgElim;
+
+impl ModulePass for DeadArgElim {
+    fn name(&self) -> &'static str {
+        "dead-arg-elim"
+    }
+
+    fn run_on_module(&mut self, ctx: &mut Context, module: &mut Module) -> bool {
+        let mut changed = false;
+        let mut updates: Vec<(FunctionId, usize)> = Vec::new();
+
+        for (fi, f) in module.functions.iter().enumerate() {
+            if f.is_declaration || f.args.is_empty() {
+                continue;
+            }
+            let mut max_used: Option<usize> = None;
+            for instr in &f.instructions {
+                for op in instr.kind.operands() {
+                    if let ValueRef::Argument(aid) = op {
+                        let idx = aid.0 as usize;
+                        max_used = Some(max_used.map_or(idx, |m| m.max(idx)));
+                    }
+                }
+            }
+            let keep_len = max_used.map_or(0, |m| m + 1).min(f.args.len());
+            if keep_len < f.args.len() {
+                updates.push((FunctionId(fi as u32), keep_len));
+            }
+        }
+
+        for (fid, keep_len) in updates {
+            let f = &mut module.functions[fid.0 as usize];
+            let old_len = f.args.len();
+            if keep_len >= old_len {
+                continue;
+            }
+            f.args.truncate(keep_len);
+            f.arg_names.retain(|_, aid| (aid.0 as usize) < keep_len);
+
+            if let TypeData::Function(ft) = ctx.get_type(f.ty).clone() {
+                let mut params = ft.params;
+                params.truncate(keep_len);
+                f.ty = ctx.mk_fn_type(ft.ret, params, ft.variadic);
+            }
+            let new_ty = f.ty;
+
+            for caller in &mut module.functions {
+                for instr in &mut caller.instructions {
+                    let InstrKind::Call {
+                        callee,
+                        callee_ty,
+                        args,
+                        ..
+                    } = &mut instr.kind
+                    else {
+                        continue;
+                    };
+                    if *callee == ValueRef::Global(GlobalId(fid.0)) {
+                        args.truncate(keep_len);
+                        *callee_ty = new_ty;
+                    }
+                }
+            }
+            changed = true;
+        }
+
+        changed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llvm_ir::{Builder, Linkage};
+
+    #[test]
+    fn dead_arg_elim_removes_trailing_unused_arg_and_rewrites_calls() {
+        let mut ctx = Context::new();
+        let mut module = Module::new("m");
+        let mut b = Builder::new(&mut ctx, &mut module);
+
+        b.add_function(
+            "f",
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty, b.ctx.i64_ty, b.ctx.i64_ty],
+            vec!["a".into(), "b".into(), "dead".into()],
+            false,
+            Linkage::External,
+        );
+        let f_entry = b.add_block("f.entry");
+        b.position_at_end(f_entry);
+        let a = b.get_arg(0);
+        let bv = b.get_arg(1);
+        let s = b.build_add("s", a, bv);
+        b.build_ret(s);
+
+        b.add_function(
+            "caller",
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let c_entry = b.add_block("caller.entry");
+        b.position_at_end(c_entry);
+        let x = b.get_arg(0);
+        let c1 = b.const_int(b.ctx.i64_ty, 1);
+        let c2 = b.const_int(b.ctx.i64_ty, 2);
+        let call_ty = b
+            .ctx
+            .mk_fn_type(b.ctx.i64_ty, vec![b.ctx.i64_ty, b.ctx.i64_ty, b.ctx.i64_ty], false);
+        let r = b.build_call(
+            "r",
+            b.ctx.i64_ty,
+            call_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![x, c1, c2],
+        );
+        b.build_ret(r);
+
+        let mut pass = DeadArgElim;
+        let changed = pass.run_on_module(&mut ctx, &mut module);
+        assert!(changed);
+        assert_eq!(module.functions[0].args.len(), 2);
+        let call = module.functions[1]
+            .instructions
+            .iter()
+            .find(|i| matches!(i.kind, InstrKind::Call { .. }))
+            .expect("call exists");
+        if let InstrKind::Call { args, .. } = &call.kind {
+            assert_eq!(args.len(), 2);
+        } else {
+            panic!("expected call");
+        }
+    }
+}

--- a/src/llvm-transforms/src/ipcp.rs
+++ b/src/llvm-transforms/src/ipcp.rs
@@ -1,0 +1,235 @@
+//! Inter-procedural constant propagation (IPCP).
+
+use crate::{const_prop::ConstProp, pass::ModulePass, value_rewrite::rewrite_values_in_kind};
+use llvm_ir::{
+    ArgId, Context, Function, FunctionId, GlobalId, InstrKind, Module, ValueRef,
+};
+
+/// Simple IPCP pass:
+/// - detect a direct callee argument that is constant across all direct callsites
+/// - clone callee and substitute that argument with the constant
+/// - redirect matching callsites to the specialized clone
+pub struct Ipcp;
+
+impl ModulePass for Ipcp {
+    fn name(&self) -> &'static str {
+        "ipcp"
+    }
+
+    fn run_on_module(&mut self, ctx: &mut Context, module: &mut Module) -> bool {
+        let mut changed = false;
+
+        for callee_idx in 0..module.functions.len() {
+            let callee_id = FunctionId(callee_idx as u32);
+            if module.functions[callee_idx].is_declaration || module.functions[callee_idx].args.is_empty() {
+                continue;
+            }
+
+            let callsites = collect_direct_calls(module, callee_id);
+            if callsites.is_empty() {
+                continue;
+            }
+            let Some((arg_idx, const_val)) = find_constant_arg(&callsites) else {
+                continue;
+            };
+
+            let spec_name = format!(
+                "{}.ipcp.a{}.c{}",
+                module.functions[callee_idx].name, arg_idx, const_val.0
+            );
+            let spec_id = if let Some(fid) = module.get_function_id(&spec_name) {
+                fid
+            } else {
+                let mut spec = clone_specialized_function(
+                    &module.functions[callee_idx],
+                    &spec_name,
+                    ArgId(arg_idx as u32),
+                    ValueRef::Constant(const_val),
+                );
+                let mut cp = ConstProp;
+                let _ = crate::pass::FunctionPass::run_on_function(&mut cp, ctx, &mut spec);
+                module.add_function(spec)
+            };
+
+            let spec_ty = module.functions[spec_id.0 as usize].ty;
+            for cs in callsites {
+                if cs.const_args.get(arg_idx).copied() == Some(Some(const_val)) {
+                    let instr = &mut module.functions[cs.caller.0 as usize].instructions[cs.iid.0 as usize];
+                    if let InstrKind::Call { callee, callee_ty, .. } = &mut instr.kind {
+                        *callee = ValueRef::Global(GlobalId(spec_id.0));
+                        *callee_ty = spec_ty;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        changed
+    }
+}
+
+#[derive(Clone)]
+struct DirectCallSite {
+    caller: FunctionId,
+    iid: llvm_ir::InstrId,
+    const_args: Vec<Option<llvm_ir::ConstId>>,
+}
+
+fn collect_direct_calls(module: &Module, callee_id: FunctionId) -> Vec<DirectCallSite> {
+    let mut out = Vec::new();
+    for (caller_idx, f) in module.functions.iter().enumerate() {
+        if f.is_declaration {
+            continue;
+        }
+        for (iid_idx, instr) in f.instructions.iter().enumerate() {
+            let InstrKind::Call { callee, args, .. } = &instr.kind else {
+                continue;
+            };
+            if *callee != ValueRef::Global(GlobalId(callee_id.0)) {
+                continue;
+            }
+            let const_args = args
+                .iter()
+                .map(|a| match a {
+                    ValueRef::Constant(c) => Some(*c),
+                    _ => None,
+                })
+                .collect();
+            out.push(DirectCallSite {
+                caller: FunctionId(caller_idx as u32),
+                iid: llvm_ir::InstrId(iid_idx as u32),
+                const_args,
+            });
+        }
+    }
+    out
+}
+
+fn find_constant_arg(callsites: &[DirectCallSite]) -> Option<(usize, llvm_ir::ConstId)> {
+    let argc = callsites.first()?.const_args.len();
+    for ai in 0..argc {
+        let mut cst: Option<llvm_ir::ConstId> = None;
+        let mut ok = true;
+        for cs in callsites {
+            match cs.const_args.get(ai).copied().flatten() {
+                Some(c) => {
+                    if let Some(prev) = cst {
+                        if prev != c {
+                            ok = false;
+                            break;
+                        }
+                    } else {
+                        cst = Some(c);
+                    }
+                }
+                None => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok {
+            return cst.map(|c| (ai, c));
+        }
+    }
+    None
+}
+
+fn clone_specialized_function(
+    src: &Function,
+    new_name: &str,
+    arg_id: ArgId,
+    const_val: ValueRef,
+) -> Function {
+    let mut dst = Function::new(new_name.to_string(), src.ty, src.args.clone(), src.linkage);
+    dst.blocks = src.blocks.clone();
+    dst.instructions = src.instructions.clone();
+    dst.value_names = src.value_names.clone();
+    dst.arg_names = src.arg_names.clone();
+    dst.is_declaration = false;
+
+    for instr in &mut dst.instructions {
+        let old = instr.kind.clone();
+        instr.kind = rewrite_values_in_kind(old, |v| {
+            if v == ValueRef::Argument(arg_id) {
+                const_val
+            } else {
+                v
+            }
+        });
+    }
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llvm_ir::{Builder, Linkage};
+
+    #[test]
+    fn ipcp_specializes_constant_argument_and_rewrites_calls() {
+        let mut ctx = Context::new();
+        let mut module = Module::new("m");
+        let mut b = Builder::new(&mut ctx, &mut module);
+
+        b.add_function(
+            "addk",
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty, b.ctx.i64_ty],
+            vec!["x".into(), "k".into()],
+            false,
+            Linkage::External,
+        );
+        let addk_entry = b.add_block("addk.entry");
+        b.position_at_end(addk_entry);
+        let x = b.get_arg(0);
+        let k = b.get_arg(1);
+        let s = b.build_add("s", x, k);
+        b.build_ret(s);
+
+        b.add_function(
+            "caller",
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let caller_entry = b.add_block("caller.entry");
+        b.position_at_end(caller_entry);
+        let x0 = b.get_arg(0);
+        let c7 = b.const_int(b.ctx.i64_ty, 7);
+        let c7b = b.const_int(b.ctx.i64_ty, 7);
+        let call_ty = b.ctx.mk_fn_type(b.ctx.i64_ty, vec![b.ctx.i64_ty, b.ctx.i64_ty], false);
+        let t1 = b.build_call(
+            "t1",
+            b.ctx.i64_ty,
+            call_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![x0, c7],
+        );
+        let t2 = b.build_call(
+            "t2",
+            b.ctx.i64_ty,
+            call_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![t1, c7],
+        );
+        let _t3 = b.build_call(
+            "t3",
+            b.ctx.i64_ty,
+            call_ty,
+            ValueRef::Global(GlobalId(0)),
+            vec![t2, c7b],
+        );
+        b.build_ret(t2);
+
+        let mut pass = Ipcp;
+        let changed = pass.run_on_module(&mut ctx, &mut module);
+        assert!(changed);
+        assert!(
+            module.functions.iter().any(|f| f.name.starts_with("addk.ipcp")),
+            "expected specialized clone"
+        );
+    }
+}

--- a/src/llvm-transforms/src/lib.rs
+++ b/src/llvm-transforms/src/lib.rs
@@ -3,18 +3,23 @@
 pub mod const_prop;
 pub mod constant_fold;
 pub mod dce;
+pub mod dead_arg_elim;
 pub mod gvn;
 pub mod inline_pass;
+pub mod ipcp;
 pub mod loop_unroll;
 pub mod mem2reg;
 pub mod pass;
 pub mod pipeline;
+mod value_rewrite;
 
 pub use const_prop::ConstProp;
 pub use constant_fold::try_fold;
 pub use dce::DeadCodeElim;
+pub use dead_arg_elim::DeadArgElim;
 pub use gvn::Gvn;
 pub use inline_pass::Inliner;
+pub use ipcp::Ipcp;
 pub use loop_unroll::LoopUnroll;
 pub use mem2reg::Mem2Reg;
 pub use pass::{FunctionPass, ModulePass, PassManager};

--- a/src/llvm-transforms/src/pipeline.rs
+++ b/src/llvm-transforms/src/pipeline.rs
@@ -3,7 +3,10 @@
 //! These presets provide a stable public API for frontends/examples to avoid
 //! manually assembling pass sequences.
 
-use crate::{pass::PassManager, ConstProp, DeadCodeElim, Gvn, Inliner, LoopUnroll, Mem2Reg};
+use crate::{
+    pass::PassManager, ConstProp, DeadArgElim, DeadCodeElim, Gvn, Inliner, Ipcp, LoopUnroll,
+    Mem2Reg,
+};
 
 /// Optimization level preset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +59,8 @@ pub fn build_pipeline(level: OptLevel) -> PassManager {
         }
         OptLevel::O3 => {
             pm.add_function_pass(Mem2Reg);
+            pm.add_module_pass(Ipcp);
+            pm.add_module_pass(DeadArgElim);
             pm.add_module_pass(Inliner {
                 size_limit: 100,
                 max_inline_depth: 16,

--- a/src/llvm-transforms/src/value_rewrite.rs
+++ b/src/llvm-transforms/src/value_rewrite.rs
@@ -1,0 +1,242 @@
+use llvm_ir::{InstrKind, ValueRef};
+
+/// Rewrite every `ValueRef` operand appearing in `kind` via mapper `f`.
+pub(crate) fn rewrite_values_in_kind<F>(kind: InstrKind, mut f: F) -> InstrKind
+where
+    F: FnMut(ValueRef) -> ValueRef,
+{
+    match kind {
+        InstrKind::Add { flags, lhs, rhs } => InstrKind::Add {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Sub { flags, lhs, rhs } => InstrKind::Sub {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Mul { flags, lhs, rhs } => InstrKind::Mul {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::UDiv { exact, lhs, rhs } => InstrKind::UDiv {
+            exact,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::SDiv { exact, lhs, rhs } => InstrKind::SDiv {
+            exact,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::URem { lhs, rhs } => InstrKind::URem {
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::SRem { lhs, rhs } => InstrKind::SRem {
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::And { lhs, rhs } => InstrKind::And {
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Or { lhs, rhs } => InstrKind::Or {
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Xor { lhs, rhs } => InstrKind::Xor {
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Shl { flags, lhs, rhs } => InstrKind::Shl {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::LShr { exact, lhs, rhs } => InstrKind::LShr {
+            exact,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::AShr { exact, lhs, rhs } => InstrKind::AShr {
+            exact,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FAdd { flags, lhs, rhs } => InstrKind::FAdd {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FSub { flags, lhs, rhs } => InstrKind::FSub {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FMul { flags, lhs, rhs } => InstrKind::FMul {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FDiv { flags, lhs, rhs } => InstrKind::FDiv {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FRem { flags, lhs, rhs } => InstrKind::FRem {
+            flags,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FNeg { flags, operand } => InstrKind::FNeg {
+            flags,
+            operand: f(operand),
+        },
+        InstrKind::ICmp { pred, lhs, rhs } => InstrKind::ICmp {
+            pred,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::FCmp {
+            flags,
+            pred,
+            lhs,
+            rhs,
+        } => InstrKind::FCmp {
+            flags,
+            pred,
+            lhs: f(lhs),
+            rhs: f(rhs),
+        },
+        InstrKind::Alloca {
+            alloc_ty,
+            num_elements,
+            align,
+        } => InstrKind::Alloca {
+            alloc_ty,
+            num_elements: num_elements.map(&mut f),
+            align,
+        },
+        InstrKind::Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Load {
+            ty,
+            ptr: f(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Store {
+            val: f(val),
+            ptr: f(ptr),
+            align,
+            volatile,
+        },
+        InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        } => InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr: f(ptr),
+            indices: indices.into_iter().map(f).collect(),
+        },
+        InstrKind::Trunc { val, to } => InstrKind::Trunc { val: f(val), to },
+        InstrKind::ZExt { val, to } => InstrKind::ZExt { val: f(val), to },
+        InstrKind::SExt { val, to } => InstrKind::SExt { val: f(val), to },
+        InstrKind::FPTrunc { val, to } => InstrKind::FPTrunc { val: f(val), to },
+        InstrKind::FPExt { val, to } => InstrKind::FPExt { val: f(val), to },
+        InstrKind::FPToUI { val, to } => InstrKind::FPToUI { val: f(val), to },
+        InstrKind::FPToSI { val, to } => InstrKind::FPToSI { val: f(val), to },
+        InstrKind::UIToFP { val, to } => InstrKind::UIToFP { val: f(val), to },
+        InstrKind::SIToFP { val, to } => InstrKind::SIToFP { val: f(val), to },
+        InstrKind::PtrToInt { val, to } => InstrKind::PtrToInt { val: f(val), to },
+        InstrKind::IntToPtr { val, to } => InstrKind::IntToPtr { val: f(val), to },
+        InstrKind::BitCast { val, to } => InstrKind::BitCast { val: f(val), to },
+        InstrKind::AddrSpaceCast { val, to } => InstrKind::AddrSpaceCast { val: f(val), to },
+        InstrKind::Select {
+            cond,
+            then_val,
+            else_val,
+        } => InstrKind::Select {
+            cond: f(cond),
+            then_val: f(then_val),
+            else_val: f(else_val),
+        },
+        InstrKind::Phi { ty, incoming } => InstrKind::Phi {
+            ty,
+            incoming: incoming.into_iter().map(|(v, b)| (f(v), b)).collect(),
+        },
+        InstrKind::ExtractValue { aggregate, indices } => InstrKind::ExtractValue {
+            aggregate: f(aggregate),
+            indices,
+        },
+        InstrKind::InsertValue {
+            aggregate,
+            val,
+            indices,
+        } => InstrKind::InsertValue {
+            aggregate: f(aggregate),
+            val: f(val),
+            indices,
+        },
+        InstrKind::ExtractElement { vec, idx } => InstrKind::ExtractElement {
+            vec: f(vec),
+            idx: f(idx),
+        },
+        InstrKind::InsertElement { vec, val, idx } => InstrKind::InsertElement {
+            vec: f(vec),
+            val: f(val),
+            idx: f(idx),
+        },
+        InstrKind::ShuffleVector { v1, v2, mask } => InstrKind::ShuffleVector {
+            v1: f(v1),
+            v2: f(v2),
+            mask,
+        },
+        InstrKind::Call {
+            tail,
+            callee_ty,
+            callee,
+            args,
+        } => InstrKind::Call {
+            tail,
+            callee_ty,
+            callee: f(callee),
+            args: args.into_iter().map(f).collect(),
+        },
+        InstrKind::Ret { val } => InstrKind::Ret { val: val.map(f) },
+        InstrKind::Br { dest } => InstrKind::Br { dest },
+        InstrKind::CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => InstrKind::CondBr {
+            cond: f(cond),
+            then_dest,
+            else_dest,
+        },
+        InstrKind::Switch {
+            val,
+            default,
+            cases,
+        } => InstrKind::Switch {
+            val: f(val),
+            default,
+            cases: cases.into_iter().map(|(v, b)| (f(v), b)).collect(),
+        },
+        InstrKind::Unreachable => InstrKind::Unreachable,
+    }
+}


### PR DESCRIPTION
## Summary
- add `Ipcp` module pass with constant-argument specialization and callsite rewrite
- add `DeadArgElim` module pass (trailing dead-arg removal + direct call rewrite)
- add generic value-rewrite helper for IR instruction operand remapping
- integrate new IPA passes into O3 pipeline
- add/extend unit tests for IPCP and dead-arg elimination
- add llvm-bench IPA fixture test showing O3 reduces call-arg pressure vs O2

## Validation
- `cargo +stable test -p llvm-transforms`
- `cargo +stable test -p llvm-analysis`
- `cargo +stable test -p llvm-bench`
- `cargo +stable test`

Closes #87
