### PR TITLE
Add explicit integrated assembler (MC) API and benchmark path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust build output
 /target/
+src/llvm-bench/target/
 
 # Claude Code local-only files (not project-wide)
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,16 @@ When:   Adding dedicated compile-time constant evaluation pass behavior,
 Skill:  skills/constant-folding/SKILL.md
 ```
 
+### integrated-assembler agent
+Use for issue #141 and direct MC/integrated assembler work.
+
+```
+Invoke: $integrated-assembler
+When:   Formalizing explicit machine-IR -> object-byte assembly APIs, adding
+        MC-stage docs/bench coverage, and preserving object-format correctness.
+Skill:  skills/integrated-assembler/SKILL.md
+```
+
 ### Plan agent
 Use **before** starting a new phase or a non-trivial fix.
 

--- a/README.md
+++ b/README.md
@@ -550,6 +550,24 @@ ld -r /tmp/eval_predicate.o -o /tmp/eval_predicate.linked.o
 cc /tmp/eval_predicate.o -o /tmp/eval_predicate_bin
 ```
 
+### Integrated Assembler (Direct MC Emission)
+
+The default backend flow already uses an integrated assembler path: machine IR
+is encoded directly into section bytes and serialized to object files (ELF /
+Mach-O / COFF) without generating textual assembly as an intermediate.
+
+`llvm-codegen` exposes this stage explicitly:
+
+```rust
+use llvm_codegen::{assemble_with_report, ObjectFormat};
+use llvm_target_x86::X86Emitter;
+
+let mut emitter = X86Emitter::new(ObjectFormat::Elf);
+let assembled = assemble_with_report(&mf, &mut emitter);
+std::fs::write("/tmp/out.o", &assembled.bytes)?;
+println!("mc bytes: {}", assembled.report.bytes);
+```
+
 macOS (Mach-O):
 
 ```bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -245,8 +245,10 @@ for O(n log n) total (not O(n² log n)).
 
 #### Object File Emission
 
-`Emitter` produces a `Section` (byte stream + relocation list). `emit_object`
-serializes to either ELF-64 or Mach-O depending on `ObjectFormat`:
+`Emitter` produces a `Section` (byte stream + relocation list). The integrated
+assembler stage (`IntegratedAssembler`) turns machine IR + section streams into
+an object and final bytes directly (no textual assembly round-trip). `emit_object`
+serializes to either ELF-64, Mach-O, or COFF depending on `ObjectFormat`:
 
 - **ELF-64**: null + `.text` + `.symtab` + `.strtab` + `.shstrtab` + optional
   `.rela.text` section headers; uses `EM_X86_64` (62) or `EM_AARCH64` (183)

--- a/skills/integrated-assembler/SKILL.md
+++ b/skills/integrated-assembler/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: integrated-assembler
+description: Implement issue #141 by formalizing direct MC emission as an explicit integrated assembler stage, with docs/tests/bench coverage.
+---
+
+# Integrated Assembler
+
+Use this skill to execute issue #141 with minimal disruption.
+
+## Workflow
+
+1. Add an explicit integrated-assembler API over existing emitter/object serialization.
+2. Keep object-format correctness and relocation behavior unchanged.
+3. Add tests for assembled bytes/report invariants.
+4. Add benchmark hooks comparing codegen paths in `llvm-bench`.
+5. Document architecture and migration intent in README/design docs.
+6. Run full tests, post PR review, and merge after green checks.
+
+## Minimum validation
+
+```bash
+cargo +stable test -p llvm-codegen
+cargo +stable test -q
+cargo bench -p llvm-bench --bench pipeline -- --warm-up-time 1
+```
+
+## Notes
+
+- Avoid introducing text-asm dependencies in default pipeline.
+- Prefer additive API (`IntegratedAssembler`) over disruptive rewrites.

--- a/skills/integrated-assembler/agents/openai.yaml
+++ b/skills/integrated-assembler/agents/openai.yaml
@@ -1,0 +1,10 @@
+name: integrated-assembler-agent
+description: Agent for issue #141 integrated assembler / direct MC emission architecture.
+model: gpt-5
+instructions: |
+  Focus on explicit architecture and compatibility:
+  - expose integrated assembler API without breaking existing emit_object callers
+  - preserve object/relocation behavior while adding metrics/reporting
+  - add tests and benchmark hooks to demonstrate end-to-end usage
+  - document stage responsibilities clearly in README/design docs
+  - run full tests and post PR review findings before merge

--- a/skills/integrated-assembler/references/issue-141-plan.md
+++ b/skills/integrated-assembler/references/issue-141-plan.md
@@ -1,0 +1,17 @@
+# Issue #141 Plan
+
+## Acceptance Targets
+
+- Explicit integrated assembler stage/API exists in codebase.
+- Default path emits object bytes directly from machine IR without text asm.
+- Tests validate the new API and object emission invariants.
+- Benchmark hook exists for compile-stage measurement.
+- Docs describe architecture and staged rollout.
+
+## Suggested Order
+
+1. Introduce integrated assembler API wrappers/types.
+2. Add tests for assembled output/reporting.
+3. Wire benchmark usage.
+4. Update docs.
+5. Validate and merge.

--- a/skills/integrated-assembler/scripts/mc_path_audit.sh
+++ b/skills/integrated-assembler/scripts/mc_path_audit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+rg -n "IntegratedAssembler|assemble_with_report|emit_object\(" src/llvm-codegen src/llvm-bench

--- a/src/llvm-bench/benches/pipeline.rs
+++ b/src/llvm-bench/benches/pipeline.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use llvm_codegen::{
-    emit_object,
+    assemble_with_report, emit_object,
     isel::IselBackend,
     regalloc::{
         allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
@@ -42,6 +42,28 @@ fn codegen_module(ctx: &Context, module: &Module) {
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);
         emit_object(&mf, &mut emitter);
+    }
+}
+
+/// Run codegen using the explicit integrated-assembler API.
+fn codegen_module_integrated_assembler(ctx: &Context, module: &Module) {
+    let mut backend = X86Backend::default();
+    for func in &module.functions {
+        if func.is_declaration {
+            continue;
+        }
+        let mut mf = backend.lower_function(ctx, module, func);
+        let intervals = compute_live_intervals(&mf);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
+        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+        apply_allocation(&mut mf, &result);
+        let mut emitter = X86Emitter::new(ObjectFormat::Elf);
+        let assembled = assemble_with_report(&mf, &mut emitter);
+        black_box(assembled.report);
     }
 }
 
@@ -118,6 +140,13 @@ fn bench_codegen_x86(c: &mut Criterion) {
     });
 }
 
+fn bench_codegen_x86_integrated_assembler(c: &mut Criterion) {
+    let (ctx, module) = parsed_module();
+    c.bench_function("pipeline/codegen_x86_integrated_assembler", |b| {
+        b.iter(|| codegen_module_integrated_assembler(black_box(&ctx), black_box(&module)))
+    });
+}
+
 fn bench_opt_o0(c: &mut Criterion) {
     c.bench_function("pipeline/opt_O0", |b| {
         b.iter(|| {
@@ -148,6 +177,7 @@ criterion_group!(
     bench_mem2reg,
     bench_dce,
     bench_codegen_x86,
+    bench_codegen_x86_integrated_assembler,
     bench_opt_o0,
     bench_opt_o2
 );

--- a/src/llvm-codegen/src/assembler.rs
+++ b/src/llvm-codegen/src/assembler.rs
@@ -1,0 +1,143 @@
+//! Integrated assembler (MC) stage.
+//!
+//! This module makes the direct machine-code emission path explicit:
+//! machine IR -> target encoder (`Emitter`) -> object sections/symbols ->
+//! object bytes. No textual assembly round-trip is required.
+
+use crate::emit::{emit_object, Emitter, ObjectFile};
+use crate::isel::MachineFunction;
+
+/// Summary metrics for one assembly invocation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct McAssemblyReport {
+    pub section_count: usize,
+    pub symbol_count: usize,
+    pub reloc_count: usize,
+    pub bytes: usize,
+}
+
+/// Result of integrated assembly.
+#[derive(Clone, Debug)]
+pub struct AssembledObject {
+    pub object: ObjectFile,
+    pub bytes: Vec<u8>,
+    pub report: McAssemblyReport,
+}
+
+/// Pluggable assembler interface for machine-code/object emission.
+pub trait McAssembler {
+    fn assemble_object(&mut self, mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFile;
+
+    fn assemble(&mut self, mf: &MachineFunction, emitter: &mut dyn Emitter) -> AssembledObject {
+        let object = self.assemble_object(mf, emitter);
+        let bytes = object.to_bytes();
+        let reloc_count = object.sections.iter().map(|s| s.relocs.len()).sum();
+        let report = McAssemblyReport {
+            section_count: object.sections.len(),
+            symbol_count: object.symbols.len(),
+            reloc_count,
+            bytes: bytes.len(),
+        };
+        AssembledObject {
+            object,
+            bytes,
+            report,
+        }
+    }
+}
+
+/// Default integrated assembler: directly lowers machine IR to object bytes.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct IntegratedAssembler;
+
+impl McAssembler for IntegratedAssembler {
+    fn assemble_object(&mut self, mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFile {
+        emit_object(mf, emitter)
+    }
+}
+
+/// Convenience wrapper that assembles machine IR directly into an object.
+pub fn assemble_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFile {
+    IntegratedAssembler.assemble_object(mf, emitter)
+}
+
+/// Convenience wrapper that assembles machine IR directly into raw bytes.
+pub fn assemble_bytes(mf: &MachineFunction, emitter: &mut dyn Emitter) -> Vec<u8> {
+    IntegratedAssembler.assemble(mf, emitter).bytes
+}
+
+/// Convenience wrapper returning object, bytes, and assembly report.
+pub fn assemble_with_report(mf: &MachineFunction, emitter: &mut dyn Emitter) -> AssembledObject {
+    IntegratedAssembler.assemble(mf, emitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emit::{ObjectFormat, Section, Symbol};
+    use crate::isel::{MachineBlock, MachineFunction};
+
+    struct NopEmitter;
+    impl Emitter for NopEmitter {
+        fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
+            Section {
+                name: ".text".into(),
+                data: vec![0x90, 0xC3],
+                relocs: vec![],
+                debug_rows: vec![],
+            }
+        }
+        fn object_format(&self) -> ObjectFormat {
+            ObjectFormat::Elf
+        }
+    }
+
+    #[test]
+    fn integrated_assembler_produces_nonempty_bytes() {
+        let mut mf = MachineFunction::new("f".into());
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
+        let mut emitter = NopEmitter;
+        let assembled = assemble_with_report(&mf, &mut emitter);
+        assert!(!assembled.bytes.is_empty());
+        assert_eq!(
+            assembled.report.section_count,
+            assembled.object.sections.len()
+        );
+    }
+
+    #[test]
+    fn report_counts_sections_symbols_and_relocs() {
+        let object = ObjectFile {
+            format: ObjectFormat::Elf,
+            elf_machine: 62,
+            coff_machine: 0x8664,
+            sections: vec![Section {
+                name: ".text".into(),
+                data: vec![0xC3],
+                relocs: vec![],
+                debug_rows: vec![],
+            }],
+            symbols: vec![Symbol {
+                name: "f".into(),
+                section: 0,
+                offset: 0,
+                size: 1,
+                global: true,
+            }],
+        };
+        let bytes = object.to_bytes();
+        let report = McAssemblyReport {
+            section_count: object.sections.len(),
+            symbol_count: object.symbols.len(),
+            reloc_count: object.sections.iter().map(|s| s.relocs.len()).sum(),
+            bytes: bytes.len(),
+        };
+        assert_eq!(report.section_count, 1);
+        assert_eq!(report.symbol_count, 1);
+        assert_eq!(report.reloc_count, 0);
+        assert!(report.bytes > 0);
+    }
+}

--- a/src/llvm-codegen/src/lib.rs
+++ b/src/llvm-codegen/src/lib.rs
@@ -1,5 +1,6 @@
 //! Target-independent code generation: legalization, instruction selection, register allocation, scheduling, and emission.
 
+pub mod assembler;
 pub mod emit;
 pub mod isel;
 pub mod legalize;
@@ -7,6 +8,10 @@ pub mod regalloc;
 pub mod regalloc_gc;
 pub mod schedule;
 
+pub use assembler::{
+    assemble_bytes, assemble_object, assemble_with_report, AssembledObject, IntegratedAssembler,
+    McAssembler, McAssemblyReport,
+};
 pub use emit::{emit_object, Emitter, ObjectFile, ObjectFormat, Reloc, RelocKind, Section, Symbol};
 pub use isel::{IselBackend, MInstr, MOpcode, MOperand, MachineBlock, MachineFunction, PReg, VReg};
 pub use regalloc::{


### PR DESCRIPTION
## Summary
- add `llvm-codegen` integrated assembler module (`IntegratedAssembler`, `McAssembler`, `assemble_with_report`)
- expose assembled bytes + report metrics from machine IR without text-asm intermediate
- add unit tests for integrated assembler output/report invariants
- add criterion benchmark path `pipeline/codegen_x86_integrated_assembler`
- document integrated assembler architecture in README and design docs
- add issue-specific `integrated-assembler` skill and agent registration

## Validation
- `cargo +stable test -p llvm-codegen`
- `cargo +stable test -q`
- `cargo +stable bench -p llvm-bench --bench pipeline -- --warm-up-time 1 --measurement-time 1`

Closes #141
