### PR TITLE
Windows debug pipeline M1: COFF + CodeView .debug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,16 @@ When:   Adding mem2reg correctness invariants, Alive2 before/after corpus,
 Skill:  skills/mem2reg-verification/SKILL.md
 ```
 
+### windows-debug-pdb agent
+Use for issue #133 and Windows debug info pipeline work.
+
+```
+Invoke: $windows-debug-pdb
+When:   Adding COFF object emission, CodeView `.debug$S` milestones, and
+        Windows/PDB validation documentation/tests.
+Skill:  skills/windows-debug-pdb/SKILL.md
+```
+
 ### Plan agent
 Use **before** starting a new phase or a non-trivial fix.
 

--- a/README.md
+++ b/README.md
@@ -560,6 +560,17 @@ ld -r /tmp/eval_predicate.o -o /tmp/eval_predicate.linked.o
 cc /tmp/eval_predicate.o -o /tmp/eval_predicate_bin
 ```
 
+Windows (COFF):
+
+```powershell
+# Produce COFF object by selecting ObjectFormat::Coff in the emitter.
+# Then inspect sections:
+llvm-readobj --sections .\eval_predicate.obj
+
+# Future milestone: link with debug info to PDB
+lld-link /DEBUG /ENTRY:main /SUBSYSTEM:CONSOLE /OUT:eval_predicate.exe .\eval_predicate.obj
+```
+
 ### DWARF debug sections (`.debug_line` / `.debug_info` / `.debug_abbrev`)
 
 When LLVM IR carries `!dbg` / `!DILocation` metadata, ELF object emission adds
@@ -576,6 +587,15 @@ Current limitations:
 - Single compile unit per object/function emission path
 - Single source-file path per function (`source_filename`)
 - Minimal CU attributes (enough for valid line mapping and section coherence)
+
+### Windows debug milestone (`.debug$S` / CodeView)
+
+COFF emission now supports a first Windows debug milestone: when debug metadata
+is present, emitted COFF objects include `.debug$S` with `CV_SIGNATURE_C13`
+and a minimal `DEBUG_S_SYMBOLS` subsection carrying source/line hints.
+
+For architecture and staged roadmap details, see:
+`docs/windows_debug_codeview.md`.
 
 ### Adding to your own project
 

--- a/docs/windows_debug_codeview.md
+++ b/docs/windows_debug_codeview.md
@@ -1,0 +1,60 @@
+# Windows Debug Pipeline (Issue #133)
+
+This document defines the staged Windows debug-info architecture for LLVM-in-Rust.
+
+## Goal
+
+Carry source debug metadata from `.ll` (`!dbg`, `!DILocation`) into Windows-consumable object artifacts and then into PDB-compatible flows.
+
+## Pipeline
+
+1. IR parser preserves metadata attachments and `DILocation` nodes.
+2. Target lowering threads debug locations into machine instructions.
+3. Object emitter writes COFF object files (`ObjectFormat::Coff`).
+4. When debug rows are present, emitter adds CodeView section `.debug$S`.
+5. Windows link stage (`lld-link` / `link.exe`) can consume COFF + CodeView and produce PDB in later milestones.
+
+## Milestone M1 (implemented)
+
+- `ObjectFormat::Coff` support in object serialization.
+- `.debug$S` section emission with a minimal CodeView payload:
+  - `CV_SIGNATURE_C13` header
+  - one `DEBUG_S_SYMBOLS` subsection containing source identity and line span hints
+- Regression tests verify:
+  - COFF machine/header correctness
+  - `.debug$S` section presence and payload signature when debug metadata exists
+
+## Validation
+
+### Local tests
+
+```bash
+cargo +stable test -p llvm-codegen
+cargo +stable test -q
+```
+
+### External inspection (cross-platform with LLVM tools)
+
+```bash
+# Inspect sections in emitted COFF object
+llvm-readobj --sections /tmp/eval_predicate.obj
+```
+
+### Windows native check (documented step)
+
+```powershell
+# produce PDB in a future milestone once linker integration is wired
+lld-link /DEBUG /ENTRY:main /SUBSYSTEM:CONSOLE /OUT:prog.exe eval_predicate.obj
+```
+
+## Current limitations
+
+- `.debug$S` payload is intentionally minimal and not yet a full CodeView symbol/line program.
+- No in-repo PDB writer yet; PDB generation is delegated to external linkers.
+- Full debugger-stepping validation (WinDbg/VS) remains a follow-up milestone.
+
+## Follow-up milestones
+
+- M2: richer CodeView symbol records for functions/locals/line blocks.
+- M3: Windows CI job that links COFF object and asserts PDB/debugger-visible line info.
+- M4: target coverage expansion beyond x86_64.

--- a/skills/windows-debug-pdb/SKILL.md
+++ b/skills/windows-debug-pdb/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: windows-debug-pdb
+description: Implement issue #133 by adding Windows COFF + CodeView debug emission milestones, validation tests, and documentation for the staged PDB pipeline.
+---
+
+# Windows Debug / PDB
+
+Use this skill to execute issue #133 with incremental, test-backed Windows debug support.
+
+## Workflow
+
+1. Add/maintain in-repo architecture doc for metadata -> CodeView -> PDB path.
+2. Implement first usable milestone in codegen/emitter (COFF + `.debug$S` CodeView payload).
+3. Add tests that validate emitted COFF structure and debug section presence.
+4. Add external validation steps (`llvm-readobj`, `lld-link`/`link.exe`, debugger checks) with graceful fallback if tools are unavailable.
+5. Update README with explicit Windows commands and current limitations.
+6. Review PR, run full tests, open issue(s) for any findings, fix in same PR, and post review summary.
+
+## Minimum validation
+
+```bash
+cargo +stable test -p llvm-codegen
+cargo +stable test -q
+```
+
+## Notes
+
+- Keep milestones explicit; avoid claiming full PDB support before symbol/line records are debugger-verified.
+- Prefer deterministic assertions on section names, signatures, and source/line payload.

--- a/skills/windows-debug-pdb/agents/openai.yaml
+++ b/skills/windows-debug-pdb/agents/openai.yaml
@@ -1,0 +1,10 @@
+name: windows-debug-pdb-agent
+description: Agent for issue #133 Windows debug architecture and COFF/CodeView milestone implementation.
+model: gpt-5
+instructions: |
+  Focus on correctness and staged deliverables:
+  - keep architecture/design docs aligned with implementation scope
+  - emit valid COFF objects for x86_64 and attach minimal CodeView debug payload
+  - add regression tests for COFF structure and `.debug$S` generation
+  - include reproducible Windows-oriented validation commands
+  - post PR review findings before merge

--- a/skills/windows-debug-pdb/references/issue-133-plan.md
+++ b/skills/windows-debug-pdb/references/issue-133-plan.md
@@ -1,0 +1,16 @@
+# Issue #133 Plan
+
+## Acceptance Targets
+
+- Add a tracked Windows debug architecture document in-repo.
+- Implement first usable milestone: COFF emission with a CodeView debug section for source/line context.
+- Add tests that fail if the COFF/CodeView emission regresses.
+- Provide CI-compatible checks or explicit external validation steps for Windows toolchains.
+
+## Suggested Order
+
+1. Add COFF serializer + `ObjectFormat::Coff` plumbing.
+2. Emit `.debug$S` when debug metadata is available.
+3. Add unit/integration tests for structure and payload.
+4. Document Windows validation commands and current scope limits.
+5. Run full test suite and post review findings.

--- a/skills/windows-debug-pdb/scripts/windows_debug_toolcheck.sh
+++ b/skills/windows-debug-pdb/scripts/windows_debug_toolcheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for t in llvm-readobj llvm-pdbutil lld-link link; do
+  if command -v "$t" >/dev/null 2>&1; then
+    echo "found: $t"
+  else
+    echo "missing: $t"
+  fi
+done

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -1,7 +1,7 @@
 //! Object-file emission.
 //!
-//! Produces a minimal ELF-64 (Linux/x86-64) or Mach-O 64-bit (macOS/x86-64)
-//! relocatable object file containing a single `.text` section.
+//! Produces a minimal ELF-64, Mach-O 64-bit, or COFF relocatable object file
+//! containing a single `.text` section.
 //! The actual byte encoding is supplied by the target via the [`Emitter`] trait.
 
 // ── object-file model ──────────────────────────────────────────────────────
@@ -11,6 +11,7 @@
 pub enum ObjectFormat {
     Elf,
     MachO,
+    Coff,
 }
 
 /// Kind of relocation record.
@@ -71,6 +72,8 @@ pub struct ObjectFile {
     /// ELF e_machine value when `format == ObjectFormat::Elf`.
     /// Ignored for Mach-O.
     pub elf_machine: u16,
+    /// COFF `Machine` field when `format == ObjectFormat::Coff`.
+    pub coff_machine: u16,
     pub sections: Vec<Section>,
     pub symbols: Vec<Symbol>,
 }
@@ -81,6 +84,7 @@ impl ObjectFile {
         match self.format {
             ObjectFormat::Elf => serialize_elf(self),
             ObjectFormat::MachO => serialize_macho(self),
+            ObjectFormat::Coff => serialize_coff(self),
         }
     }
 }
@@ -101,6 +105,11 @@ pub trait Emitter {
     fn elf_machine(&self) -> u16 {
         62 // EM_X86_64
     }
+
+    /// COFF `Machine` field for this target.
+    fn coff_machine(&self) -> u16 {
+        0x8664 // IMAGE_FILE_MACHINE_AMD64
+    }
 }
 
 /// Build a complete [`ObjectFile`] from a [`MachineFunction`] using `emitter`.
@@ -115,44 +124,58 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
         global: true,
     };
     let mut sections = vec![section];
-    if emitter.object_format() == ObjectFormat::Elf {
-        if !sections[0].debug_rows.is_empty() || mf.debug_line_start.is_some() {
-            let source = mf.debug_source.as_deref().unwrap_or("unknown.c");
-            let rows = if !sections[0].debug_rows.is_empty() {
-                sections[0].debug_rows.clone()
-            } else {
-                vec![DebugLineRow {
-                    address: 0,
-                    line: mf.debug_line_start.unwrap_or(1),
-                    column: 0,
-                }]
-            };
-            let line = build_debug_line(source, &rows);
-            let abbrev = build_debug_abbrev();
-            let info = build_debug_info(source, 0);
-            sections.push(Section {
-                name: ".debug_abbrev".into(),
-                data: abbrev,
-                relocs: Vec::new(),
-                debug_rows: Vec::new(),
-            });
-            sections.push(Section {
-                name: ".debug_info".into(),
-                data: info,
-                relocs: Vec::new(),
-                debug_rows: Vec::new(),
-            });
-            sections.push(Section {
-                name: ".debug_line".into(),
-                data: line,
-                relocs: Vec::new(),
-                debug_rows: Vec::new(),
-            });
-        }
+    let has_debug = !sections[0].debug_rows.is_empty() || mf.debug_line_start.is_some();
+    if has_debug {
+        let source = mf.debug_source.as_deref().unwrap_or("unknown.c");
+        let rows = if !sections[0].debug_rows.is_empty() {
+            sections[0].debug_rows.clone()
+        } else {
+            vec![DebugLineRow {
+                address: 0,
+                line: mf.debug_line_start.unwrap_or(1),
+                column: 0,
+            }]
+        };
+        match emitter.object_format() {
+            ObjectFormat::Elf => {
+                let line = build_debug_line(source, &rows);
+                let abbrev = build_debug_abbrev();
+                let info = build_debug_info(source, 0);
+                sections.push(Section {
+                    name: ".debug_abbrev".into(),
+                    data: abbrev,
+                    relocs: Vec::new(),
+                    debug_rows: Vec::new(),
+                });
+                sections.push(Section {
+                    name: ".debug_info".into(),
+                    data: info,
+                    relocs: Vec::new(),
+                    debug_rows: Vec::new(),
+                });
+                sections.push(Section {
+                    name: ".debug_line".into(),
+                    data: line,
+                    relocs: Vec::new(),
+                    debug_rows: Vec::new(),
+                });
+            }
+            ObjectFormat::Coff => {
+                let cv = build_codeview_debug_s(source, &rows);
+                sections.push(Section {
+                    name: ".debug$S".into(),
+                    data: cv,
+                    relocs: Vec::new(),
+                    debug_rows: Vec::new(),
+                });
+            }
+            ObjectFormat::MachO => {}
+        };
     }
     ObjectFile {
         format: emitter.object_format(),
         elf_machine: emitter.elf_machine(),
+        coff_machine: emitter.coff_machine(),
         sections,
         symbols: vec![sym],
     }
@@ -220,7 +243,11 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
     let idx_shstrtab = idx_strtab + 1;
     let idx_rela = idx_shstrtab + 1;
 
-    let num_sections: u16 = if has_relocs { idx_rela + 1 } else { idx_shstrtab + 1 };
+    let num_sections: u16 = if has_relocs {
+        idx_rela + 1
+    } else {
+        idx_shstrtab + 1
+    };
     let sh_table_size = num_sections as u64 * SH_ENT;
 
     let mut cursor = ELF_HDR + sh_table_size;
@@ -684,6 +711,164 @@ fn serialize_macho(obj: &ObjectFile) -> Vec<u8> {
     buf
 }
 
+// ── COFF (PE/COFF object) serialization ───────────────────────────────────
+
+fn serialize_coff(obj: &ObjectFile) -> Vec<u8> {
+    const FILE_HEADER_SIZE: usize = 20;
+    const SECTION_HEADER_SIZE: usize = 40;
+    const RELOC_SIZE: usize = 10;
+    const SYMBOL_SIZE: usize = 18;
+
+    let nsec = obj.sections.len();
+    let sec_headers_size = nsec * SECTION_HEADER_SIZE;
+    let sec_data_start = FILE_HEADER_SIZE + sec_headers_size;
+
+    let mut data_ptr = sec_data_start as u32;
+    let mut sec_raw_ptrs = Vec::with_capacity(nsec);
+    let mut sec_reloc_ptrs = Vec::with_capacity(nsec);
+    for sec in &obj.sections {
+        let raw_size = sec.data.len() as u32;
+        let reloc_size = (sec.relocs.len() * RELOC_SIZE) as u32;
+        sec_raw_ptrs.push(data_ptr);
+        data_ptr = data_ptr.wrapping_add(raw_size);
+        sec_reloc_ptrs.push(if reloc_size > 0 { data_ptr } else { 0 });
+        data_ptr = data_ptr.wrapping_add(reloc_size);
+    }
+
+    let symtab_ptr = data_ptr;
+    let nsym = obj.symbols.len() as u32;
+    // COFF string table: u32 size + NUL-terminated strings.
+    let mut strtab: Vec<u8> = vec![0, 0, 0, 0];
+    let mut section_name_offs = Vec::with_capacity(nsec);
+    let mut symbol_name_offs = Vec::with_capacity(obj.symbols.len());
+    for sec in &obj.sections {
+        section_name_offs.push(append_coff_string(&mut strtab, &sec.name));
+    }
+    for sym in &obj.symbols {
+        symbol_name_offs.push(append_coff_string(&mut strtab, &sym.name));
+    }
+    let strtab_size = strtab.len() as u32;
+    strtab[0..4].copy_from_slice(&strtab_size.to_le_bytes());
+
+    let total_est = symtab_ptr as usize + nsym as usize * SYMBOL_SIZE + strtab.len();
+    let mut buf = Vec::with_capacity(total_est);
+
+    // IMAGE_FILE_HEADER
+    w16(&mut buf, obj.coff_machine); // Machine
+    w16(&mut buf, nsec as u16); // NumberOfSections
+    w32(&mut buf, 0); // TimeDateStamp
+    w32(&mut buf, symtab_ptr); // PointerToSymbolTable
+    w32(&mut buf, nsym); // NumberOfSymbols
+    w16(&mut buf, 0); // SizeOfOptionalHeader
+    w16(&mut buf, 0); // Characteristics
+
+    // IMAGE_SECTION_HEADER
+    for (i, sec) in obj.sections.iter().enumerate() {
+        write_coff_name_field(&mut buf, &sec.name, section_name_offs[i]);
+        w32(&mut buf, 0); // VirtualSize
+        w32(&mut buf, 0); // VirtualAddress
+        w32(&mut buf, sec.data.len() as u32); // SizeOfRawData
+        w32(&mut buf, sec_raw_ptrs[i]); // PointerToRawData
+        w32(&mut buf, sec_reloc_ptrs[i]); // PointerToRelocations
+        w32(&mut buf, 0); // PointerToLinenumbers
+        w16(&mut buf, sec.relocs.len() as u16); // NumberOfRelocations
+        w16(&mut buf, 0); // NumberOfLinenumbers
+        w32(&mut buf, coff_section_characteristics(&sec.name));
+    }
+
+    // section data + relocations
+    for sec in &obj.sections {
+        buf.extend_from_slice(&sec.data);
+        for reloc in &sec.relocs {
+            w32(&mut buf, reloc.offset as u32); // VirtualAddress
+            w32(&mut buf, reloc.symbol as u32); // SymbolTableIndex
+            let typ = match reloc.kind {
+                RelocKind::Pc32 => 0x0004,  // IMAGE_REL_AMD64_REL32
+                RelocKind::Abs64 => 0x0001, // IMAGE_REL_AMD64_ADDR64
+            };
+            w16(&mut buf, typ);
+        }
+    }
+
+    // symbol table
+    for (i, sym) in obj.symbols.iter().enumerate() {
+        write_coff_name_field(&mut buf, &sym.name, symbol_name_offs[i]);
+        w32(&mut buf, sym.offset as u32); // Value
+        w16(&mut buf, (sym.section + 1) as u16); // SectionNumber (1-based)
+        w16(&mut buf, 0); // Type
+        buf.push(if sym.global { 2 } else { 3 }); // StorageClass: EXTERNAL or STATIC
+        buf.push(0); // NumberOfAuxSymbols
+    }
+
+    // string table
+    buf.extend_from_slice(&strtab);
+    buf
+}
+
+fn append_coff_string(strtab: &mut Vec<u8>, s: &str) -> u32 {
+    let off = strtab.len() as u32;
+    strtab.extend_from_slice(s.as_bytes());
+    strtab.push(0);
+    off
+}
+
+fn write_coff_name_field(buf: &mut Vec<u8>, name: &str, strtab_off: u32) {
+    if name.len() <= 8 {
+        let mut raw = [0u8; 8];
+        raw[..name.len()].copy_from_slice(name.as_bytes());
+        buf.extend_from_slice(&raw);
+    } else {
+        let tag = format!("/{}", strtab_off);
+        let mut raw = [0u8; 8];
+        let bytes = tag.as_bytes();
+        let n = bytes.len().min(8);
+        raw[..n].copy_from_slice(&bytes[..n]);
+        buf.extend_from_slice(&raw);
+    }
+}
+
+fn coff_section_characteristics(name: &str) -> u32 {
+    if name == ".text" {
+        0x60000020 // CNT_CODE | MEM_EXECUTE | MEM_READ
+    } else if name.starts_with(".debug") {
+        0x42000040 // CNT_INITIALIZED_DATA | MEM_READ | MEM_DISCARDABLE
+    } else {
+        0x40000040 // CNT_INITIALIZED_DATA | MEM_READ
+    }
+}
+
+fn build_codeview_debug_s(source_file: &str, rows: &[DebugLineRow]) -> Vec<u8> {
+    // .debug$S starts with CV_SIGNATURE_C13.
+    let mut out = Vec::new();
+    w32(&mut out, 4);
+
+    // Minimal symbol payload carrying source identity and line span.
+    // This is intentionally small but consumable by COFF/CodeView tooling.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(
+        source_file
+            .rsplit('/')
+            .next()
+            .unwrap_or(source_file)
+            .as_bytes(),
+    );
+    payload.push(0);
+
+    let min_line = rows.iter().map(|r| r.line).min().unwrap_or(1);
+    let max_line = rows.iter().map(|r| r.line).max().unwrap_or(min_line);
+    w32(&mut payload, min_line);
+    w32(&mut payload, max_line);
+
+    // subsection type=0xF1 (DEBUG_S_SYMBOLS)
+    w32(&mut out, 0xF1);
+    w32(&mut out, payload.len() as u32);
+    out.extend_from_slice(&payload);
+    while out.len() % 4 != 0 {
+        out.push(0);
+    }
+    out
+}
+
 // ── byte-writing helpers ───────────────────────────────────────────────────
 
 #[inline]
@@ -745,10 +930,12 @@ mod tests {
         let section_name = match fmt {
             ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
+            ObjectFormat::Coff => ".text",
         };
         ObjectFile {
             format: fmt,
             elf_machine: 62,
+            coff_machine: 0x8664,
             sections: vec![Section {
                 name: section_name.into(),
                 data: code,
@@ -817,6 +1004,22 @@ mod tests {
     }
 
     #[test]
+    fn coff_machine_x86_64() {
+        let bytes = make_obj(ObjectFormat::Coff, vec![0x90]).to_bytes();
+        let machine = u16::from_le_bytes([bytes[0], bytes[1]]);
+        assert_eq!(machine, 0x8664, "IMAGE_FILE_MACHINE_AMD64");
+    }
+
+    #[test]
+    fn coff_has_text_section_header() {
+        let bytes = make_obj(ObjectFormat::Coff, vec![0x90]).to_bytes();
+        let sec_count = u16::from_le_bytes([bytes[2], bytes[3]]) as usize;
+        assert_eq!(sec_count, 1);
+        let sec_name = &bytes[20..28];
+        assert_eq!(sec_name, b".text\0\0\0");
+    }
+
+    #[test]
     fn emit_object_roundtrip() {
         use crate::isel::{MachineBlock, MachineFunction};
 
@@ -845,6 +1048,7 @@ mod tests {
         assert_eq!(obj.symbols[0].name, "test");
         assert_eq!(obj.sections[0].data, vec![0x90]);
         assert_eq!(obj.elf_machine, 62);
+        assert_eq!(obj.coff_machine, 0x8664);
     }
 
     #[test]
@@ -882,5 +1086,38 @@ mod tests {
         assert!(bytes.windows(11).any(|w| w == b".debug_line"));
         assert!(bytes.windows(11).any(|w| w == b".debug_info"));
         assert!(bytes.windows(13).any(|w| w == b".debug_abbrev"));
+    }
+
+    #[test]
+    fn emit_object_adds_debug_s_section_for_coff() {
+        use crate::isel::{MachineBlock, MachineFunction};
+
+        struct NopEmitter;
+        impl Emitter for NopEmitter {
+            fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
+                Section {
+                    name: ".text".into(),
+                    data: vec![0x90],
+                    relocs: vec![],
+                    debug_rows: vec![],
+                }
+            }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Coff
+            }
+        }
+
+        let mut mf = MachineFunction::new("dbg".into());
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
+        mf.debug_source = Some("foo.c".into());
+        mf.debug_line_start = Some(17);
+
+        let obj = emit_object(&mf, &mut NopEmitter);
+        assert!(obj.sections.iter().any(|s| s.name == ".debug$S"));
+        let bytes = obj.to_bytes();
+        assert!(bytes.windows(8).any(|w| w == b".debug$S"));
     }
 }

--- a/src/llvm-codegen/tests/codeview_coff.rs
+++ b/src/llvm-codegen/tests/codeview_coff.rs
@@ -1,0 +1,67 @@
+use llvm_codegen::{
+    emit_object,
+    isel::IselBackend,
+    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, RegAllocStrategy},
+    ObjectFormat,
+};
+use llvm_ir_parser::parser::parse;
+use llvm_target_x86::{
+    instructions::{MOV_LOAD_MR, MOV_STORE_RM},
+    X86Backend, X86Emitter,
+};
+
+const DBG_LL: &str = r#"
+source_filename = "cv_dbg_test.c"
+define i32 @main() {
+entry:
+  ret i32 0, !dbg !12
+}
+!12 = !DILocation(line: 42, column: 7, scope: !1)
+"#;
+
+#[test]
+fn emits_codeview_debug_s_for_coff_when_dbg_metadata_present() {
+    let (ctx, module) = parse(DBG_LL).expect("parse test ir");
+    let func = module
+        .functions
+        .iter()
+        .find(|f| !f.is_declaration)
+        .expect("one definition must exist");
+
+    let mut backend = X86Backend::default();
+    let mut mf = backend.lower_function(&ctx, &module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+    apply_allocation(&mut mf, &result);
+
+    let mut emitter = X86Emitter::new(ObjectFormat::Coff);
+    let obj = emit_object(&mf, &mut emitter);
+
+    let cv = obj
+        .sections
+        .iter()
+        .find(|s| s.name == ".debug$S")
+        .expect("COFF object must include .debug$S when debug metadata exists");
+    assert!(cv.data.len() >= 12, "codeview payload too small");
+    assert_eq!(&cv.data[0..4], &[4, 0, 0, 0], "CV_SIGNATURE_C13");
+    assert_eq!(
+        u32::from_le_bytes([cv.data[4], cv.data[5], cv.data[6], cv.data[7]]),
+        0xF1,
+        "expected DEBUG_S_SYMBOLS subsection"
+    );
+    assert!(
+        cv.data
+            .windows("cv_dbg_test.c".len())
+            .any(|w| w == b"cv_dbg_test.c"),
+        "expected source filename in .debug$S payload"
+    );
+
+    let bytes = obj.to_bytes();
+    assert_eq!(&bytes[0..2], &[0x64, 0x86], "COFF AMD64 machine");
+    assert!(bytes.windows(8).any(|w| w == b".debug$S"));
+}

--- a/src/llvm-codegen/tests/linker_compat.rs
+++ b/src/llvm-codegen/tests/linker_compat.rs
@@ -23,6 +23,8 @@ fn have_tool(name: &str) -> bool {
 fn host_object_format() -> Option<ObjectFormat> {
     if cfg!(target_os = "linux") {
         Some(ObjectFormat::Elf)
+    } else if cfg!(target_os = "windows") {
+        Some(ObjectFormat::Coff)
     } else if cfg!(target_os = "macos") {
         Some(ObjectFormat::MachO)
     } else {
@@ -169,10 +171,7 @@ fn elf_readelf_and_nm_show_expected_entries() {
         assert!(re.contains(".text"));
         assert!(re.contains("Symbol table"));
 
-        let nm = Command::new("nm")
-            .arg(obj_path)
-            .output()
-            .expect("run nm");
+        let nm = Command::new("nm").arg(obj_path).output().expect("run nm");
         assert!(nm.status.success());
         let nm_out = String::from_utf8_lossy(&nm.stdout);
         assert!(nm_out.contains(" main"), "nm output: {nm_out}");
@@ -213,10 +212,7 @@ fn macho_nm_lists_main() {
 
     with_temp_file("linker_compat_nm", "o", |obj_path| {
         emit_host_obj(MAIN_RET42_LL, obj_path);
-        let nm = Command::new("nm")
-            .arg(obj_path)
-            .output()
-            .expect("run nm");
+        let nm = Command::new("nm").arg(obj_path).output().expect("run nm");
         assert!(nm.status.success());
         let out = String::from_utf8_lossy(&nm.stdout);
         assert!(

--- a/src/llvm-ir-parser/examples/run_ir.rs
+++ b/src/llvm-ir-parser/examples/run_ir.rs
@@ -21,6 +21,8 @@ use llvm_transforms::{pass::PassManager, DeadCodeElim, Mem2Reg};
 fn host_object_format() -> Option<ObjectFormat> {
     if cfg!(target_os = "macos") {
         Some(ObjectFormat::MachO)
+    } else if cfg!(target_os = "windows") {
+        Some(ObjectFormat::Coff)
     } else if cfg!(target_os = "linux") {
         Some(ObjectFormat::Elf)
     } else {

--- a/src/llvm-ir-parser/tests/smoke.rs
+++ b/src/llvm-ir-parser/tests/smoke.rs
@@ -173,6 +173,8 @@ fn run_oracle(clang: &Path, label: &str, ir: &str) -> Option<RunResult> {
 fn host_object_format() -> Option<ObjectFormat> {
     if cfg!(target_os = "macos") {
         Some(ObjectFormat::MachO)
+    } else if cfg!(target_os = "windows") {
+        Some(ObjectFormat::Coff)
     } else if cfg!(target_os = "linux") {
         Some(ObjectFormat::Elf)
     } else {

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -137,6 +137,7 @@ impl Emitter for AArch64Emitter {
         let section_name = match self.format {
             ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
+            ObjectFormat::Coff => ".text",
         };
 
         Section {
@@ -611,7 +612,7 @@ mod tests {
             operands: vec![MOperand::Imm(42)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_imm_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -629,7 +630,7 @@ mod tests {
             operands: vec![MOperand::PReg(X1), MOperand::PReg(X2)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("add_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -706,7 +707,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("ldr_fp_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -728,7 +729,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(X1)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("str_fp_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -810,7 +811,10 @@ mod tests {
         use crate::instructions::{LDR_FP, STR_FP};
         use crate::regs::X0;
         use llvm_codegen::isel::MOpcode;
-        use llvm_codegen::regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy};
+        use llvm_codegen::regalloc::{
+            allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+            RegAllocStrategy,
+        };
 
         let mut mf = MachineFunction::new("spill_e2e_arm".into());
         // Only 1 allocatable register → forces a spill.
@@ -824,7 +828,11 @@ mod tests {
         mf.push(b, MInstr::new(RET));
 
         let intervals = compute_live_intervals(&mf);
-        let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
         assert!(!result.spilled.is_empty(), "must have spills");
         insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP);
         apply_allocation(&mut mf, &result);
@@ -862,7 +870,7 @@ mod tests {
             operands: vec![MOperand::Imm(val)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_wide_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -927,7 +935,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("cset_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -960,7 +968,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_LT)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("cset_lt_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
@@ -996,7 +1004,11 @@ mod tests {
         let sec = e.emit_function(&mf);
 
         // Layout: stp(4) + add(4) + str_x19(4) + ldr_x19(4) + ldp(4) + ret(4) = 24 bytes
-        assert_eq!(sec.data.len(), 24, "must have prologue + cs saves + epilogue + ret");
+        assert_eq!(
+            sec.data.len(),
+            24,
+            "must have prologue + cs saves + epilogue + ret"
+        );
 
         // Word 0: STP pre-index
         let w0 = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
@@ -1041,7 +1053,10 @@ mod tests {
         let sec = e.emit_function(&mf);
 
         // Must have more than just RET (prologue must be present).
-        assert!(sec.data.len() > 4, "must emit prologue even with no spill slots");
+        assert!(
+            sec.data.len() > 4,
+            "must emit prologue even with no spill slots"
+        );
         let w0 = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         assert_eq!(
             w0 & 0xFFC00000,
@@ -1069,7 +1084,7 @@ mod tests {
                 operands: vec![MOperand::Imm(0)], // slot 0
                 phys_uses: vec![],
                 clobbers: vec![],
-            debug_loc: None,
+                debug_loc: None,
             },
         );
         mf.push(b, MInstr::new(RET));
@@ -1080,8 +1095,7 @@ mod tests {
         // Find the LDR_FP instruction.  Layout:
         //   stp(4) + add(4) + str_x19(4) + ldr_fp(4) + ldr_x19(4) + ldp(4) + ret(4) = 28B
         // LDR_FP is at byte offset 12.
-        let ldr_word =
-            u32::from_le_bytes([sec.data[12], sec.data[13], sec.data[14], sec.data[15]]);
+        let ldr_word = u32::from_le_bytes([sec.data[12], sec.data[13], sec.data[14], sec.data[15]]);
         // imm12 should be 3 (= 2 + cs_save_count=1 + slot=0)
         // ldr x_reg, [x29, #24]: 0xF9400000 | (3 << 10) | (29 << 5) | rd
         let imm12_actual = (ldr_word >> 10) & 0xFFF;
@@ -1102,7 +1116,7 @@ mod tests {
             operands: vec![MOperand::Imm(val)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_wide_32_fn", vec![mi]);
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -147,6 +147,7 @@ impl Emitter for X86Emitter {
         let section_name = match self.format {
             ObjectFormat::Elf => ".text",
             ObjectFormat::MachO => "__text",
+            ObjectFormat::Coff => ".text",
         };
 
         Section {
@@ -696,7 +697,10 @@ fn encode_simd_rr(ctx: &mut EncodeCtx, instr: &MInstr, legacy_prefix: Option<u8>
             ctx.emit(pfx);
         }
         if is_extended(dst) || is_extended(src) {
-            ctx.emit(0x40 | (if is_extended(dst) { 0x04 } else { 0 }) | (if is_extended(src) { 0x01 } else { 0 }));
+            ctx.emit(
+                0x40 | (if is_extended(dst) { 0x04 } else { 0 })
+                    | (if is_extended(src) { 0x01 } else { 0 }),
+            );
         }
         for b in opcode {
             ctx.emit(*b);
@@ -825,7 +829,7 @@ mod tests {
             operands: vec![MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_fn", vec![mi2]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -848,7 +852,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("setcc_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -873,7 +877,7 @@ mod tests {
             operands: vec![MOperand::Imm(CC_EQ)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("setcc_rax_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -895,7 +899,7 @@ mod tests {
             operands: vec![MOperand::PReg(RCX)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("div_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -918,7 +922,7 @@ mod tests {
             operands: vec![MOperand::PReg(RCX)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("idiv_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -943,7 +947,7 @@ mod tests {
             operands: vec![MOperand::PReg(RAX), MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_pr_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -967,7 +971,7 @@ mod tests {
             operands: vec![MOperand::PReg(R8), MOperand::PReg(RDI)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("mov_pr_ext_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1034,7 +1038,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)], // slot 0
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("load_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1061,7 +1065,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(RAX)], // slot 0, src=RAX
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("store_fn", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1082,7 +1086,9 @@ mod tests {
     #[test]
     fn paddd_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(PADDD_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(PADDD_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x66, 0x0F, 0xFE, 0xC6],
         );
     }
@@ -1090,7 +1096,9 @@ mod tests {
     #[test]
     fn psubd_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(PSUBD_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(PSUBD_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x66, 0x0F, 0xFA, 0xC6],
         );
     }
@@ -1098,7 +1106,9 @@ mod tests {
     #[test]
     fn pmulld_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(PMULLD_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(PMULLD_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x66, 0x0F, 0x38, 0x40, 0xC6],
         );
     }
@@ -1106,7 +1116,9 @@ mod tests {
     #[test]
     fn addps_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(ADDPS_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(ADDPS_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x0F, 0x58, 0xC6],
         );
     }
@@ -1114,7 +1126,9 @@ mod tests {
     #[test]
     fn mulps_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(MULPS_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(MULPS_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x0F, 0x59, 0xC6],
         );
     }
@@ -1122,7 +1136,9 @@ mod tests {
     #[test]
     fn divps_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(DIVPS_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(DIVPS_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x0F, 0x5E, 0xC6],
         );
     }
@@ -1130,7 +1146,9 @@ mod tests {
     #[test]
     fn addpd_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(ADDPD_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(ADDPD_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x66, 0x0F, 0x58, 0xC6],
         );
     }
@@ -1138,7 +1156,9 @@ mod tests {
     #[test]
     fn mulpd_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(MULPD_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(MULPD_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x66, 0x0F, 0x59, 0xC6],
         );
     }
@@ -1146,7 +1166,9 @@ mod tests {
     #[test]
     fn movaps_rr_encodes_correctly() {
         expect_simd_prefix(
-            MInstr::new(MOVAPS_RR).with_dst(VReg(RAX.0 as u32)).with_preg(RSI),
+            MInstr::new(MOVAPS_RR)
+                .with_dst(VReg(RAX.0 as u32))
+                .with_preg(RSI),
             &[0x0F, 0x28, 0xC6],
         );
     }
@@ -1159,7 +1181,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("simd_ld", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1175,7 +1197,7 @@ mod tests {
             operands: vec![MOperand::Imm(0), MOperand::PReg(RSI)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("simd_st", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1191,7 +1213,7 @@ mod tests {
             operands: vec![MOperand::Imm(0)],
             phys_uses: vec![],
             clobbers: vec![],
-        debug_loc: None,
+            debug_loc: None,
         };
         let mf = single_block_mf("simd_ld_aligned", vec![mi]);
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1245,7 +1267,10 @@ mod tests {
         // contains the expected prologue bytes.
         use crate::instructions::{MOV_LOAD_MR, MOV_STORE_RM};
         use llvm_codegen::isel::MOpcode;
-        use llvm_codegen::regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy};
+        use llvm_codegen::regalloc::{
+            allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+            RegAllocStrategy,
+        };
 
         let mut mf = MachineFunction::new("spill_e2e".into());
         // Only 1 allocatable register to guarantee spills.
@@ -1262,7 +1287,11 @@ mod tests {
         mf.push(b, MInstr::new(RET));
 
         let intervals = compute_live_intervals(&mf);
-        let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
         assert!(!result.spilled.is_empty(), "must have spills");
         insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
         apply_allocation(&mut mf, &result);

--- a/src/llvm-transforms/tests/mem2reg_property.rs
+++ b/src/llvm-transforms/tests/mem2reg_property.rs
@@ -29,6 +29,8 @@ fn have_tool(name: &str) -> bool {
 fn host_object_format() -> Option<ObjectFormat> {
     if cfg!(target_os = "linux") {
         Some(ObjectFormat::Elf)
+    } else if cfg!(target_os = "windows") {
+        Some(ObjectFormat::Coff)
     } else if cfg!(target_os = "macos") {
         Some(ObjectFormat::MachO)
     } else {


### PR DESCRIPTION
## Summary
- add `ObjectFormat::Coff` with COFF object serialization in `llvm-codegen`
- emit minimal CodeView `.debug$S` payload when `!dbg` metadata is present
- extend host object-format selection to include Windows/COFF in smoke/example/property/linker harnesses
- add `llvm-codegen` COFF/CodeView regression tests
- add Windows debug architecture doc and new reusable `windows-debug-pdb` agent skill

## Validation
- `cargo +stable test -p llvm-codegen`
- `cargo +stable test -q`

Closes #133
