### PR TITLE
Carry per-instruction debug locations through backend emission

### DIFF
--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -34,12 +34,22 @@ pub struct Reloc {
     pub addend: i64,
 }
 
+/// A single source mapping row for debug line table emission.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DebugLineRow {
+    pub address: u64,
+    pub line: u32,
+    pub column: u32,
+}
+
 /// A named output section (`.text`, `__TEXT,__text`, etc.).
 #[derive(Clone, Debug)]
 pub struct Section {
     pub name: String,
     pub data: Vec<u8>,
     pub relocs: Vec<Reloc>,
+    /// Address->source rows collected while encoding this section.
+    pub debug_rows: Vec<DebugLineRow>,
 }
 
 /// A symbol definition.
@@ -106,12 +116,28 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
     };
     let mut sections = vec![section];
     if emitter.object_format() == ObjectFormat::Elf {
-        if let Some(line) = mf.debug_line_start {
+        if !sections[0].debug_rows.is_empty() {
             let source = mf.debug_source.as_deref().unwrap_or("unknown");
             sections.push(Section {
                 name: ".debug_line".into(),
-                data: build_minimal_debug_line(source, line),
+                data: build_debug_line(source, &sections[0].debug_rows),
                 relocs: Vec::new(),
+                debug_rows: Vec::new(),
+            });
+        } else if let Some(line) = mf.debug_line_start {
+            let source = mf.debug_source.as_deref().unwrap_or("unknown");
+            sections.push(Section {
+                name: ".debug_line".into(),
+                data: build_debug_line(
+                    source,
+                    &[DebugLineRow {
+                        address: 0,
+                        line,
+                        column: 0,
+                    }],
+                ),
+                relocs: Vec::new(),
+                debug_rows: Vec::new(),
             });
         }
     }
@@ -378,7 +404,7 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
     buf
 }
 
-fn build_minimal_debug_line(source_file: &str, line: u32) -> Vec<u8> {
+fn build_debug_line(source_file: &str, rows: &[DebugLineRow]) -> Vec<u8> {
     let file = source_file.rsplit('/').next().unwrap_or(source_file);
 
     let mut header_body = Vec::<u8>::new();
@@ -397,11 +423,29 @@ fn build_minimal_debug_line(source_file: &str, line: u32) -> Vec<u8> {
     header_body.push(0); // file_names terminator
 
     let mut program = Vec::<u8>::new();
-    if line > 1 {
-        program.push(3); // DW_LNS_advance_line
-        write_sleb128(&mut program, (line - 1) as i64);
+    let mut sorted = rows.to_vec();
+    sorted.sort_by_key(|r| r.address);
+    let mut cur_addr = 0u64;
+    let mut cur_line = 1u32;
+    let mut cur_col = 0u32;
+    for row in sorted {
+        if row.address > cur_addr {
+            program.push(2); // DW_LNS_advance_pc
+            write_uleb128(&mut program, row.address - cur_addr);
+            cur_addr = row.address;
+        }
+        if row.line != cur_line {
+            program.push(3); // DW_LNS_advance_line
+            write_sleb128(&mut program, row.line as i64 - cur_line as i64);
+            cur_line = row.line;
+        }
+        if row.column != cur_col {
+            program.push(5); // DW_LNS_set_column
+            write_uleb128(&mut program, row.column as u64);
+            cur_col = row.column;
+        }
+        program.push(1); // DW_LNS_copy
     }
-    program.push(1); // DW_LNS_copy
     program.push(0);
     program.push(1);
     program.push(1); // DW_LNE_end_sequence
@@ -640,6 +684,7 @@ mod tests {
                 name: section_name.into(),
                 data: code,
                 relocs: vec![],
+                debug_rows: vec![],
             }],
             symbols: vec![Symbol {
                 name: "f".into(),
@@ -714,6 +759,7 @@ mod tests {
                     name: ".text".into(),
                     data: vec![0x90],
                     relocs: vec![],
+                    debug_rows: vec![],
                 }
             }
             fn object_format(&self) -> ObjectFormat {
@@ -743,6 +789,7 @@ mod tests {
                     name: ".text".into(),
                     data: vec![0x90],
                     relocs: vec![],
+                    debug_rows: vec![],
                 }
             }
             fn object_format(&self) -> ObjectFormat {

--- a/src/llvm-codegen/src/isel.rs
+++ b/src/llvm-codegen/src/isel.rs
@@ -20,6 +20,13 @@ pub struct PReg(pub u8);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MOpcode(pub u32);
 
+/// Source-level debug location carried with machine instructions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DebugLoc {
+    pub line: u32,
+    pub column: u32,
+}
+
 // ── machine operand ────────────────────────────────────────────────────────
 
 /// An operand in a machine instruction.
@@ -52,6 +59,8 @@ pub struct MInstr {
     /// Physical registers whose values are destroyed by this instruction
     /// (e.g. caller-saved regs clobbered by a call).
     pub clobbers: Vec<PReg>,
+    /// Source debug location associated with this machine instruction.
+    pub debug_loc: Option<DebugLoc>,
 }
 
 impl MInstr {
@@ -62,6 +71,7 @@ impl MInstr {
             operands: Vec::new(),
             phys_uses: Vec::new(),
             clobbers: Vec::new(),
+            debug_loc: None,
         }
     }
 
@@ -126,6 +136,8 @@ pub struct MachineFunction {
     pub debug_source: Option<String>,
     /// First source line observed from IR `!dbg` metadata.
     pub debug_line_start: Option<u32>,
+    /// Debug location automatically attached by [`MachineFunction::push`].
+    pub current_debug_loc: Option<DebugLoc>,
 }
 
 impl MachineFunction {
@@ -142,6 +154,7 @@ impl MachineFunction {
             next_slot: 0,
             debug_source: None,
             debug_line_start: None,
+            current_debug_loc: None,
         }
     }
 
@@ -180,7 +193,10 @@ impl MachineFunction {
     }
 
     /// Append `instr` to block `block_idx`.
-    pub fn push(&mut self, block_idx: usize, instr: MInstr) {
+    pub fn push(&mut self, block_idx: usize, mut instr: MInstr) {
+        if instr.debug_loc.is_none() {
+            instr.debug_loc = self.current_debug_loc;
+        }
         self.blocks[block_idx].instrs.push(instr);
     }
 }

--- a/src/llvm-codegen/tests/dwarf_line.rs
+++ b/src/llvm-codegen/tests/dwarf_line.rs
@@ -5,7 +5,7 @@ use llvm_codegen::{
     emit_object,
     isel::IselBackend,
     regalloc::{allocate_registers, apply_allocation, compute_live_intervals, RegAllocStrategy},
-    ObjectFormat,
+    ObjectFile, ObjectFormat,
 };
 use llvm_ir_parser::parser::parse;
 
@@ -18,23 +18,38 @@ entry:
 !12 = !DILocation(line: 42, column: 7, scope: !1)
 "#;
 
+const DBG_MULTI_LL: &str = r#"
+source_filename = "dbg_multi.c"
+define i32 @f(i1 %c) {
+entry:
+  br i1 %c, label %then, label %else, !dbg !10
+then:
+  ret i32 1, !dbg !11
+else:
+  ret i32 2, !dbg !12
+}
+!10 = !DILocation(line: 10, column: 1, scope: !1)
+!11 = !DILocation(line: 20, column: 3, scope: !1)
+!12 = !DILocation(line: 30, column: 5, scope: !1)
+"#;
+
 fn have_tool(name: &str) -> bool {
     Command::new(name).arg("--version").output().is_ok()
 }
 
 #[cfg(target_arch = "x86_64")]
-fn emit_dbg_elf_obj(out: &Path) {
+fn emit_dbg_elf_obj_from_ir(src: &str, out: &Path) -> ObjectFile {
     use llvm_target_x86::{
         instructions::{MOV_LOAD_MR, MOV_STORE_RM},
         X86Backend, X86Emitter,
     };
 
-    let (ctx, module) = parse(DBG_LL).expect("parse test ir");
+    let (ctx, module) = parse(src).expect("parse test ir");
     let func = module
         .functions
         .iter()
-        .find(|f| f.name == "main" && !f.is_declaration)
-        .expect("@main must exist");
+        .find(|f| !f.is_declaration)
+        .expect("one definition must exist");
 
     let mut backend = X86Backend::default();
     let mut mf = backend.lower_function(&ctx, &module, func);
@@ -51,22 +66,23 @@ fn emit_dbg_elf_obj(out: &Path) {
 
     assert!(obj.sections.iter().any(|s| s.name == ".debug_line"));
     std::fs::write(out, obj.to_bytes()).expect("write object");
+    obj
 }
 
 #[cfg(target_arch = "aarch64")]
-fn emit_dbg_elf_obj(out: &Path) {
+fn emit_dbg_elf_obj_from_ir(src: &str, out: &Path) -> ObjectFile {
     use llvm_target_arm::{
         encode::AArch64Emitter,
         instructions::{LDR_FP, STR_FP},
         lower::AArch64Backend,
     };
 
-    let (ctx, module) = parse(DBG_LL).expect("parse test ir");
+    let (ctx, module) = parse(src).expect("parse test ir");
     let func = module
         .functions
         .iter()
-        .find(|f| f.name == "main" && !f.is_declaration)
-        .expect("@main must exist");
+        .find(|f| !f.is_declaration)
+        .expect("one definition must exist");
 
     let mut backend = AArch64Backend;
     let mut mf = backend.lower_function(&ctx, &module, func);
@@ -83,17 +99,18 @@ fn emit_dbg_elf_obj(out: &Path) {
 
     assert!(obj.sections.iter().any(|s| s.name == ".debug_line"));
     std::fs::write(out, obj.to_bytes()).expect("write object");
+    obj
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-fn emit_dbg_elf_obj(_out: &Path) {
+fn emit_dbg_elf_obj_from_ir(_src: &str, _out: &Path) -> ObjectFile {
     panic!("unsupported host arch for dwarf_line test");
 }
 
 #[test]
 fn emits_debug_line_when_dbg_metadata_present() {
     let obj_path = std::env::temp_dir().join("llvm_codegen_dbg_line.o");
-    emit_dbg_elf_obj(&obj_path);
+    let _ = emit_dbg_elf_obj_from_ir(DBG_LL, &obj_path);
 
     if have_tool("readelf") {
         let out = Command::new("readelf")
@@ -117,5 +134,30 @@ fn emits_debug_line_when_dbg_metadata_present() {
         assert!(text.contains("dbg_test.c") || text.contains("line"), "dwarfdump output: {text}");
     }
 
+    let _ = std::fs::remove_file(&obj_path);
+}
+
+#[test]
+fn debug_rows_preserve_line_transitions_across_blocks() {
+    let obj_path = std::env::temp_dir().join("llvm_codegen_dbg_multi.o");
+    let obj = emit_dbg_elf_obj_from_ir(DBG_MULTI_LL, &obj_path);
+    let text = obj
+        .sections
+        .iter()
+        .find(|s| s.name == ".text" || s.name == "__text")
+        .expect("text section");
+    assert!(!text.debug_rows.is_empty(), "expected instruction debug rows");
+    let mut lines: Vec<u32> = text.debug_rows.iter().map(|r| r.line).collect();
+    lines.sort_unstable();
+    lines.dedup();
+    assert!(lines.contains(&10));
+    assert!(lines.contains(&20));
+    assert!(lines.contains(&30));
+    assert!(
+        text.debug_rows
+            .windows(2)
+            .all(|w| w[0].address <= w[1].address),
+        "rows must be in non-decreasing address order"
+    );
     let _ = std::fs::remove_file(&obj_path);
 }

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -9,7 +9,7 @@
 
 use crate::{instructions::*, regs::reg_enc};
 use llvm_codegen::{
-    emit::{Emitter, ObjectFormat, Reloc, Section},
+    emit::{DebugLineRow, Emitter, ObjectFormat, Reloc, Section},
     isel::{MInstr, MOperand, MachineFunction, PReg},
 };
 use std::collections::HashMap;
@@ -28,6 +28,7 @@ impl AArch64Emitter {
 impl Emitter for AArch64Emitter {
     fn emit_function(&mut self, mf: &MachineFunction) -> Section {
         let mut ctx = EncodeCtx::default();
+        let mut debug_rows: Vec<DebugLineRow> = Vec::new();
 
         // Determine whether we need a frame (x29/x30 save + sub-sp).
         // Needed when there are spill slots OR when callee-saved regs were used.
@@ -72,6 +73,7 @@ impl Emitter for AArch64Emitter {
         for (bi, block) in mf.blocks.iter().enumerate() {
             ctx.block_offsets.insert(bi, ctx.code.len());
             for instr in &block.instrs {
+                let instr_addr = ctx.code.len() as u64;
                 // Emit epilogue before any RET when we have a frame.
                 if instr.opcode == RET && needs_frame {
                     // ldr Xreg, [x29, #(16 + i*8)] for each callee-saved reg (reverse order).
@@ -87,6 +89,13 @@ impl Emitter for AArch64Emitter {
                     ctx.emit4(0xA8C00000 | (imm7 << 15) | (30 << 10) | (31 << 5) | 29);
                 }
                 encode_instr(instr, &mut ctx);
+                if let Some(loc) = instr.debug_loc {
+                    debug_rows.push(DebugLineRow {
+                        address: instr_addr,
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                }
             }
         }
 
@@ -134,6 +143,7 @@ impl Emitter for AArch64Emitter {
             name: section_name.into(),
             data: ctx.code,
             relocs: ctx.relocs,
+            debug_rows,
         }
     }
 
@@ -601,6 +611,7 @@ mod tests {
             operands: vec![MOperand::Imm(42)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_imm_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -618,6 +629,7 @@ mod tests {
             operands: vec![MOperand::PReg(X1), MOperand::PReg(X2)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("add_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -694,6 +706,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("ldr_fp_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -715,6 +728,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(X1)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("str_fp_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -848,6 +862,7 @@ mod tests {
             operands: vec![MOperand::Imm(val)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_wide_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -912,6 +927,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("cset_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -944,6 +960,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_LT)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("cset_lt_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -1052,6 +1069,7 @@ mod tests {
                 operands: vec![MOperand::Imm(0)], // slot 0
                 phys_uses: vec![],
                 clobbers: vec![],
+            debug_loc: None,
             },
         );
         mf.push(b, MInstr::new(RET));
@@ -1084,6 +1102,7 @@ mod tests {
             operands: vec![MOperand::Imm(val)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_wide_32_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-target-arm/src/lower.rs
+++ b/src/llvm-target-arm/src/lower.rs
@@ -9,7 +9,7 @@ use crate::{
     instructions::*,
     regs::{ALLOCATABLE, CALLEE_SAVED},
 };
-use llvm_codegen::isel::{IselBackend, MInstr, MachineFunction, PReg, VReg};
+use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MachineFunction, PReg, VReg};
 use llvm_ir::{
     ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
     TypeData, ValueRef,
@@ -80,23 +80,36 @@ impl IselBackend for AArch64Backend {
         // Lower each IR block.
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                let dbg = func
+                    .instr_dbg_loc(iid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_instr(ctx, module, func, &mut mf, bi, iid, &mut vmap);
             }
             if let Some(tid) = bb.terminator {
+                let dbg = func
+                    .instr_dbg_loc(tid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }
 
+        mf.current_debug_loc = None;
         mf
     }
 }

--- a/src/llvm-target-riscv/src/encode.rs
+++ b/src/llvm-target-riscv/src/encode.rs
@@ -1,7 +1,7 @@
 //! RV64 encoder and object emission.
 
 use crate::instructions::*;
-use llvm_codegen::emit::{Emitter, ObjectFormat, Section};
+use llvm_codegen::emit::{DebugLineRow, Emitter, ObjectFormat, Section};
 use llvm_codegen::isel::{MInstr, MOpcode, MOperand, MachineFunction, PReg, VReg};
 
 pub struct RiscVEmitter {
@@ -18,10 +18,18 @@ impl Emitter for RiscVEmitter {
     fn emit_function(&mut self, mf: &MachineFunction) -> Section {
         let mut data = Vec::new();
         let mut patches: Vec<(usize, usize, PatchKind, MOpcode)> = Vec::new();
+        let mut debug_rows: Vec<DebugLineRow> = Vec::new();
 
         for block in &mf.blocks {
             for instr in &block.instrs {
                 let off = data.len();
+                if let Some(loc) = instr.debug_loc {
+                    debug_rows.push(DebugLineRow {
+                        address: off as u64,
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                }
                 if let Some((target, kind)) = patch_from_instr(instr) {
                     patches.push((off, target, kind, instr.opcode));
                 }
@@ -59,6 +67,7 @@ impl Emitter for RiscVEmitter {
             name: ".text".into(),
             data,
             relocs: Vec::new(),
+            debug_rows,
         }
     }
 

--- a/src/llvm-target-riscv/src/lower.rs
+++ b/src/llvm-target-riscv/src/lower.rs
@@ -5,7 +5,7 @@ use crate::{
     instructions::*,
     regs::{ALLOCATABLE, CALLEE_SAVED, X0},
 };
-use llvm_codegen::isel::{IselBackend, MInstr, MachineFunction, PReg, VReg};
+use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MachineFunction, PReg, VReg};
 use llvm_ir::{
     ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
     ValueRef,
@@ -71,23 +71,36 @@ impl IselBackend for RiscVBackend {
 
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                let dbg = func
+                    .instr_dbg_loc(iid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_instr(ctx, module, func, &mut mf, bi, iid, &mut vmap);
             }
             if let Some(tid) = bb.terminator {
+                let dbg = func
+                    .instr_dbg_loc(tid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }
 
+        mf.current_debug_loc = None;
         mf
     }
 }

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -13,7 +13,7 @@ use crate::{
     regs::{is_extended, reg_enc},
 };
 use llvm_codegen::{
-    emit::{Emitter, ObjectFormat, Reloc, Section},
+    emit::{DebugLineRow, Emitter, ObjectFormat, Reloc, Section},
     isel::{MInstr, MOperand, MachineFunction, PReg},
 };
 use std::collections::HashMap;
@@ -32,6 +32,7 @@ impl X86Emitter {
 impl Emitter for X86Emitter {
     fn emit_function(&mut self, mf: &MachineFunction) -> Section {
         let mut ctx = EncodeCtx::default();
+        let mut debug_rows: Vec<DebugLineRow> = Vec::new();
 
         let n_callee = mf.used_callee_saved.len();
         let needs_frame = mf.frame_size > 0 || n_callee > 0;
@@ -95,6 +96,7 @@ impl Emitter for X86Emitter {
         for (bi, block) in mf.blocks.iter().enumerate() {
             ctx.block_offsets.insert(bi, ctx.code.len());
             for instr in &block.instrs {
+                let instr_addr = ctx.code.len() as u64;
                 // Emit epilogue before any RET instruction when we have a frame.
                 if instr.opcode == RET && needs_frame {
                     // add rsp, sub_rsp
@@ -122,6 +124,13 @@ impl Emitter for X86Emitter {
                     ctx.emit(0x5D);
                 }
                 encode_instr(instr, &mut ctx);
+                if let Some(loc) = instr.debug_loc {
+                    debug_rows.push(DebugLineRow {
+                        address: instr_addr,
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                }
             }
         }
 
@@ -144,6 +153,7 @@ impl Emitter for X86Emitter {
             name: section_name.into(),
             data: ctx.code,
             relocs: ctx.relocs,
+            debug_rows,
         }
     }
 
@@ -815,6 +825,7 @@ mod tests {
             operands: vec![MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_fn", vec![mi2]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -837,6 +848,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("setcc_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -861,6 +873,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("setcc_rax_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -882,6 +895,7 @@ mod tests {
             operands: vec![MOperand::PReg(RCX)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("div_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -904,6 +918,7 @@ mod tests {
             operands: vec![MOperand::PReg(RCX)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("idiv_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -928,6 +943,7 @@ mod tests {
             operands: vec![MOperand::PReg(RAX), MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_pr_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -951,6 +967,7 @@ mod tests {
             operands: vec![MOperand::PReg(R8), MOperand::PReg(RDI)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("mov_pr_ext_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1017,6 +1034,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)], // slot 0
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("load_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1043,6 +1061,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(RAX)], // slot 0, src=RAX
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("store_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1140,6 +1159,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("simd_ld", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1155,6 +1175,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("simd_st", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1170,6 +1191,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
+        debug_loc: None,
         };
         let mf = single_block_mf("simd_ld_aligned", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -9,7 +9,7 @@ use crate::{
     instructions::*,
     regs::{ALLOCATABLE, CALLEE_SAVED, RCX, RDX},
 };
-use llvm_codegen::isel::{IselBackend, MInstr, MachineFunction, PReg, VReg};
+use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MachineFunction, PReg, VReg};
 use llvm_ir::{
     ArgId, BlockId, ConstantData, Context, FloatKind, Function, InstrId, InstrKind, IntPredicate,
     Module, TypeData, ValueRef,
@@ -126,10 +126,16 @@ impl IselBackend for X86Backend {
         // Lower each IR block.
         for (bi, bb) in func.blocks.iter().enumerate() {
             for &iid in &bb.body {
+                let dbg = func
+                    .instr_dbg_loc(iid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(iid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_instr(
                     ctx,
@@ -143,15 +149,22 @@ impl IselBackend for X86Backend {
                 );
             }
             if let Some(tid) = bb.terminator {
+                let dbg = func
+                    .instr_dbg_loc(tid)
+                    .and_then(|loc_id| module.debug_location(loc_id))
+                    .map(|loc| DebugLoc {
+                        line: loc.line,
+                        column: loc.column,
+                    });
+                mf.current_debug_loc = dbg;
                 if mf.debug_line_start.is_none() {
-                    if let Some(loc_id) = func.instr_dbg_loc(tid) {
-                        mf.debug_line_start = module.debug_location(loc_id).map(|loc| loc.line);
-                    }
+                    mf.debug_line_start = dbg.map(|loc| loc.line);
                 }
                 lower_terminator(ctx, func, &mut mf, bi, tid, &mut vmap);
             }
         }
 
+        mf.current_debug_loc = None;
         mf
     }
 }


### PR DESCRIPTION
## Summary
- attach source debug locations (line/column) to machine instructions during lowering
- collect encoded instruction address->source rows in x86/AArch64/RISC-V emitters
- generate `.debug_line` from per-instruction rows instead of a single function-level line
- keep fallback path using `debug_line_start` when row-level data is unavailable
- add regression test covering multi-block line transitions in emitted debug rows

## Validation
- `cargo +stable test -p llvm-codegen -p llvm-target-x86 -p llvm-target-arm -p llvm-target-riscv`
- `cargo +stable test`

Closes #131
