### PR TITLE
Issue #92: thread !dbg metadata and emit ELF .debug_line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,16 @@ When:   Adding linker/tool integration tests, fixing ELF/Mach-O object
 Skill:  skills/linker-compat/SKILL.md
 ```
 
+### dwarf-debug agent
+Use for issue #92 and DWARF debug metadata/line-table implementation work.
+
+```
+Invoke: $dwarf-debug
+When:   Threading `!dbg` metadata through parser/codegen, emitting
+        `.debug_line`, and validating debug output with toolchain utilities.
+Skill:  skills/dwarf-debug/SKILL.md
+```
+
 ### Plan agent
 Use **before** starting a new phase or a non-trivial fix.
 

--- a/README.md
+++ b/README.md
@@ -560,6 +560,16 @@ ld -r /tmp/eval_predicate.o -o /tmp/eval_predicate.linked.o
 cc /tmp/eval_predicate.o -o /tmp/eval_predicate_bin
 ```
 
+### Debug line tables (`.debug_line`)
+
+When LLVM IR carries `!dbg` / `!DILocation` metadata, ELF object emission now
+adds a `.debug_line` section. Quick checks:
+
+```bash
+readelf -S /tmp/eval_predicate.o | grep debug_line
+llvm-dwarfdump --debug-line /tmp/eval_predicate.o
+```
+
 ### Adding to your own project
 
 Add the crates you need to your `Cargo.toml`. For a local checkout use path dependencies:

--- a/skills/dwarf-debug/SKILL.md
+++ b/skills/dwarf-debug/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: dwarf-debug
+description: Implement issue #92 by threading LLVM `!dbg` metadata and emitting DWARF debug sections (starting with `.debug_line`) with validation via toolchain utilities.
+---
+
+# DWARF Debug
+
+Use this skill to execute issue #92 with incremental, test-backed DWARF support.
+
+## Workflow
+
+1. Parse and preserve `!dbg` / `!DILocation` metadata in IR.
+2. Thread debug locations into codegen structures.
+3. Emit `.debug_line` for ELF objects when debug metadata is present.
+4. Validate with integration tests + external tools when available (`readelf`, `llvm-dwarfdump`, `dwarfdump`).
+5. Update docs and PR with explicit limitations/follow-ups.
+6. Review PR, run full tests, post review feedback before merge.
+
+## Minimum validation
+
+```bash
+cargo +stable test -p llvm-ir-parser
+cargo +stable test -p llvm-codegen
+cargo +stable test -q
+```
+
+## Notes
+
+- Keep output deterministic and avoid host-only assumptions in tests.
+- If full DWARF verification is not yet complete, keep scope explicit and open follow-up issues.

--- a/skills/dwarf-debug/agents/openai.yaml
+++ b/skills/dwarf-debug/agents/openai.yaml
@@ -1,0 +1,9 @@
+name: dwarf-debug-agent
+description: Agent for issue #92 DWARF debug metadata plumbing and `.debug_line` emission.
+model: gpt-5
+instructions: |
+  Focus on correctness and compatibility first:
+  - preserve `!dbg` metadata in parser/IR
+  - add minimal but valid DWARF line-table emission
+  - enforce regression tests and external-tool checks when available
+  - post PR review findings before merge

--- a/skills/dwarf-debug/references/issue-92-plan.md
+++ b/skills/dwarf-debug/references/issue-92-plan.md
@@ -1,0 +1,9 @@
+# Issue #92 Execution Checklist
+
+- [ ] Parse `!dbg` attachments and `!DILocation` metadata records.
+- [ ] Thread debug metadata signal into codegen.
+- [ ] Emit `.debug_line` for debug-carrying modules.
+- [ ] Add integration test for debug-line section generation.
+- [ ] Validate using `readelf`/`llvm-dwarfdump` when available.
+- [ ] Run full test suite.
+- [ ] Post PR review comment with findings and fixes.

--- a/skills/dwarf-debug/scripts/dwarf_toolcheck.sh
+++ b/skills/dwarf-debug/scripts/dwarf_toolcheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for tool in llvm-dwarfdump dwarfdump readelf nm objdump; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool: found"
+  else
+    echo "$tool: missing"
+  fi
+done

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -104,10 +104,21 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
         size,
         global: true,
     };
+    let mut sections = vec![section];
+    if emitter.object_format() == ObjectFormat::Elf {
+        if let Some(line) = mf.debug_line_start {
+            let source = mf.debug_source.as_deref().unwrap_or("unknown");
+            sections.push(Section {
+                name: ".debug_line".into(),
+                data: build_minimal_debug_line(source, line),
+                relocs: Vec::new(),
+            });
+        }
+    }
     ObjectFile {
         format: emitter.object_format(),
         elf_machine: emitter.elf_machine(),
-        sections: vec![section],
+        sections,
         symbols: vec![sym],
     }
 }
@@ -126,20 +137,25 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
 //   Section data: .text, .symtab, .strtab, .shstrtab, .rela.text
 
 fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
-    // ── string tables ───────────────────────────────────────────────────────
-    let mut shstrtab: Vec<u8> = vec![0u8]; // index 0 = empty string
+    let text_sec = obj.sections.first();
+    let text_data = text_sec.map_or(&[][..], |s| s.data.as_slice());
+    let text_relocs = text_sec.map_or(&[][..], |s| s.relocs.as_slice());
+    let extra_secs = if obj.sections.len() > 1 {
+        &obj.sections[1..]
+    } else {
+        &[][..]
+    };
+    let has_relocs = !text_relocs.is_empty();
+
+    let mut shstrtab: Vec<u8> = vec![0u8];
     let text_name_off = push_str(&mut shstrtab, b".text");
+    let extra_name_offs: Vec<u32> = extra_secs
+        .iter()
+        .map(|s| push_str(&mut shstrtab, s.name.as_bytes()))
+        .collect();
     let symtab_name_off = push_str(&mut shstrtab, b".symtab");
     let strtab_name_off = push_str(&mut shstrtab, b".strtab");
     let shstrtab_name_off = push_str(&mut shstrtab, b".shstrtab");
-
-    let text_data = obj.sections.first().map_or(&[][..], |s| s.data.as_slice());
-    let text_relocs = obj
-        .sections
-        .first()
-        .map_or(&[][..], |s| s.relocs.as_slice());
-    let has_relocs = !text_relocs.is_empty();
-
     let relatext_name_off = if has_relocs {
         push_str(&mut shstrtab, b".rela.text")
     } else {
@@ -153,50 +169,70 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         .map(|s| push_str(&mut strtab, s.name.as_bytes()))
         .collect();
 
-    // ── layout ─────────────────────────────────────────────────────────────
     const ELF_HDR: u64 = 64;
     const SH_ENT: u64 = 64;
     const SYM_ENT: u64 = 24;
     const RELA_ENT: u64 = 24;
+    const SHT_PROGBITS: u32 = 1;
+    const SHT_SYMTAB: u32 = 2;
+    const SHT_STRTAB: u32 = 3;
+    const SHT_RELA: u32 = 4;
 
-    let num_sections: u16 = if has_relocs { 6 } else { 5 };
+    let idx_text = 1u16;
+    let idx_extra_start = idx_text + 1;
+    let idx_symtab = idx_extra_start + extra_secs.len() as u16;
+    let idx_strtab = idx_symtab + 1;
+    let idx_shstrtab = idx_strtab + 1;
+    let idx_rela = idx_shstrtab + 1;
+
+    let num_sections: u16 = if has_relocs { idx_rela + 1 } else { idx_shstrtab + 1 };
     let sh_table_size = num_sections as u64 * SH_ENT;
 
-    let text_off = ELF_HDR + sh_table_size;
+    let mut cursor = ELF_HDR + sh_table_size;
+    let text_off = cursor;
     let text_size = text_data.len() as u64;
-    let sym_count = 1 + obj.symbols.len() as u64; // null + symbols
-    let symtab_off = text_off + text_size;
+    cursor += text_size;
+
+    let mut extra_offs = Vec::with_capacity(extra_secs.len());
+    for sec in extra_secs {
+        extra_offs.push(cursor);
+        cursor += sec.data.len() as u64;
+    }
+
+    let sym_count = 1 + obj.symbols.len() as u64;
+    let symtab_off = cursor;
     let symtab_size = sym_count * SYM_ENT;
-    let strtab_off = symtab_off + symtab_size;
-    let shstrtab_off = strtab_off + strtab.len() as u64;
-    let relatext_off = shstrtab_off + shstrtab.len() as u64;
+    cursor += symtab_size;
+
+    let strtab_off = cursor;
+    cursor += strtab.len() as u64;
+    let shstrtab_off = cursor;
+    cursor += shstrtab.len() as u64;
+
+    let relatext_off = cursor;
     let relatext_size = text_relocs.len() as u64 * RELA_ENT;
 
-    // ── buffer ─────────────────────────────────────────────────────────────
     let mut buf = Vec::<u8>::new();
+    buf.extend_from_slice(b"\x7fELF");
+    buf.push(2);
+    buf.push(1);
+    buf.push(1);
+    buf.push(0);
+    buf.extend_from_slice(&[0u8; 8]);
+    w16(&mut buf, 1);
+    w16(&mut buf, obj.elf_machine);
+    w32(&mut buf, 1);
+    w64(&mut buf, 0);
+    w64(&mut buf, 0);
+    w64(&mut buf, ELF_HDR);
+    w32(&mut buf, 0);
+    w16(&mut buf, ELF_HDR as u16);
+    w16(&mut buf, 0);
+    w16(&mut buf, 0);
+    w16(&mut buf, SH_ENT as u16);
+    w16(&mut buf, num_sections);
+    w16(&mut buf, idx_shstrtab);
 
-    // ELF header
-    buf.extend_from_slice(b"\x7fELF"); // magic
-    buf.push(2); // EI_CLASS: 64-bit
-    buf.push(1); // EI_DATA: little-endian
-    buf.push(1); // EI_VERSION
-    buf.push(0); // EI_OSABI: System V
-    buf.extend_from_slice(&[0u8; 8]); // padding
-    w16(&mut buf, 1); // e_type: ET_REL
-    w16(&mut buf, obj.elf_machine); // e_machine: target-specific
-    w32(&mut buf, 1); // e_version
-    w64(&mut buf, 0); // e_entry
-    w64(&mut buf, 0); // e_phoff
-    w64(&mut buf, ELF_HDR); // e_shoff
-    w32(&mut buf, 0); // e_flags
-    w16(&mut buf, ELF_HDR as u16); // e_ehsize
-    w16(&mut buf, 0); // e_phentsize
-    w16(&mut buf, 0); // e_phnum
-    w16(&mut buf, SH_ENT as u16); // e_shentsize
-    w16(&mut buf, num_sections); // e_shnum
-    w16(&mut buf, 4); // e_shstrndx (.shstrtab at index 4)
-
-    // Helper: write a 64-byte section header entry
     let write_shdr = |buf: &mut Vec<u8>,
                       name: u32,
                       sh_type: u32,
@@ -220,13 +256,12 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         w64(buf, entsize);
     };
 
-    // Section headers
-    write_shdr(&mut buf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0); // [0] null
+    write_shdr(&mut buf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     write_shdr(
         &mut buf,
         text_name_off,
-        1,
-        6, // [1] .text  SHF_ALLOC|SHF_EXECINSTR
+        SHT_PROGBITS,
+        6,
         0,
         text_off,
         text_size,
@@ -235,15 +270,32 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         16,
         0,
     );
+
+    for (i, sec) in extra_secs.iter().enumerate() {
+        write_shdr(
+            &mut buf,
+            extra_name_offs[i],
+            SHT_PROGBITS,
+            0,
+            0,
+            extra_offs[i],
+            sec.data.len() as u64,
+            0,
+            0,
+            1,
+            0,
+        );
+    }
+
     write_shdr(
         &mut buf,
         symtab_name_off,
-        2,
-        0, // [2] .symtab link=3 info=first_global(1)
+        SHT_SYMTAB,
+        0,
         0,
         symtab_off,
         symtab_size,
-        3,
+        idx_strtab as u32,
         1,
         8,
         SYM_ENT,
@@ -251,8 +303,8 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
     write_shdr(
         &mut buf,
         strtab_name_off,
-        3,
-        0, // [3] .strtab
+        SHT_STRTAB,
+        0,
         0,
         strtab_off,
         strtab.len() as u64,
@@ -264,8 +316,8 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
     write_shdr(
         &mut buf,
         shstrtab_name_off,
-        3,
-        0, // [4] .shstrtab
+        SHT_STRTAB,
+        0,
         0,
         shstrtab_off,
         shstrtab.len() as u64,
@@ -278,47 +330,44 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         write_shdr(
             &mut buf,
             relatext_name_off,
-            4,
-            0, // [5] .rela.text link=2 info=1
+            SHT_RELA,
+            0,
             0,
             relatext_off,
             relatext_size,
-            2,
-            1,
+            idx_symtab as u32,
+            idx_text as u32,
             8,
             RELA_ENT,
         );
     }
 
-    // Section data: .text
     buf.extend_from_slice(text_data);
+    for sec in extra_secs {
+        buf.extend_from_slice(&sec.data);
+    }
 
-    // .symtab: null entry then symbols
     buf.extend_from_slice(&[0u8; 24]);
     for (i, sym) in obj.symbols.iter().enumerate() {
-        let st_info: u8 = (1u8 << 4) | 2u8; // STB_GLOBAL | STT_FUNC
-        let st_shndx: u16 = (sym.section + 1) as u16; // +1 for null section header
+        let st_info: u8 = (1u8 << 4) | 2u8;
+        let st_shndx: u16 = (sym.section + 1) as u16;
         w32(&mut buf, sym_name_offs[i]);
         buf.push(st_info);
-        buf.push(0); // st_other
+        buf.push(0);
         w16(&mut buf, st_shndx);
         w64(&mut buf, sym.offset);
         w64(&mut buf, sym.size);
     }
 
-    // .strtab
     buf.extend_from_slice(&strtab);
-
-    // .shstrtab
     buf.extend_from_slice(&shstrtab);
 
-    // .rela.text
     if has_relocs {
         for reloc in text_relocs {
             let sym_idx = (reloc.symbol + 1) as u64;
             let r_type: u64 = match reloc.kind {
-                RelocKind::Pc32 => 2,  // R_X86_64_PC32
-                RelocKind::Abs64 => 1, // R_X86_64_64
+                RelocKind::Pc32 => 2,
+                RelocKind::Abs64 => 1,
             };
             let r_info = (sym_idx << 32) | r_type;
             w64(&mut buf, reloc.offset);
@@ -326,9 +375,45 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
             buf.extend_from_slice(&reloc.addend.to_le_bytes());
         }
     }
-
-    let _ = relatext_name_off;
     buf
+}
+
+fn build_minimal_debug_line(source_file: &str, line: u32) -> Vec<u8> {
+    let file = source_file.rsplit('/').next().unwrap_or(source_file);
+
+    let mut header_body = Vec::<u8>::new();
+    header_body.push(1); // minimum_instruction_length
+    header_body.push(1); // default_is_stmt
+    header_body.push((-5i8) as u8); // line_base
+    header_body.push(14); // line_range
+    header_body.push(13); // opcode_base
+    header_body.extend_from_slice(&[0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1]); // std opcode lengths
+    header_body.push(0); // include_directories terminator
+    header_body.extend_from_slice(file.as_bytes());
+    header_body.push(0); // file name terminator
+    write_uleb128(&mut header_body, 0); // dir index
+    write_uleb128(&mut header_body, 0); // mtime
+    write_uleb128(&mut header_body, 0); // size
+    header_body.push(0); // file_names terminator
+
+    let mut program = Vec::<u8>::new();
+    if line > 1 {
+        program.push(3); // DW_LNS_advance_line
+        write_sleb128(&mut program, (line - 1) as i64);
+    }
+    program.push(1); // DW_LNS_copy
+    program.push(0);
+    program.push(1);
+    program.push(1); // DW_LNE_end_sequence
+
+    let unit_length = (2 + 4 + header_body.len() + program.len()) as u32;
+    let mut out = Vec::<u8>::new();
+    w32(&mut out, unit_length);
+    w16(&mut out, 2); // DWARF v2 line table
+    w32(&mut out, header_body.len() as u32);
+    out.extend_from_slice(&header_body);
+    out.extend_from_slice(&program);
+    out
 }
 
 // ── Mach-O 64-bit serialization ────────────────────────────────────────────
@@ -501,6 +586,34 @@ fn w64(buf: &mut Vec<u8>, v: u64) {
     buf.extend_from_slice(&v.to_le_bytes());
 }
 
+fn write_uleb128(buf: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+}
+
+fn write_sleb128(buf: &mut Vec<u8>, mut v: i64) {
+    loop {
+        let byte = (v as u8) & 0x7f;
+        let sign = (byte & 0x40) != 0;
+        v >>= 7;
+        let done = (v == 0 && !sign) || (v == -1 && sign);
+        if done {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
 /// Append a null-terminated string to `table` and return its start offset.
 fn push_str(table: &mut Vec<u8>, s: &[u8]) -> u32 {
     let off = table.len() as u32;
@@ -617,5 +730,37 @@ mod tests {
         assert_eq!(obj.symbols[0].name, "test");
         assert_eq!(obj.sections[0].data, vec![0x90]);
         assert_eq!(obj.elf_machine, 62);
+    }
+
+    #[test]
+    fn emit_object_adds_debug_line_section_for_elf() {
+        use crate::isel::{MachineBlock, MachineFunction};
+
+        struct NopEmitter;
+        impl Emitter for NopEmitter {
+            fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
+                Section {
+                    name: ".text".into(),
+                    data: vec![0x90],
+                    relocs: vec![],
+                }
+            }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Elf
+            }
+        }
+
+        let mut mf = MachineFunction::new("dbg".into());
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
+        mf.debug_source = Some("foo.c".into());
+        mf.debug_line_start = Some(17);
+
+        let obj = emit_object(&mf, &mut NopEmitter);
+        assert!(obj.sections.iter().any(|s| s.name == ".debug_line"));
+        let bytes = obj.to_bytes();
+        assert!(bytes.windows(11).any(|w| w == b".debug_line"));
     }
 }

--- a/src/llvm-codegen/src/isel.rs
+++ b/src/llvm-codegen/src/isel.rs
@@ -122,6 +122,10 @@ pub struct MachineFunction {
     pub used_callee_saved: Vec<PReg>,
     /// Counter for frame slot allocation.
     next_slot: u32,
+    /// Source filename used for debug line tables.
+    pub debug_source: Option<String>,
+    /// First source line observed from IR `!dbg` metadata.
+    pub debug_line_start: Option<u32>,
 }
 
 impl MachineFunction {
@@ -136,6 +140,8 @@ impl MachineFunction {
             spill_slots: HashMap::new(),
             used_callee_saved: Vec::new(),
             next_slot: 0,
+            debug_source: None,
+            debug_line_start: None,
         }
     }
 

--- a/src/llvm-codegen/tests/dwarf_line.rs
+++ b/src/llvm-codegen/tests/dwarf_line.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+use std::process::Command;
+
+use llvm_codegen::{
+    emit_object,
+    isel::IselBackend,
+    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, RegAllocStrategy},
+    ObjectFormat,
+};
+use llvm_ir_parser::parser::parse;
+
+const DBG_LL: &str = r#"
+source_filename = "dbg_test.c"
+define i32 @main() {
+entry:
+  ret i32 0, !dbg !12
+}
+!12 = !DILocation(line: 42, column: 7, scope: !1)
+"#;
+
+fn have_tool(name: &str) -> bool {
+    Command::new(name).arg("--version").output().is_ok()
+}
+
+#[cfg(target_arch = "x86_64")]
+fn emit_dbg_elf_obj(out: &Path) {
+    use llvm_target_x86::{
+        instructions::{MOV_LOAD_MR, MOV_STORE_RM},
+        X86Backend, X86Emitter,
+    };
+
+    let (ctx, module) = parse(DBG_LL).expect("parse test ir");
+    let func = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main" && !f.is_declaration)
+        .expect("@main must exist");
+
+    let mut backend = X86Backend::default();
+    let mut mf = backend.lower_function(&ctx, &module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+    apply_allocation(&mut mf, &result);
+    let mut emitter = X86Emitter::new(ObjectFormat::Elf);
+    let obj = emit_object(&mf, &mut emitter);
+
+    assert!(obj.sections.iter().any(|s| s.name == ".debug_line"));
+    std::fs::write(out, obj.to_bytes()).expect("write object");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn emit_dbg_elf_obj(out: &Path) {
+    use llvm_target_arm::{
+        encode::AArch64Emitter,
+        instructions::{LDR_FP, STR_FP},
+        lower::AArch64Backend,
+    };
+
+    let (ctx, module) = parse(DBG_LL).expect("parse test ir");
+    let func = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main" && !f.is_declaration)
+        .expect("@main must exist");
+
+    let mut backend = AArch64Backend;
+    let mut mf = backend.lower_function(&ctx, &module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP);
+    apply_allocation(&mut mf, &result);
+    let mut emitter = AArch64Emitter::new(ObjectFormat::Elf);
+    let obj = emit_object(&mf, &mut emitter);
+
+    assert!(obj.sections.iter().any(|s| s.name == ".debug_line"));
+    std::fs::write(out, obj.to_bytes()).expect("write object");
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+fn emit_dbg_elf_obj(_out: &Path) {
+    panic!("unsupported host arch for dwarf_line test");
+}
+
+#[test]
+fn emits_debug_line_when_dbg_metadata_present() {
+    let obj_path = std::env::temp_dir().join("llvm_codegen_dbg_line.o");
+    emit_dbg_elf_obj(&obj_path);
+
+    if have_tool("readelf") {
+        let out = Command::new("readelf")
+            .arg("-S")
+            .arg(&obj_path)
+            .output()
+            .expect("run readelf");
+        assert!(out.status.success());
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(text.contains(".debug_line"), "readelf output: {text}");
+    }
+
+    if have_tool("llvm-dwarfdump") {
+        let out = Command::new("llvm-dwarfdump")
+            .arg("--debug-line")
+            .arg(&obj_path)
+            .output()
+            .expect("run llvm-dwarfdump");
+        assert!(out.status.success());
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(text.contains("dbg_test.c") || text.contains("line"), "dwarfdump output: {text}");
+    }
+
+    let _ = std::fs::remove_file(&obj_path);
+}

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -120,7 +120,7 @@ impl<'src> Parser<'src> {
                     self.parse_function(true)?;
                 }
                 Token::Bang => {
-                    self.skip_metadata_line()?;
+                    self.parse_metadata_definition_or_skip()?;
                 }
                 _ => {
                     let t = self.lex.next()?;
@@ -627,11 +627,15 @@ impl<'src> Parser<'src> {
         };
 
         let (kind, ty) = self.parse_instr_kind()?;
+        let dbg_loc = self.parse_optional_dbg_attachment()?;
         let is_term = kind.is_terminator();
 
         let instr_name = result_name.clone();
         let instr = Instruction::new(instr_name, ty, kind);
         let iid = self.module.functions[fid].alloc_instr(instr);
+        if let Some(loc_id) = dbg_loc {
+            self.module.functions[fid].set_instr_dbg_loc(iid, loc_id);
+        }
 
         if is_term {
             self.module.functions[fid]
@@ -1628,7 +1632,7 @@ impl<'src> Parser<'src> {
                     self.lex.next()?;
                 }
                 Token::Bang => {
-                    self.skip_metadata_line()?;
+                    self.parse_metadata_definition_or_skip()?;
                     break;
                 }
                 _ => {
@@ -1660,17 +1664,147 @@ impl<'src> Parser<'src> {
         Ok(())
     }
 
-    fn skip_metadata_line(&mut self) -> Result<(), ParseError> {
-        while !matches!(self.lex.peek()?, Token::Eof) {
-            // Consume tokens until newline-ish heuristic: next top-level token.
-            // We approximate: consume until we see a GlobalIdent, Kw(Define), etc.
-            let tok = self.lex.next()?;
-            if matches!(tok, Token::Eof) {
+    fn parse_optional_dbg_attachment(&mut self) -> Result<Option<u32>, ParseError> {
+        let mut dbg = None;
+        while self.lex.eat(&Token::Comma) {
+            if !self.lex.eat(&Token::Bang) {
                 break;
             }
-            // Metadata lines end at things that look like module-level items.
-            // Heuristic: stop when we've consumed something that looks complete.
-            // For now we consume an entire "statement" by stopping at Eof.
+            let key = self.lex.expect_local_ident()?;
+            if key == "dbg" {
+                self.lex.expect(&Token::Bang)?;
+                let id = self.lex.expect_uint_lit()? as u32;
+                dbg = Some(id);
+            } else {
+                self.skip_one_metadata_value()?;
+            }
+        }
+        Ok(dbg)
+    }
+
+    fn parse_metadata_definition_or_skip(&mut self) -> Result<(), ParseError> {
+        // Optional form: !<id> = !DILocation(line: N, column: M, ...)
+        self.lex.expect(&Token::Bang)?;
+        let id = match self.lex.peek()? {
+            Token::IntLit(_) | Token::UIntLit(_) => self.lex.expect_uint_lit()? as u32,
+            _ => {
+                self.skip_one_metadata_value()?;
+                return Ok(());
+            }
+        };
+        if !self.lex.eat(&Token::Equal) {
+            self.skip_one_metadata_value()?;
+            return Ok(());
+        }
+        self.lex.expect(&Token::Bang)?;
+        let head = match self.lex.peek()? {
+            Token::LocalIdent(_) => self.lex.expect_local_ident()?,
+            _ => {
+                self.skip_one_metadata_value()?;
+                return Ok(());
+            }
+        };
+
+        if head == "DILocation" {
+            if let Some(loc) = self.parse_dilocation_body()? {
+                self.module.set_debug_location(id, loc);
+            }
+        } else {
+            self.skip_balanced_payload()?;
+        }
+        Ok(())
+    }
+
+    fn parse_dilocation_body(&mut self) -> Result<Option<llvm_ir::DebugLocation>, ParseError> {
+        if !self.lex.eat(&Token::LParen) {
+            return Ok(None);
+        }
+        let mut depth = 1usize;
+        let mut line: Option<u32> = None;
+        let mut column: Option<u32> = None;
+        while depth > 0 {
+            match self.lex.peek()? {
+                Token::LParen | Token::LBrace | Token::LBracket | Token::LAngle => {
+                    depth += 1;
+                    let _ = self.lex.next()?;
+                }
+                Token::RParen | Token::RBrace | Token::RBracket | Token::RAngle => {
+                    depth -= 1;
+                    let _ = self.lex.next()?;
+                }
+                Token::LocalIdent(ref s) if depth == 1 && s == "line" => {
+                    let _ = self.lex.next()?;
+                    self.lex.expect(&Token::Colon)?;
+                    line = Some(self.lex.expect_uint_lit()? as u32);
+                }
+                Token::LocalIdent(ref s) if depth == 1 && s == "column" => {
+                    let _ = self.lex.next()?;
+                    self.lex.expect(&Token::Colon)?;
+                    column = Some(self.lex.expect_uint_lit()? as u32);
+                }
+                Token::Eof => break,
+                _ => {
+                    let _ = self.lex.next()?;
+                }
+            }
+        }
+        if let Some(line) = line {
+            Ok(Some(llvm_ir::DebugLocation {
+                line,
+                column: column.unwrap_or(0),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn skip_one_metadata_value(&mut self) -> Result<(), ParseError> {
+        // Skip a single metadata value after a key, e.g. `!12`, `"foo"`, or
+        // a balanced tuple/list.
+        match self.lex.peek()? {
+            Token::Bang => {
+                let _ = self.lex.next()?;
+                if matches!(self.lex.peek()?, Token::IntLit(_) | Token::UIntLit(_)) {
+                    let _ = self.lex.next()?;
+                } else if matches!(self.lex.peek()?, Token::LocalIdent(_)) {
+                    let _ = self.lex.next()?;
+                    self.skip_balanced_payload()?;
+                }
+            }
+            Token::LParen | Token::LBrace | Token::LBracket | Token::LAngle => {
+                self.skip_balanced_payload()?;
+            }
+            _ => {
+                let _ = self.lex.next()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_balanced_payload(&mut self) -> Result<(), ParseError> {
+        if !matches!(
+            self.lex.peek()?,
+            Token::LParen | Token::LBrace | Token::LBracket | Token::LAngle
+        ) {
+            return Ok(());
+        }
+        let mut depth = 0usize;
+        loop {
+            let tok = self.lex.next()?;
+            match tok {
+                Token::LParen | Token::LBrace | Token::LBracket | Token::LAngle => depth += 1,
+                Token::RParen | Token::RBrace | Token::RBracket | Token::RAngle => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                Token::Eof => break,
+                _ => {}
+            }
         }
         Ok(())
     }
@@ -1771,5 +1905,24 @@ else:
         let (_ctx, module) = parse(src).expect("parse failed");
         let f = &module.functions[0];
         assert_eq!(f.blocks.len(), 3);
+    }
+
+    #[test]
+    fn parse_dbg_attachment_and_dilocation() {
+        let src = r#"
+source_filename = "dbg.ll"
+define i32 @f() {
+entry:
+  ret i32 0, !dbg !12
+}
+!12 = !DILocation(line: 27, column: 3, scope: !1)
+"#;
+        let (_ctx, module) = parse(src).expect("parse failed");
+        let f = &module.functions[0];
+        let tid = f.blocks[0].terminator.expect("terminator");
+        assert_eq!(f.instr_dbg_loc(tid), Some(12));
+        let loc = module.debug_location(12).expect("dilocation");
+        assert_eq!(loc.line, 27);
+        assert_eq!(loc.column, 3);
     }
 }

--- a/src/llvm-ir/src/function.rs
+++ b/src/llvm-ir/src/function.rs
@@ -17,6 +17,8 @@ pub struct Function {
     pub blocks: Vec<BasicBlock>,
     /// Flat instruction pool; `InstrId(i)` indexes `instructions[i]`.
     pub instructions: Vec<Instruction>,
+    /// Optional `!dbg !N` attachment for each instruction id.
+    pub instr_dbg_locs: HashMap<InstrId, u32>,
     /// Maps result name → InstrId.
     pub value_names: HashMap<String, InstrId>,
     /// Maps argument name → ArgId.
@@ -36,6 +38,7 @@ impl Function {
             args: Vec::new(),
             blocks: Vec::new(),
             instructions: Vec::new(),
+            instr_dbg_locs: HashMap::new(),
             value_names: HashMap::new(),
             arg_names: HashMap::new(),
             is_declaration: false,
@@ -118,6 +121,14 @@ impl Function {
 
     pub fn num_instrs(&self) -> usize {
         self.instructions.len()
+    }
+
+    pub fn set_instr_dbg_loc(&mut self, id: InstrId, loc_id: u32) {
+        self.instr_dbg_locs.insert(id, loc_id);
+    }
+
+    pub fn instr_dbg_loc(&self, id: InstrId) -> Option<u32> {
+        self.instr_dbg_locs.get(&id).copied()
     }
 
     // -----------------------------------------------------------------------

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -21,7 +21,7 @@ pub use instruction::{
     ExactFlag, FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
     TailCallKind,
 };
-pub use module::Module;
+pub use module::{DebugLocation, Module};
 pub use printer::Printer;
 pub use types::{FloatKind, FunctionType, StructType, TypeData};
 pub use value::{Argument, ConstantData, GlobalVariable, Linkage};

--- a/src/llvm-ir/src/module.rs
+++ b/src/llvm-ir/src/module.rs
@@ -5,6 +5,12 @@ use crate::function::Function;
 use crate::value::GlobalVariable;
 use std::collections::HashMap;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DebugLocation {
+    pub line: u32,
+    pub column: u32,
+}
+
 /// Top-level IR module.
 pub struct Module {
     pub name: String,
@@ -17,6 +23,8 @@ pub struct Module {
     pub global_names: HashMap<String, GlobalId>,
     /// Named type definitions in declaration order (for printing).
     pub named_types: Vec<(String, TypeId)>,
+    /// `!N = !DILocation(...)` records keyed by metadata id `N`.
+    pub debug_locations: HashMap<u32, DebugLocation>,
 }
 
 impl Module {
@@ -31,6 +39,7 @@ impl Module {
             function_names: HashMap::new(),
             global_names: HashMap::new(),
             named_types: Vec::new(),
+            debug_locations: HashMap::new(),
         }
     }
 
@@ -111,6 +120,14 @@ impl Module {
         if !self.named_types.iter().any(|(n, _)| n == &name) {
             self.named_types.push((name, ty));
         }
+    }
+
+    pub fn set_debug_location(&mut self, id: u32, loc: DebugLocation) {
+        self.debug_locations.insert(id, loc);
+    }
+
+    pub fn debug_location(&self, id: u32) -> Option<DebugLocation> {
+        self.debug_locations.get(&id).copied()
     }
 }
 

--- a/src/llvm-target-arm/src/lower.rs
+++ b/src/llvm-target-arm/src/lower.rs
@@ -29,6 +29,7 @@ impl IselBackend for AArch64Backend {
         let mut mf = MachineFunction::new(func.name.clone());
         mf.allocatable_pregs = ALLOCATABLE.to_vec();
         mf.callee_saved_pregs = CALLEE_SAVED.to_vec();
+        mf.debug_source = module.source_filename.clone();
 
         if func.is_declaration || func.blocks.is_empty() {
             return mf;
@@ -79,9 +80,19 @@ impl IselBackend for AArch64Backend {
         // Lower each IR block.
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_instr(ctx, module, func, &mut mf, bi, iid, &mut vmap);
             }
             if let Some(tid) = bb.terminator {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }

--- a/src/llvm-target-riscv/src/lower.rs
+++ b/src/llvm-target-riscv/src/lower.rs
@@ -25,6 +25,7 @@ impl IselBackend for RiscVBackend {
         let mut mf = MachineFunction::new(func.name.clone());
         mf.allocatable_pregs = ALLOCATABLE.to_vec();
         mf.callee_saved_pregs = CALLEE_SAVED.to_vec();
+        mf.debug_source = module.source_filename.clone();
 
         if func.is_declaration || func.blocks.is_empty() {
             return mf;
@@ -70,9 +71,19 @@ impl IselBackend for RiscVBackend {
 
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_instr(ctx, module, func, &mut mf, bi, iid, &mut vmap);
             }
             if let Some(tid) = bb.terminator {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -75,6 +75,7 @@ impl IselBackend for X86Backend {
         let mut mf = MachineFunction::new(func.name.clone());
         mf.allocatable_pregs = ALLOCATABLE.to_vec();
         mf.callee_saved_pregs = CALLEE_SAVED.to_vec();
+        mf.debug_source = module.source_filename.clone();
 
         if func.is_declaration || func.blocks.is_empty() {
             return mf;
@@ -125,6 +126,11 @@ impl IselBackend for X86Backend {
         // Lower each IR block.
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_instr(
                     ctx,
                     module,
@@ -137,6 +143,11 @@ impl IselBackend for X86Backend {
                 );
             }
             if let Some(tid) = bb.terminator {
+                if mf.debug_line_start.is_none() {
+                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
+                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
+                    }
+                }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }


### PR DESCRIPTION
## Summary
- add a dedicated `dwarf-debug` skill/agent and register it in `AGENTS.md`
- parse and preserve instruction `!dbg !N` attachments plus top-level `!DILocation` metadata
- thread debug metadata signal into machine lowering (`debug_source`, first debug line)
- emit a minimal ELF `.debug_line` section when debug metadata is present
- extend ELF serializer to support additional non-text sections
- add parser + codegen regression tests for debug-line flow
- document `.debug_line` verification commands in README

## Validation
- `cargo +stable test -p llvm-ir-parser`
- `cargo +stable test -p llvm-codegen`
- `cargo +stable test -q`

Closes #92
