### PR TITLE
Validate linker/tool compatibility and fix Mach-O header layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,16 @@ When:   Adding the `llvm-target-riscv` crate, implementing regs/ABI/lowering/
 Skill:  skills/riscv-backend/SKILL.md
 ```
 
+### linker-compat agent
+Use for issue #91 and linker/debugger compatibility validation work.
+
+```
+Invoke: $linker-compat
+When:   Adding linker/tool integration tests, fixing ELF/Mach-O object
+        conformance issues, and documenting exact link commands.
+Skill:  skills/linker-compat/SKILL.md
+```
+
 ### Plan agent
 Use **before** starting a new phase or a non-trivial fix.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,10 @@ version = "0.1.0"
 dependencies = [
  "llvm-analysis",
  "llvm-ir",
+ "llvm-ir-parser",
+ "llvm-target-arm",
+ "llvm-target-x86",
+ "llvm-transforms",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -538,6 +538,28 @@ cargo run -p tikv_jit
 objdump -d /tmp/eval_predicate.o   # inspect generated x86-64 assembly
 ```
 
+### Linking emitted `.o` files
+
+Linux (ELF):
+
+```bash
+# Relocatable link
+ld -r /tmp/eval_predicate.o -o /tmp/eval_predicate.linked.o
+
+# Link an executable with system startup/runtime
+cc /tmp/eval_predicate.o -o /tmp/eval_predicate_bin
+```
+
+macOS (Mach-O):
+
+```bash
+# Relocatable link
+ld -r /tmp/eval_predicate.o -o /tmp/eval_predicate.linked.o
+
+# Link an executable with system toolchain
+cc /tmp/eval_predicate.o -o /tmp/eval_predicate_bin
+```
+
 ### Adding to your own project
 
 Add the crates you need to your `Cargo.toml`. For a local checkout use path dependencies:

--- a/skills/linker-compat/SKILL.md
+++ b/skills/linker-compat/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: linker-compat
+description: Implement issue #91 by validating ELF/Mach-O objects against real linkers/tools, adding linker compatibility integration tests in llvm-codegen, fixing format gaps, and documenting exact link commands.
+---
+
+# Linker Compatibility
+
+Use this skill to execute issue #91 end-to-end with external-tool validation.
+
+## Workflow
+
+1. Add integration tests in `llvm-codegen` that emit objects and validate linker/tool compatibility.
+2. Run and triage `cc`/`ld`/`lld`/`readelf`/`nm` (and macOS tools when applicable).
+3. Fix object-format conformance issues found by the tests.
+4. Add regression coverage for each fix.
+5. Update README with exact link commands.
+6. Review PR, run full tests, open issue(s) for findings, fix in same PR, and post review summary.
+
+## Step 1: Test Harness
+
+- Add `src/llvm-codegen/tests/linker_compat.rs`.
+- Include at least:
+  - ELF/Linux linker compatibility path (`cc` link + run)
+  - Mach-O/macOS path (`cc`/`ld -r`) under platform guard
+- If external tool is unavailable, skip test gracefully unless strict mode is set.
+
+## Step 2: Tool Validation
+
+- Validate object structure with available tools (`readelf`, `nm`, `objdump`, `otool`).
+- Prefer deterministic assertions: exit code, symbol presence, relocation section presence.
+
+## Step 3: Fix Format Gaps
+
+- Address concrete linker/debugger compatibility failures surfaced by tests.
+- Add focused regression tests for each root cause.
+
+## Step 4: README Update
+
+- Document exact link invocations for produced `.o` files on Linux and macOS.
+- Keep commands copy-paste ready.
+
+## Step 5: Validation
+
+Run at minimum:
+
+```bash
+cargo +stable test -p llvm-codegen
+cargo +stable test
+```
+
+If required external tools are unavailable in environment, document exactly which tools are missing.
+
+## Step 6: Review/Test/Issue+Fix Loop
+
+- Review PR diff and run targeted + full test suites.
+- If bugs are found, open issue(s), fix in same PR branch, and push follow-up commits.
+- Post PR review summary comment with findings/fixes before merge.
+
+## Resources
+
+- Use [`references/issue-91-plan.md`](references/issue-91-plan.md) for acceptance checklist.
+- Use [`scripts/linker_toolcheck.sh`](scripts/linker_toolcheck.sh) to quickly detect local tool availability.

--- a/skills/linker-compat/agents/openai.yaml
+++ b/skills/linker-compat/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Linker Compat Agent"
+  short_description: "Issue #91 linker/debugger compatibility workflow"
+  default_prompt: "Use $linker-compat to implement issue #91 with linker/tool integration tests, object-format fixes, README link-command updates, and PR review/test issue-fix loop before merge."

--- a/skills/linker-compat/references/issue-91-plan.md
+++ b/skills/linker-compat/references/issue-91-plan.md
@@ -1,0 +1,17 @@
+# Issue #91 Plan
+
+## Acceptance Targets
+
+- Add `llvm-codegen` integration tests for ELF (Linux) and Mach-O (macOS).
+- Validate link + run path for simple no-libc style test program where feasible.
+- Validate object inspection output via available tools (`readelf`/`nm`/`otool`).
+- Fix any discovered object conformance gaps.
+- Update README with explicit commands.
+
+## Suggested Order
+
+1. Add test harness with graceful tool discovery.
+2. Run tests to capture current failures.
+3. Fix serializer/emitter gaps.
+4. Add regression assertions.
+5. Update docs.

--- a/skills/linker-compat/scripts/linker_toolcheck.sh
+++ b/skills/linker-compat/scripts/linker_toolcheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for t in cc ld lld readelf nm objdump otool; do
+  if command -v "$t" >/dev/null 2>&1; then
+    echo "$t: OK ($(command -v "$t"))"
+  else
+    echo "$t: MISSING"
+  fi
+done

--- a/src/llvm-codegen/Cargo.toml
+++ b/src/llvm-codegen/Cargo.toml
@@ -7,3 +7,9 @@ license = "Apache-2.0"
 [dependencies]
 llvm-ir = { path = "../llvm-ir" }
 llvm-analysis = { path = "../llvm-analysis" }
+
+[dev-dependencies]
+llvm-ir-parser = { path = "../llvm-ir-parser" }
+llvm-transforms = { path = "../llvm-transforms" }
+llvm-target-x86 = { path = "../llvm-target-x86" }
+llvm-target-arm = { path = "../llvm-target-arm" }

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -401,6 +401,7 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     w32(&mut buf, 3); // ncmds
     w32(&mut buf, cmds_size); // sizeofcmds
     w32(&mut buf, 0); // flags
+    w32(&mut buf, 0); // reserved
 
     // LC_SEGMENT_64
     w32(&mut buf, 0x19); // LC_SEGMENT_64

--- a/src/llvm-codegen/tests/linker_compat.rs
+++ b/src/llvm-codegen/tests/linker_compat.rs
@@ -1,0 +1,237 @@
+use std::path::Path;
+use std::process::Command;
+
+use llvm_codegen::{
+    emit_object,
+    isel::IselBackend,
+    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, RegAllocStrategy},
+    ObjectFormat,
+};
+use llvm_ir_parser::parser::parse;
+
+const MAIN_RET42_LL: &str = r#"
+define i32 @main() {
+entry:
+  ret i32 42
+}
+"#;
+
+fn have_tool(name: &str) -> bool {
+    Command::new(name).arg("--version").output().is_ok()
+}
+
+fn host_object_format() -> Option<ObjectFormat> {
+    if cfg!(target_os = "linux") {
+        Some(ObjectFormat::Elf)
+    } else if cfg!(target_os = "macos") {
+        Some(ObjectFormat::MachO)
+    } else {
+        None
+    }
+}
+
+fn emit_host_obj(ll: &str, out: &Path) {
+    let (ctx, module) = parse(ll).expect("parse test ir");
+    let func = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main" && !f.is_declaration)
+        .expect("@main must exist");
+
+    let obj_format = host_object_format().expect("unsupported host object format");
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        emit_host_obj_x86(&ctx, &module, func, obj_format, out);
+        return;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        emit_host_obj_aarch64(&ctx, &module, func, obj_format, out);
+        return;
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    panic!("unsupported host arch for linker_compat test");
+}
+
+#[cfg(target_arch = "x86_64")]
+fn emit_host_obj_x86(
+    ctx: &llvm_ir::Context,
+    module: &llvm_ir::Module,
+    func: &llvm_ir::Function,
+    obj_format: ObjectFormat,
+    out: &Path,
+) {
+    use llvm_target_x86::{
+        instructions::{MOV_LOAD_MR, MOV_STORE_RM},
+        X86Backend, X86Emitter,
+    };
+
+    let mut backend = X86Backend::default();
+    let mut mf = backend.lower_function(ctx, module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+    apply_allocation(&mut mf, &result);
+    let mut emitter = X86Emitter::new(obj_format);
+    let obj = emit_object(&mf, &mut emitter);
+    std::fs::write(out, obj.to_bytes()).expect("write object");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn emit_host_obj_aarch64(
+    ctx: &llvm_ir::Context,
+    module: &llvm_ir::Module,
+    func: &llvm_ir::Function,
+    obj_format: ObjectFormat,
+    out: &Path,
+) {
+    use llvm_target_arm::{
+        encode::AArch64Emitter,
+        instructions::{LDR_FP, STR_FP},
+        lower::AArch64Backend,
+    };
+
+    let mut backend = AArch64Backend;
+    let mut mf = backend.lower_function(ctx, module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP);
+    apply_allocation(&mut mf, &result);
+    let mut emitter = AArch64Emitter::new(obj_format);
+    let obj = emit_object(&mf, &mut emitter);
+    std::fs::write(out, obj.to_bytes()).expect("write object");
+}
+
+fn with_temp_file<R>(tag: &str, ext: &str, f: impl FnOnce(&Path) -> R) -> R {
+    let path = std::env::temp_dir().join(format!("{tag}.{ext}"));
+    let result = f(&path);
+    let _ = std::fs::remove_file(&path);
+    result
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn elf_link_with_cc_and_run_exit_code() {
+    if !have_tool("cc") {
+        return;
+    }
+
+    with_temp_file("linker_compat_main", "o", |obj_path| {
+        emit_host_obj(MAIN_RET42_LL, obj_path);
+
+        let bin_path = std::env::temp_dir().join("linker_compat_main_bin");
+        let link = Command::new("cc")
+            .arg(obj_path)
+            .arg("-o")
+            .arg(&bin_path)
+            .output()
+            .expect("run cc");
+        assert!(
+            link.status.success(),
+            "cc link failed: {}",
+            String::from_utf8_lossy(&link.stderr)
+        );
+
+        let run = Command::new(&bin_path).output().expect("run binary");
+        let _ = std::fs::remove_file(&bin_path);
+        assert_eq!(run.status.code(), Some(42));
+    });
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn elf_readelf_and_nm_show_expected_entries() {
+    if !have_tool("readelf") || !have_tool("nm") {
+        return;
+    }
+
+    with_temp_file("linker_compat_info", "o", |obj_path| {
+        emit_host_obj(MAIN_RET42_LL, obj_path);
+
+        let readelf = Command::new("readelf")
+            .arg("-a")
+            .arg(obj_path)
+            .output()
+            .expect("run readelf");
+        assert!(readelf.status.success());
+        let re = String::from_utf8_lossy(&readelf.stdout);
+        assert!(re.contains(".text"));
+        assert!(re.contains("Symbol table"));
+
+        let nm = Command::new("nm")
+            .arg(obj_path)
+            .output()
+            .expect("run nm");
+        assert!(nm.status.success());
+        let nm_out = String::from_utf8_lossy(&nm.stdout);
+        assert!(nm_out.contains(" main"), "nm output: {nm_out}");
+    });
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macho_link_with_cc_succeeds() {
+    if !have_tool("cc") {
+        return;
+    }
+
+    with_temp_file("linker_compat_main", "o", |obj_path| {
+        emit_host_obj(MAIN_RET42_LL, obj_path);
+        let bin_path = std::env::temp_dir().join("linker_compat_main_bin");
+        let link = Command::new("cc")
+            .arg(obj_path)
+            .arg("-o")
+            .arg(&bin_path)
+            .output()
+            .expect("run cc");
+        assert!(
+            link.status.success(),
+            "cc link failed: {}",
+            String::from_utf8_lossy(&link.stderr)
+        );
+        let _ = std::fs::remove_file(&bin_path);
+    });
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macho_nm_lists_main() {
+    if !have_tool("nm") {
+        return;
+    }
+
+    with_temp_file("linker_compat_nm", "o", |obj_path| {
+        emit_host_obj(MAIN_RET42_LL, obj_path);
+        let nm = Command::new("nm")
+            .arg(obj_path)
+            .output()
+            .expect("run nm");
+        assert!(nm.status.success());
+        let out = String::from_utf8_lossy(&nm.stdout);
+        assert!(
+            out.contains(" _main") || out.contains(" main"),
+            "nm output: {out}"
+        );
+    });
+}
+
+#[test]
+fn tool_presence_report_is_accessible() {
+    // Lightweight smoke to keep path used in CI logs if desired.
+    let mut tools = Vec::<(&str, bool)>::new();
+    for t in ["cc", "ld", "lld", "readelf", "nm", "objdump", "otool"] {
+        tools.push((t, have_tool(t)));
+    }
+    assert!(!tools.is_empty());
+}


### PR DESCRIPTION
## Summary
- add `linker-compat` skill/agent scaffolding and register it in `AGENTS.md`
- add `src/llvm-codegen/tests/linker_compat.rs` with host-gated ELF/Mach-O linker/tool compatibility checks
- add llvm-codegen dev-dependencies required by the integration test harness
- update README with concrete Linux/macOS linking commands for emitted object files
- fix Mach-O serializer to emit the required `mach_header_64.reserved` field

## Validation
- `cargo +stable test -p llvm-codegen --test linker_compat`
- `cargo +stable test -p llvm-codegen`
- `cargo +stable test -q`

Closes #91
