### PR TITLE
Add dedicated constant-folding pass and wire into O1+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,16 @@ When:   Adding COFF object emission, CodeView `.debug$S` milestones, and
 Skill:  skills/windows-debug-pdb/SKILL.md
 ```
 
+### constant-folding agent
+Use for issue #140 and middle-end constant-folding pass work.
+
+```
+Invoke: $constant-folding
+When:   Adding dedicated compile-time constant evaluation pass behavior,
+        pipeline integration at O1+, and fold/non-fold regression tests.
+Skill:  skills/constant-folding/SKILL.md
+```
+
 ### Plan agent
 Use **before** starting a new phase or a non-trivial fix.
 

--- a/skills/constant-folding/SKILL.md
+++ b/skills/constant-folding/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: constant-folding
+description: Implement issue #140 by adding a dedicated middle-end constant-folding pass, integrating it into O1+ pipelines, and validating fold/non-fold regressions.
+---
+
+# Constant Folding
+
+Use this skill to execute issue #140 with small, correctness-first compiler changes.
+
+## Workflow
+
+1. Implement a dedicated function pass that folds compile-time constant expressions.
+2. Reuse existing fold semantics helper (`try_fold`) to avoid divergent rules.
+3. Integrate pass into optimization presets (`-O1`, `-O2`, `-O3`).
+4. Add regression tests for both folded (`2 + 2`) and non-folded (value-dependent) cases.
+5. Run targeted and full test suites.
+6. Review PR, post review findings, and merge once checks are green.
+
+## Minimum validation
+
+```bash
+cargo +stable test -p llvm-transforms
+cargo +stable test -q
+```
+
+## Notes
+
+- Preserve behavior on undefined/edge cases (e.g., division by zero stays unfolder).
+- Keep pass ordering explicit in `pipeline.rs` to satisfy roadmap traceability.

--- a/skills/constant-folding/agents/openai.yaml
+++ b/skills/constant-folding/agents/openai.yaml
@@ -1,0 +1,10 @@
+name: constant-folding-agent
+description: Agent for issue #140 dedicated constant-folding pass and O1+ pipeline integration.
+model: gpt-5
+instructions: |
+  Focus on semantic correctness:
+  - use existing fold semantics helper for arithmetic/bitwise/shift/icmp/select
+  - implement a dedicated pass object instead of implicit-only folding
+  - add fold and non-fold regression coverage
+  - integrate into optimization presets with explicit ordering
+  - run full tests and post PR review comment before merge

--- a/skills/constant-folding/references/issue-140-plan.md
+++ b/skills/constant-folding/references/issue-140-plan.md
@@ -1,0 +1,16 @@
+# Issue #140 Plan
+
+## Acceptance Targets
+
+- Introduce a first-class constant-folding pass in `llvm-transforms`.
+- Ensure O1+ pipelines execute the pass.
+- Add tests proving compile-time fold of `2 + 2` and preserving non-foldable cases.
+- Keep behavior-preservation guarantees across full test suite.
+
+## Suggested Order
+
+1. Add pass module and export.
+2. Wire pass into pipeline presets.
+3. Add targeted tests for fold/non-fold semantics.
+4. Run targeted/full tests.
+5. Open PR, review, and merge.

--- a/skills/constant-folding/scripts/fold_audit.sh
+++ b/skills/constant-folding/scripts/fold_audit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+rg -n "ConstantFold|ConstProp|build_pipeline\(OptLevel::O[123]\)" src/llvm-transforms/src

--- a/src/llvm-transforms/src/const_prop.rs
+++ b/src/llvm-transforms/src/const_prop.rs
@@ -345,7 +345,7 @@ pub(crate) fn subst_kind(kind: InstrKind, subst: &HashMap<InstrId, ValueRef>) ->
 ///
 /// Unreachable blocks are appended at the end (in their stored order) so that
 /// the pass still processes them for correctness.
-fn rpo(func: &Function) -> Vec<usize> {
+pub(crate) fn rpo(func: &Function) -> Vec<usize> {
     let n = func.blocks.len();
     let mut visited: HashSet<usize> = HashSet::with_capacity(n);
     let mut post_order: Vec<usize> = Vec::with_capacity(n);

--- a/src/llvm-transforms/src/constant_fold_pass.rs
+++ b/src/llvm-transforms/src/constant_fold_pass.rs
@@ -1,0 +1,127 @@
+//! Dedicated constant-folding function pass.
+//!
+//! This pass evaluates foldable instructions whose operands are compile-time
+//! constants (via [`crate::constant_fold::try_fold`]) and rewrites downstream
+//! uses to direct constants.
+
+use crate::const_prop::{rpo, subst_kind};
+use crate::constant_fold::try_fold;
+use crate::pass::FunctionPass;
+use llvm_ir::{Context, Function, InstrId, ValueRef};
+use std::collections::HashMap;
+
+/// Function pass that folds compile-time constant expressions.
+pub struct ConstantFold;
+
+impl FunctionPass for ConstantFold {
+    fn name(&self) -> &'static str {
+        "constant-fold"
+    }
+
+    fn run_on_function(&mut self, ctx: &mut Context, func: &mut Function) -> bool {
+        if func.blocks.is_empty() {
+            return false;
+        }
+
+        // Map InstrId -> folded constant replacement.
+        let mut subst: HashMap<InstrId, ValueRef> = HashMap::new();
+
+        for bi in rpo(func) {
+            let body = func.blocks[bi].body.clone();
+            for iid in body {
+                if !subst.is_empty() {
+                    let new_kind = subst_kind(func.instr(iid).kind.clone(), &subst);
+                    func.instr_mut(iid).kind = new_kind;
+                }
+                let kind = func.instr(iid).kind.clone();
+                if let Some(cid) = try_fold(ctx, &kind) {
+                    subst.insert(iid, ValueRef::Constant(cid));
+                }
+            }
+            if let Some(tid) = func.blocks[bi].terminator {
+                if !subst.is_empty() {
+                    let new_kind = subst_kind(func.instr(tid).kind.clone(), &subst);
+                    func.instr_mut(tid).kind = new_kind;
+                }
+            }
+        }
+
+        if subst.is_empty() {
+            return false;
+        }
+
+        for bb in &mut func.blocks {
+            bb.body.retain(|id| !subst.contains_key(id));
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llvm_ir::{Builder, Context, InstrKind, Linkage, Module, ValueRef};
+
+    fn make_const_add_fn() -> (Context, Module) {
+        let mut ctx = Context::new();
+        let mut module = Module::new("const_add");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let c2 = b.const_int(b.ctx.i32_ty, 2);
+        let sum = b.build_add("sum", c2, c2);
+        b.build_ret(sum);
+        (ctx, module)
+    }
+
+    fn make_non_const_add_fn() -> (Context, Module) {
+        let mut ctx = Context::new();
+        let mut module = Module::new("non_const_add");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "f",
+            b.ctx.i32_ty,
+            vec![b.ctx.i32_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let x = b.get_arg(0);
+        let c2 = b.const_int(b.ctx.i32_ty, 2);
+        let sum = b.build_add("sum", x, c2);
+        b.build_ret(sum);
+        (ctx, module)
+    }
+
+    #[test]
+    fn folds_add_2_plus_2() {
+        let (mut ctx, mut module) = make_const_add_fn();
+        let mut pass = ConstantFold;
+        let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+        assert!(changed);
+        assert_eq!(module.functions[0].blocks[0].body.len(), 0);
+        let func = &module.functions[0];
+        let tid = func.blocks[0].terminator.expect("terminator");
+        match &func.instr(tid).kind {
+            InstrKind::Ret {
+                val: Some(ValueRef::Constant(cid)),
+            } => match ctx.get_const(*cid) {
+                llvm_ir::ConstantData::Int { val, .. } => assert_eq!(*val, 4),
+                other => panic!("unexpected ret constant: {other:?}"),
+            },
+            other => panic!("expected ret constant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn does_not_fold_non_constant_expression() {
+        let (mut ctx, mut module) = make_non_const_add_fn();
+        let mut pass = ConstantFold;
+        let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+        assert!(!changed);
+        assert_eq!(module.functions[0].blocks[0].body.len(), 1);
+    }
+}

--- a/src/llvm-transforms/src/lib.rs
+++ b/src/llvm-transforms/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod const_prop;
 pub mod constant_fold;
+pub mod constant_fold_pass;
 pub mod dce;
 pub mod dead_arg_elim;
 pub mod gvn;
@@ -15,6 +16,7 @@ mod value_rewrite;
 
 pub use const_prop::ConstProp;
 pub use constant_fold::try_fold;
+pub use constant_fold_pass::ConstantFold;
 pub use dce::DeadCodeElim;
 pub use dead_arg_elim::DeadArgElim;
 pub use gvn::Gvn;

--- a/src/llvm-transforms/src/pipeline.rs
+++ b/src/llvm-transforms/src/pipeline.rs
@@ -4,8 +4,8 @@
 //! manually assembling pass sequences.
 
 use crate::{
-    pass::PassManager, ConstProp, DeadArgElim, DeadCodeElim, Gvn, Inliner, Ipcp, LoopUnroll,
-    Mem2Reg,
+    pass::PassManager, ConstProp, ConstantFold, DeadArgElim, DeadCodeElim, Gvn, Inliner, Ipcp,
+    LoopUnroll, Mem2Reg,
 };
 
 /// Optimization level preset.
@@ -42,6 +42,7 @@ pub fn build_pipeline(level: OptLevel) -> PassManager {
         }
         OptLevel::O1 => {
             pm.add_function_pass(Mem2Reg);
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
         }
@@ -50,10 +51,12 @@ pub fn build_pipeline(level: OptLevel) -> PassManager {
             pm.add_module_pass(Inliner::default());
             pm.add_function_pass(Gvn);
             pm.add_function_pass(LoopUnroll::default());
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
             // Clean up after inlining.
             pm.add_function_pass(Gvn);
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
         }
@@ -71,12 +74,15 @@ pub fn build_pipeline(level: OptLevel) -> PassManager {
                 factor: 8,
                 max_trip_count: 16,
             });
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
             // Extra cleanup rounds as a placeholder for future aggressive O3.
             pm.add_function_pass(Gvn);
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
+            pm.add_function_pass(ConstantFold);
             pm.add_function_pass(ConstProp);
             pm.add_function_pass(DeadCodeElim);
         }
@@ -94,7 +100,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("main", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
+        b.add_function(
+            "main",
+            b.ctx.i32_ty,
+            vec![],
+            vec![],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
 
@@ -159,5 +172,39 @@ mod tests {
         assert_eq!(OptLevel::parse("o2"), Some(OptLevel::O2));
         assert_eq!(OptLevel::parse(" 3 "), Some(OptLevel::O3));
         assert_eq!(OptLevel::parse("Ox"), None);
+    }
+
+    #[test]
+    fn o1_folds_trivial_constant_expression() {
+        let mut ctx = Context::new();
+        let mut module = Module::new("fold");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "main",
+            b.ctx.i32_ty,
+            vec![],
+            vec![],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let c2 = b.const_int(b.ctx.i32_ty, 2);
+        let sum = b.build_add("sum", c2, c2);
+        b.build_ret(sum);
+
+        let mut pm = build_pipeline(OptLevel::O1);
+        pm.run_until_fixed_point(&mut ctx, &mut module, 4);
+        assert_eq!(module.functions[0].blocks[0].body.len(), 0);
+        let tid = module.functions[0].blocks[0].terminator.expect("ret");
+        match &module.functions[0].instr(tid).kind {
+            InstrKind::Ret {
+                val: Some(ValueRef::Constant(cid)),
+            } => match ctx.get_const(*cid) {
+                llvm_ir::ConstantData::Int { val, .. } => assert_eq!(*val, 4),
+                other => panic!("unexpected constant kind: {other:?}"),
+            },
+            other => panic!("expected constant return after O1, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add new `ConstantFold` function pass (`constant_fold_pass.rs`) that folds compile-time constant expressions and rewrites uses
- keep fold semantics centralized via existing `try_fold` helper
- export `ConstantFold` from `llvm-transforms` public API
- integrate `ConstantFold` into optimization presets (`-O1`, `-O2`, `-O3`)
- add regression tests for folded (`2 + 2`) and non-folded value-dependent expressions
- add issue-specific `constant-folding` agent skill and register it in `AGENTS.md`

## Validation
- `cargo +stable test -p llvm-transforms`
- `cargo +stable test -q`

Closes #140
