### PR TITLE
Add graph-coloring register allocator with strategy opt-in

### DIFF
--- a/examples/tikv_jit/src/main.rs
+++ b/examples/tikv_jit/src/main.rs
@@ -32,7 +32,10 @@ use std::fs;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{Builder, Context, IntPredicate, Linkage, Module, Printer};
@@ -146,7 +149,11 @@ fn main() {
     let mut mf = backend.lower_function(&ctx, &module, func);
 
     let intervals = compute_live_intervals(&mf);
-    let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
     insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
     apply_allocation(&mut mf, &result);
 

--- a/fuzz/fuzz_targets/parser.rs
+++ b/fuzz/fuzz_targets/parser.rs
@@ -4,7 +4,10 @@ use libfuzzer_sys::fuzz_target;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::Module;
@@ -38,7 +41,11 @@ fn run_codegen(module: &Module, ctx: &llvm_ir::Context) {
         }
         let mut mf = backend.lower_function(ctx, module, func);
         let intervals = compute_live_intervals(&mf);
-        let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
         insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(obj_format);

--- a/src/llvm-bench/benches/pipeline.rs
+++ b/src/llvm-bench/benches/pipeline.rs
@@ -4,7 +4,10 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{Builder, Context, Linkage, Module, Printer};
@@ -30,7 +33,11 @@ fn codegen_module(ctx: &Context, module: &Module) {
         }
         let mut mf = backend.lower_function(ctx, module, func);
         let intervals = compute_live_intervals(&mf);
-        let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
         insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-codegen/src/lib.rs
+++ b/src/llvm-codegen/src/lib.rs
@@ -4,8 +4,12 @@ pub mod emit;
 pub mod isel;
 pub mod legalize;
 pub mod regalloc;
+pub mod regalloc_gc;
 pub mod schedule;
 
 pub use emit::{emit_object, Emitter, ObjectFile, ObjectFormat, Reloc, RelocKind, Section, Symbol};
 pub use isel::{IselBackend, MInstr, MOpcode, MOperand, MachineBlock, MachineFunction, PReg, VReg};
-pub use regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan};
+pub use regalloc::{
+    allocate_registers, apply_allocation, compute_live_intervals, graph_color,
+    insert_spill_reloads, linear_scan, RegAllocStrategy,
+};

--- a/src/llvm-codegen/src/regalloc.rs
+++ b/src/llvm-codegen/src/regalloc.rs
@@ -11,6 +11,7 @@
 //!    - Otherwise spill the interval with the largest end point.
 
 use crate::isel::{MInstr, MOpcode, MOperand, MachineFunction, PReg, VReg};
+pub use crate::regalloc_gc::graph_color;
 use std::collections::HashMap;
 
 // ── live intervals ─────────────────────────────────────────────────────────
@@ -83,6 +84,26 @@ pub struct RegAllocResult {
     pub vreg_to_preg: HashMap<VReg, PReg>,
     /// VRegs for which no physical register was available.
     pub spilled: Vec<VReg>,
+}
+
+/// Register allocation strategy used by [`allocate_registers`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RegAllocStrategy {
+    #[default]
+    LinearScan,
+    GraphColor,
+}
+
+/// Allocate registers with the selected strategy.
+pub fn allocate_registers(
+    intervals: &[LiveInterval],
+    allocatable: &[PReg],
+    strategy: RegAllocStrategy,
+) -> RegAllocResult {
+    match strategy {
+        RegAllocStrategy::LinearScan => linear_scan(intervals, allocatable),
+        RegAllocStrategy::GraphColor => graph_color(intervals, allocatable),
+    }
 }
 
 // ── linear scan ────────────────────────────────────────────────────────────

--- a/src/llvm-codegen/src/regalloc_gc.rs
+++ b/src/llvm-codegen/src/regalloc_gc.rs
@@ -1,0 +1,294 @@
+//! Graph-coloring register allocator (Chaitin-Briggs style).
+
+use crate::isel::{PReg, VReg};
+use crate::regalloc::{LiveInterval, RegAllocResult};
+use std::collections::{HashMap, HashSet};
+
+pub type InterferenceGraph = HashMap<VReg, HashSet<VReg>>;
+
+fn overlaps(a: &LiveInterval, b: &LiveInterval) -> bool {
+    a.start < b.end && b.start < a.end
+}
+
+pub fn build_interference_graph(intervals: &[LiveInterval]) -> InterferenceGraph {
+    let mut graph: InterferenceGraph = HashMap::new();
+    for iv in intervals {
+        graph.entry(iv.vreg).or_default();
+    }
+
+    for i in 0..intervals.len() {
+        for j in (i + 1)..intervals.len() {
+            let a = &intervals[i];
+            let b = &intervals[j];
+            if overlaps(a, b) {
+                graph.entry(a.vreg).or_default().insert(b.vreg);
+                graph.entry(b.vreg).or_default().insert(a.vreg);
+            }
+        }
+    }
+
+    graph
+}
+
+/// Compute spill costs from interval length and use density.
+/// Longer intervals are considered more expensive to spill.
+pub fn spill_costs(intervals: &[LiveInterval]) -> HashMap<VReg, usize> {
+    let mut costs = HashMap::new();
+    for iv in intervals {
+        let len = iv.end.saturating_sub(iv.start).max(1);
+        costs.insert(iv.vreg, len);
+    }
+    costs
+}
+
+/// Chaitin-Briggs style graph-coloring allocator.
+///
+/// The returned type matches linear-scan, so spill/reload insertion and
+/// allocation application can remain unchanged.
+pub fn graph_color(intervals: &[LiveInterval], allocatable: &[PReg]) -> RegAllocResult {
+    if allocatable.is_empty() {
+        return RegAllocResult {
+            vreg_to_preg: HashMap::new(),
+            spilled: intervals.iter().map(|iv| iv.vreg).collect(),
+        };
+    }
+    if intervals.is_empty() {
+        return RegAllocResult::default();
+    }
+
+    let k = allocatable.len();
+    let graph = build_interference_graph(intervals);
+    let costs = spill_costs(intervals);
+
+    let mut work = graph.clone();
+    let mut stack: Vec<VReg> = Vec::with_capacity(work.len());
+    let mut potential_spills: HashSet<VReg> = HashSet::new();
+
+    while !work.is_empty() {
+        let low_degree = work
+            .iter()
+            .filter(|(_, neigh)| neigh.len() < k)
+            .map(|(vr, neigh)| (*vr, neigh.len()))
+            .min_by_key(|(vr, degree)| (*degree, vr.0));
+
+        let chosen = if let Some((vr, _)) = low_degree {
+            vr
+        } else {
+            let spill_vr = work
+                .iter()
+                .map(|(vr, neigh)| {
+                    let cost = *costs.get(vr).unwrap_or(&1);
+                    (*vr, cost, neigh.len())
+                })
+                .min_by_key(|(vr, cost, degree)| (*cost, std::cmp::Reverse(*degree), vr.0))
+                .map(|(vr, _, _)| vr)
+                .expect("non-empty graph must pick a node");
+            potential_spills.insert(spill_vr);
+            spill_vr
+        };
+
+        if let Some(neighs) = work.remove(&chosen) {
+            for n in neighs {
+                if let Some(nset) = work.get_mut(&n) {
+                    nset.remove(&chosen);
+                }
+            }
+        }
+        stack.push(chosen);
+    }
+
+    let mut assigned: HashMap<VReg, PReg> = HashMap::new();
+    let mut spilled: HashSet<VReg> = HashSet::new();
+
+    while let Some(vr) = stack.pop() {
+        let forbidden: HashSet<PReg> = graph
+            .get(&vr)
+            .into_iter()
+            .flat_map(|neigh| neigh.iter())
+            .filter_map(|n| assigned.get(n).copied())
+            .collect();
+
+        if let Some(&pr) = allocatable.iter().find(|pr| !forbidden.contains(pr)) {
+            assigned.insert(vr, pr);
+        } else {
+            spilled.insert(vr);
+        }
+    }
+
+    // Keep potential spills that could not be assigned as actual spills.
+    for vr in potential_spills {
+        if !assigned.contains_key(&vr) {
+            spilled.insert(vr);
+        }
+    }
+
+    RegAllocResult {
+        vreg_to_preg: assigned,
+        spilled: {
+            let mut out: Vec<VReg> = spilled.into_iter().collect();
+            out.sort_unstable_by_key(|vr| vr.0);
+            out
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regalloc::{allocate_registers, linear_scan, RegAllocStrategy};
+
+    fn iv(vreg: u32, start: usize, end: usize) -> LiveInterval {
+        LiveInterval {
+            vreg: VReg(vreg),
+            start,
+            end,
+        }
+    }
+
+    #[test]
+    fn graph_builds_empty() {
+        let g = build_interference_graph(&[]);
+        assert!(g.is_empty());
+    }
+
+    #[test]
+    fn graph_adds_overlap_edge() {
+        let g = build_interference_graph(&[iv(0, 0, 4), iv(1, 2, 5)]);
+        assert!(g[&VReg(0)].contains(&VReg(1)));
+        assert!(g[&VReg(1)].contains(&VReg(0)));
+    }
+
+    #[test]
+    fn graph_omits_non_overlap_edge() {
+        let g = build_interference_graph(&[iv(0, 0, 2), iv(1, 2, 4)]);
+        assert!(g[&VReg(0)].is_empty());
+        assert!(g[&VReg(1)].is_empty());
+    }
+
+    #[test]
+    fn graph_touching_endpoints_do_not_interfere() {
+        let a = iv(0, 3, 7);
+        let b = iv(1, 7, 9);
+        assert!(!overlaps(&a, &b));
+    }
+
+    #[test]
+    fn spill_cost_favors_longer_ranges() {
+        let costs = spill_costs(&[iv(0, 0, 2), iv(1, 0, 10)]);
+        assert!(costs[&VReg(1)] > costs[&VReg(0)]);
+    }
+
+    #[test]
+    fn graph_color_empty_intervals() {
+        let r = graph_color(&[], &[PReg(0)]);
+        assert!(r.vreg_to_preg.is_empty());
+        assert!(r.spilled.is_empty());
+    }
+
+    #[test]
+    fn graph_color_no_registers_spills_all() {
+        let intervals = vec![iv(0, 0, 4), iv(1, 1, 3)];
+        let r = graph_color(&intervals, &[]);
+        assert_eq!(r.vreg_to_preg.len(), 0);
+        assert_eq!(r.spilled.len(), 2);
+    }
+
+    #[test]
+    fn graph_color_non_overlapping_share_one_reg() {
+        let intervals = vec![iv(0, 0, 2), iv(1, 2, 4), iv(2, 4, 6)];
+        let r = graph_color(&intervals, &[PReg(0)]);
+        assert!(r.spilled.is_empty());
+        assert_eq!(r.vreg_to_preg.len(), 3);
+    }
+
+    #[test]
+    fn graph_color_triangle_two_regs_spills_one() {
+        let intervals = vec![iv(0, 0, 6), iv(1, 1, 7), iv(2, 2, 8)];
+        let r = graph_color(&intervals, &[PReg(0), PReg(1)]);
+        assert_eq!(r.spilled.len(), 1);
+    }
+
+    #[test]
+    fn graph_color_triangle_three_regs_spills_none() {
+        let intervals = vec![iv(0, 0, 6), iv(1, 1, 7), iv(2, 2, 8)];
+        let r = graph_color(&intervals, &[PReg(0), PReg(1), PReg(2)]);
+        assert!(r.spilled.is_empty());
+    }
+
+    #[test]
+    fn graph_color_deterministic_for_same_input() {
+        let intervals = vec![iv(3, 0, 5), iv(0, 1, 4), iv(2, 2, 6), iv(1, 5, 7)];
+        let regs = vec![PReg(0), PReg(1)];
+        let a = graph_color(&intervals, &regs);
+        let b = graph_color(&intervals, &regs);
+        assert_eq!(a.spilled, b.spilled);
+        assert_eq!(a.vreg_to_preg, b.vreg_to_preg);
+    }
+
+    #[test]
+    fn graph_color_respects_interference_assignments() {
+        let intervals = vec![iv(0, 0, 5), iv(1, 0, 5), iv(2, 5, 8)];
+        let r = graph_color(&intervals, &[PReg(0), PReg(1)]);
+        let p0 = r.vreg_to_preg[&VReg(0)];
+        let p1 = r.vreg_to_preg[&VReg(1)];
+        assert_ne!(p0, p1);
+    }
+
+    #[test]
+    fn graph_color_can_recover_potential_spill() {
+        // 0 and 2 do not interfere, so one color can be reused.
+        let intervals = vec![iv(0, 0, 3), iv(1, 1, 4), iv(2, 4, 6)];
+        let r = graph_color(&intervals, &[PReg(0), PReg(1)]);
+        assert!(r.spilled.is_empty());
+        assert_eq!(r.vreg_to_preg.len(), 3);
+    }
+
+    #[test]
+    fn strategy_dispatch_uses_graph_color() {
+        let intervals = vec![iv(0, 0, 6), iv(1, 1, 7), iv(2, 2, 8)];
+        let regs = vec![PReg(0), PReg(1)];
+        let r = allocate_registers(&intervals, &regs, RegAllocStrategy::GraphColor);
+        assert_eq!(r.spilled.len(), 1);
+    }
+
+    #[test]
+    fn strategy_dispatch_linear_scan_default() {
+        let intervals = vec![iv(0, 0, 4), iv(1, 2, 6)];
+        let regs = vec![PReg(0)];
+        let a = allocate_registers(&intervals, &regs, RegAllocStrategy::default());
+        let b = linear_scan(&intervals, &regs);
+        assert_eq!(a.spilled, b.spilled);
+        assert_eq!(a.vreg_to_preg, b.vreg_to_preg);
+    }
+
+    #[test]
+    fn graph_color_spills_no_more_than_linear_scan_case1() {
+        let intervals = vec![
+            iv(0, 0, 8),
+            iv(1, 1, 5),
+            iv(2, 2, 6),
+            iv(3, 6, 10),
+            iv(4, 8, 11),
+        ];
+        let regs = vec![PReg(0), PReg(1)];
+        let gc = graph_color(&intervals, &regs);
+        let ls = linear_scan(&intervals, &regs);
+        assert!(gc.spilled.len() <= ls.spilled.len());
+    }
+
+    #[test]
+    fn graph_color_spills_no_more_than_linear_scan_case2() {
+        let intervals = vec![
+            iv(0, 0, 7),
+            iv(1, 0, 7),
+            iv(2, 1, 3),
+            iv(3, 3, 5),
+            iv(4, 5, 9),
+            iv(5, 6, 10),
+        ];
+        let regs = vec![PReg(0), PReg(1), PReg(2)];
+        let gc = graph_color(&intervals, &regs);
+        let ls = linear_scan(&intervals, &regs);
+        assert!(gc.spilled.len() <= ls.spilled.len());
+    }
+}

--- a/src/llvm-ir-parser/examples/run_ir.rs
+++ b/src/llvm-ir-parser/examples/run_ir.rs
@@ -4,7 +4,10 @@ use std::process::Command;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{Context, Module};
@@ -42,7 +45,11 @@ fn run_ours(ctx: &Context, module: &Module, label: &str) -> Result<i32, String> 
     let mut backend = X86Backend::default();
     let mut mf = backend.lower_function(ctx, module, main_func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
     insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
     apply_allocation(&mut mf, &result);
 
@@ -67,7 +74,9 @@ fn run_ours(ctx: &Context, module: &Module, label: &str) -> Result<i32, String> 
             ));
         }
 
-        let run = Command::new(&bin_path).output().map_err(|e| e.to_string())?;
+        let run = Command::new(&bin_path)
+            .output()
+            .map_err(|e| e.to_string())?;
         let _ = std::fs::remove_file(&bin_path);
         Ok(run.status.code().unwrap_or(-1))
     })

--- a/src/llvm-ir-parser/tests/differential.rs
+++ b/src/llvm-ir-parser/tests/differential.rs
@@ -14,7 +14,7 @@ use std::process::Command;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy},
     ObjectFormat,
 };
 use llvm_ir::{printer::Printer, Context, Module};
@@ -563,7 +563,7 @@ fn compile_and_run_ours(ctx: &Context, module: &Module, label: &str) -> (Option<
 
     let mut mf = backend.lower_function(ctx, module, main_func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
     insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
     apply_allocation(&mut mf, &result);
     let mut emitter = X86Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-ir-parser/tests/smoke.rs
+++ b/src/llvm-ir-parser/tests/smoke.rs
@@ -19,7 +19,10 @@ use std::process::Command;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{printer::Printer, Context, Module};
@@ -188,7 +191,11 @@ fn run_ours(ctx: &Context, module: &Module, label: &str) -> Option<RunResult> {
     let mut backend = X86Backend::default();
     let mut mf = backend.lower_function(ctx, module, main_func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
     insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
     apply_allocation(&mut mf, &result);
     let obj_format = match host_object_format() {
@@ -282,15 +289,11 @@ fn smoke_oracle(label: &str, src: &str) {
     };
 
     assert_eq!(
-        oracle,
-        ours,
+        oracle, ours,
         "[smoke/{label}] oracle vs ours mismatch\n\
          oracle exit={} stdout={:?}\n\
          ours   exit={} stdout={:?}",
-        oracle.exit_code,
-        oracle.stdout,
-        ours.exit_code,
-        ours.stdout,
+        oracle.exit_code, oracle.stdout, ours.exit_code, ours.stdout,
     );
     eprintln!(
         "[smoke/{label}] PASS — exit={} stdout={:?}",

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -795,9 +795,7 @@ mod tests {
         use crate::instructions::{LDR_FP, STR_FP};
         use crate::regs::X0;
         use llvm_codegen::isel::MOpcode;
-        use llvm_codegen::regalloc::{
-            apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan,
-        };
+        use llvm_codegen::regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy};
 
         let mut mf = MachineFunction::new("spill_e2e_arm".into());
         // Only 1 allocatable register → forces a spill.
@@ -811,7 +809,7 @@ mod tests {
         mf.push(b, MInstr::new(RET));
 
         let intervals = compute_live_intervals(&mf);
-        let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+        let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
         assert!(!result.spilled.is_empty(), "must have spills");
         insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP);
         apply_allocation(&mut mf, &result);

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -1219,9 +1219,7 @@ mod tests {
         // contains the expected prologue bytes.
         use crate::instructions::{MOV_LOAD_MR, MOV_STORE_RM};
         use llvm_codegen::isel::MOpcode;
-        use llvm_codegen::regalloc::{
-            apply_allocation, compute_live_intervals, insert_spill_reloads, linear_scan,
-        };
+        use llvm_codegen::regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy};
 
         let mut mf = MachineFunction::new("spill_e2e".into());
         // Only 1 allocatable register to guarantee spills.
@@ -1238,7 +1236,7 @@ mod tests {
         mf.push(b, MInstr::new(RET));
 
         let intervals = compute_live_intervals(&mf);
-        let mut result = linear_scan(&intervals, &mf.allocatable_pregs);
+        let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
         assert!(!result.spilled.is_empty(), "must have spills");
         insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
         apply_allocation(&mut mf, &result);


### PR DESCRIPTION
## Summary
- add `regalloc_gc` with a Chaitin-Briggs-style graph-coloring allocator implementing `graph_color(intervals, allocatable) -> RegAllocResult`
- add `RegAllocStrategy` and `allocate_registers(...)` dispatcher while keeping linear-scan as default behavior
- wire existing pipeline call sites through the dispatcher using `RegAllocStrategy::LinearScan`
- add graph-coloring specific tests (interference graph construction, spill costs, allocator behavior, determinism, and strategy dispatch)

## Validation
- `cargo +stable test -p llvm-codegen`
- `cargo +stable test`
- `cargo +stable test -q`

Closes #88
