### PR TITLE
Parse clang constexpr operands and aggregate global initializers (#207)

### DIFF
--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -71,6 +71,10 @@ struct Parser<'src> {
     pending_blocks: HashMap<String, BlockId>,
     /// Current function being parsed (None at module level).
     current_func: Option<usize>, // index into module.functions
+    /// Current block being filled (set inside `parse_instruction`; used to
+    /// hoist parse-time constexprs to fresh SSA instructions inserted
+    /// before the using instruction).
+    current_block: Option<BlockId>,
     /// Local value table: name → ValueRef, for the current function.
     locals: HashMap<String, ValueRef>,
     /// Unnamed slots: slot number → ValueRef.
@@ -85,6 +89,7 @@ impl<'src> Parser<'src> {
             module: Module::new(""),
             pending_blocks: HashMap::new(),
             current_func: None,
+            current_block: None,
             locals: HashMap::new(),
             unnamed: HashMap::new(),
         }
@@ -601,6 +606,10 @@ impl<'src> Parser<'src> {
     // -----------------------------------------------------------------------
 
     fn parse_instruction(&mut self, bid: BlockId) -> Result<(), ParseError> {
+        // Record current insertion point so that constexpr operands inside
+        // this instruction can hoist themselves to fresh SSA instructions
+        // (appended before the using instruction).
+        self.current_block = Some(bid);
         let fid = self
             .current_func
             .ok_or_else(|| self.err("instruction outside function"))?;
@@ -1576,11 +1585,213 @@ impl<'src> Parser<'src> {
                 let i1 = self.ctx.i1_ty;
                 Ok(ValueRef::Constant(self.ctx.const_int(i1, 0)))
             }
+            // ----- Aggregate constant literals (issue #207) -----
+            //
+            // Clang produces global initializers such as
+            //     @t = constant [8 x i32] [i32 1, i32 2, ..., i32 8]
+            //     @v = constant [2 x %S] [%S { ptr @h, i32 10 }, %S { ... }]
+            // and the inner aggregate literals can appear nested.  We parse
+            // them into `ConstantData::Array` / `ConstantData::Struct`
+            // records directly; the surrounding type comes from the parser
+            // context (`ty` argument).
+            Token::LBracket => self.parse_array_constant(ty),
+            Token::LBrace => self.parse_struct_constant(ty, /*packed=*/ false),
+            Token::LAngle => self.parse_packed_struct_or_vector_constant(ty),
+            // ----- LLVM constant expressions (issue #207) -----
+            //
+            // Clang emits forms such as
+            //     load i32, ptr getelementptr inbounds (i32, ptr @t, i64 3)
+            // where the inner `getelementptr (...)` is a ConstantExpr rather
+            // than a value reference.  Our IR does not yet have a first-class
+            // ConstantExpr representation, so we materialise each such
+            // constexpr as a fresh anonymous SSA instruction inserted before
+            // the using instruction and use that instruction's result in
+            // place of the would-be constant.
+            //
+            // Hoisting only works inside a function body — global initializer
+            // constexprs (PR-B follow-up) need a real `ConstantData::Expr`
+            // variant; until then they error out cleanly.
+            Token::Kw(Keyword::Getelementptr) => self.parse_constexpr_gep_as_instr(),
+            Token::Kw(Keyword::Bitcast) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Bitcast, |val, to| {
+                    InstrKind::BitCast { val, to }
+                })
+            }
+            Token::Kw(Keyword::Inttoptr) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Inttoptr, |val, to| {
+                    InstrKind::IntToPtr { val, to }
+                })
+            }
+            Token::Kw(Keyword::Ptrtoint) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Ptrtoint, |val, to| {
+                    InstrKind::PtrToInt { val, to }
+                })
+            }
+            Token::Kw(Keyword::Addrspacecast) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Addrspacecast, |val, to| {
+                    InstrKind::AddrSpaceCast { val, to }
+                })
+            }
+            Token::Kw(Keyword::Trunc) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Trunc, |val, to| {
+                    InstrKind::Trunc { val, to }
+                })
+            }
+            Token::Kw(Keyword::Zext) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Zext, |val, to| {
+                    InstrKind::ZExt { val, to }
+                })
+            }
+            Token::Kw(Keyword::Sext) => {
+                self.parse_constexpr_cast_as_instr(Keyword::Sext, |val, to| {
+                    InstrKind::SExt { val, to }
+                })
+            }
             _ => {
                 let t = self.lex.next()?;
                 Err(self.err(format!("expected value, got {:?}", t)))
             }
         }
+    }
+
+    /// Parse `[ <ty> <v>, <ty> <v>, ... ]` as a constant array.
+    fn parse_array_constant(&mut self, ty: TypeId) -> Result<ValueRef, ParseError> {
+        self.lex.expect(&Token::LBracket)?;
+        let mut elements = Vec::new();
+        if !matches!(self.lex.peek()?, Token::RBracket) {
+            let (val, _) = self.parse_typed_value()?;
+            elements.push(self.value_ref_to_const_id(val)?);
+            while self.lex.eat(&Token::Comma) {
+                let (val, _) = self.parse_typed_value()?;
+                elements.push(self.value_ref_to_const_id(val)?);
+            }
+        }
+        self.lex.expect(&Token::RBracket)?;
+        let c = self.ctx.push_const(ConstantData::Array { ty, elements });
+        Ok(ValueRef::Constant(c))
+    }
+
+    /// Parse `{ <ty> <v>, <ty> <v>, ... }` as an anonymous (or named) struct
+    /// constant.  The result `TypeId` is the surrounding context's type.
+    fn parse_struct_constant(
+        &mut self,
+        ty: TypeId,
+        _packed: bool,
+    ) -> Result<ValueRef, ParseError> {
+        self.lex.expect(&Token::LBrace)?;
+        let mut fields = Vec::new();
+        if !matches!(self.lex.peek()?, Token::RBrace) {
+            let (val, _) = self.parse_typed_value()?;
+            fields.push(self.value_ref_to_const_id(val)?);
+            while self.lex.eat(&Token::Comma) {
+                let (val, _) = self.parse_typed_value()?;
+                fields.push(self.value_ref_to_const_id(val)?);
+            }
+        }
+        self.lex.expect(&Token::RBrace)?;
+        let c = self.ctx.push_const(ConstantData::Struct { ty, fields });
+        Ok(ValueRef::Constant(c))
+    }
+
+    /// Disambiguate `<{ ... }>` (packed struct) from `< <ty> <v>, ... >`
+    /// (vector constant).
+    fn parse_packed_struct_or_vector_constant(
+        &mut self,
+        ty: TypeId,
+    ) -> Result<ValueRef, ParseError> {
+        self.lex.expect(&Token::LAngle)?;
+        if matches!(self.lex.peek()?, Token::LBrace) {
+            // <{ ... }> packed struct literal.
+            let result = self.parse_struct_constant(ty, /*packed=*/ true)?;
+            self.lex.expect(&Token::RAngle)?;
+            return Ok(result);
+        }
+        // Vector literal: <ty v, ty v, ...>
+        let mut elements = Vec::new();
+        if !matches!(self.lex.peek()?, Token::RAngle) {
+            let (val, _) = self.parse_typed_value()?;
+            elements.push(self.value_ref_to_const_id(val)?);
+            while self.lex.eat(&Token::Comma) {
+                let (val, _) = self.parse_typed_value()?;
+                elements.push(self.value_ref_to_const_id(val)?);
+            }
+        }
+        self.lex.expect(&Token::RAngle)?;
+        let c = self.ctx.push_const(ConstantData::Vector { ty, elements });
+        Ok(ValueRef::Constant(c))
+    }
+
+    /// Convert a `ValueRef` to a `ConstId` for use inside an aggregate
+    /// literal.  Non-constant references inside a constant aggregate are a
+    /// parse error.
+    fn value_ref_to_const_id(&self, vref: ValueRef) -> Result<ConstId, ParseError> {
+        match vref {
+            ValueRef::Constant(c) => Ok(c),
+            _ => Err(self.err("expected constant inside aggregate literal")),
+        }
+    }
+
+    /// Hoist a constant `getelementptr (...)` expression to a fresh SSA
+    /// instruction inserted at the current insertion point.
+    fn parse_constexpr_gep_as_instr(&mut self) -> Result<ValueRef, ParseError> {
+        let bid = self
+            .current_block
+            .ok_or_else(|| self.err("constant getelementptr outside function body not yet supported"))?;
+        let fid = self
+            .current_func
+            .ok_or_else(|| self.err("constant getelementptr outside function body not yet supported"))?;
+        self.lex.expect_kw(&Keyword::Getelementptr)?;
+        let inbounds = self.lex.eat_kw(Keyword::Inbounds);
+        self.lex.expect(&Token::LParen)?;
+        let base_ty = self.parse_type()?;
+        self.lex.expect(&Token::Comma)?;
+        let ptr_ty2 = self.parse_type()?;
+        let ptr = self.parse_value(ptr_ty2)?;
+        let mut indices = Vec::new();
+        while self.lex.eat(&Token::Comma) {
+            let (idx, _) = self.parse_typed_value()?;
+            indices.push(idx);
+        }
+        self.lex.expect(&Token::RParen)?;
+        let result_ty = self.ctx.ptr_ty;
+        let kind = InstrKind::GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        };
+        let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, result_ty, kind));
+        self.module.functions[fid].block_mut(bid).append_instr(iid);
+        Ok(ValueRef::Instruction(iid))
+    }
+
+    /// Hoist a constant cast expression — `bitcast / inttoptr / ptrtoint /
+    /// addrspacecast / trunc / zext / sext (<src-ty> <src-val> to <dst-ty>)`
+    /// — to a fresh SSA instruction inserted at the current insertion point.
+    fn parse_constexpr_cast_as_instr<F>(
+        &mut self,
+        kw: Keyword,
+        make_kind: F,
+    ) -> Result<ValueRef, ParseError>
+    where
+        F: FnOnce(ValueRef, TypeId) -> InstrKind,
+    {
+        let bid = self
+            .current_block
+            .ok_or_else(|| self.err("constant cast outside function body not yet supported"))?;
+        let fid = self
+            .current_func
+            .ok_or_else(|| self.err("constant cast outside function body not yet supported"))?;
+        self.lex.expect_kw(&kw)?;
+        self.lex.expect(&Token::LParen)?;
+        let (val, _src_ty) = self.parse_typed_value()?;
+        self.lex.expect_kw(&Keyword::To)?;
+        let dst_ty = self.parse_type()?;
+        self.lex.expect(&Token::RParen)?;
+        let kind = make_kind(val, dst_ty);
+        let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
+        self.module.functions[fid].block_mut(bid).append_instr(iid);
+        Ok(ValueRef::Instruction(iid))
     }
 
     fn parse_constant(&mut self, ty: TypeId) -> Result<ConstId, ParseError> {

--- a/src/llvm-ir-parser/tests/parse_basic.rs
+++ b/src/llvm-ir-parser/tests/parse_basic.rs
@@ -243,6 +243,141 @@ entry:
     }
 }
 
+/// Parse clang-style constant getelementptr in `load` operand position.
+/// Each constexpr in an instruction operand is hoisted at parse time to a
+/// fresh anonymous SSA instruction inserted at the current insertion point.
+/// Covers issue #207 PR-A.
+#[test]
+fn parse_constexpr_gep_in_load_operand() {
+    let src = r#"
+@table = external constant [8 x i32]
+define i32 @f() {
+entry:
+  %v = load i32, ptr getelementptr inbounds ([8 x i32], ptr @table, i64 0, i64 3), align 4
+  ret i32 %v
+}
+"#;
+    let (ctx, module) = parse(src).expect("parse failed");
+    let f = &module.functions[0];
+    let bb = &f.blocks[0];
+
+    // The constexpr GEP must have been hoisted into the entry block before
+    // the load that uses it — block body length goes from 1 (the load) to 2
+    // (hoisted GEP + load).
+    assert_eq!(
+        bb.body.len(),
+        2,
+        "expected hoisted GEP + load in block body, got body={:?}",
+        bb.body
+    );
+
+    let hoisted = f.instr(bb.body[0]);
+    assert!(
+        matches!(hoisted.kind, InstrKind::GetElementPtr { inbounds: true, .. }),
+        "first instruction should be a hoisted inbounds GEP, got {:?}",
+        hoisted.kind
+    );
+    assert_eq!(
+        hoisted.name, None,
+        "hoisted constexpr should be anonymous (parser slot)"
+    );
+
+    let load = f.instr(bb.body[1]);
+    assert!(matches!(load.kind, InstrKind::Load { .. }));
+
+    let printed = Printer::new(&ctx).print_module(&module);
+    assert!(
+        printed.contains("%v0 = getelementptr inbounds [8 x i32], ptr @table, i64 0, i64 3"),
+        "printed module missing hoisted GEP definition:\n{printed}"
+    );
+    assert!(
+        printed.contains("%v = load i32, ptr %v0"),
+        "printed module missing load using hoisted GEP:\n{printed}"
+    );
+}
+
+/// `bitcast`, `inttoptr`, `ptrtoint`, `addrspacecast`, `trunc`, `zext`,
+/// `sext` constexpr forms in instruction operand position all hoist to
+/// fresh SSA instructions.
+#[test]
+fn parse_constexpr_cast_forms_in_operands() {
+    let src = r#"
+@g = external constant i32
+declare void @sink(ptr)
+define i64 @f() {
+entry:
+  call void @sink(ptr bitcast (ptr @g to ptr))
+  call void @sink(ptr inttoptr (i64 4096 to ptr))
+  %p = ptrtoint ptr getelementptr inbounds ([4 x i32], ptr @g, i64 0, i64 2) to i64
+  ret i64 %p
+}
+"#;
+    let (_ctx, module) = parse(src).expect("parse failed");
+    let bb = &module.functions[1].blocks[0];
+
+    // entry must now contain: hoisted bitcast, call#1, hoisted inttoptr,
+    // call#2, hoisted GEP, ptrtoint, ret = 7 instrs total (5 body + 1
+    // terminator pulled out).  Just assert at least 5 in body since the
+    // exact terminator handling lives in the test harness conventions.
+    assert!(
+        bb.body.len() >= 5,
+        "expected at least 5 body instructions from hoisting, got {}",
+        bb.body.len()
+    );
+
+    // First instruction must be the hoisted bitcast (anonymous).
+    let first = module.functions[1].instr(bb.body[0]);
+    assert!(matches!(first.kind, InstrKind::BitCast { .. }));
+    assert_eq!(first.name, None);
+}
+
+/// `@table = internal constant [8 x i32] [i32 1, i32 2, ...]` style array
+/// global initializers parse into `ConstantData::Array`.  Covers issue #207
+/// PR-A's "array literal as global initializer" gap.
+#[test]
+fn parse_global_array_constant_initializer() {
+    let src = r#"
+@table = internal constant [8 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8]
+"#;
+    let (ctx, module) = parse(src).expect("parse failed");
+    assert_eq!(module.globals.len(), 1);
+    let init_cid = module.globals[0].initializer.expect("initializer present");
+    match ctx.get_const(init_cid) {
+        ConstantData::Array { elements, .. } => assert_eq!(elements.len(), 8),
+        other => panic!("expected Array initializer, got {other:?}"),
+    }
+    let printed = Printer::new(&ctx).print_module(&module);
+    assert!(
+        printed.contains("[i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8]"),
+        "{printed}"
+    );
+}
+
+/// Array of named-struct constants — each element prefixed with the named
+/// struct type and a `{ ... }` field list — round-trips through the parser.
+/// Mirrors clang's vtable-style emission pattern.
+#[test]
+fn parse_global_array_of_named_struct_constants() {
+    let src = r#"
+%struct.entry = type { ptr, i32 }
+declare i32 @handler(i32)
+@vt = internal constant [3 x %struct.entry] [%struct.entry { ptr @handler, i32 10 }, %struct.entry { ptr @handler, i32 20 }, %struct.entry { ptr @handler, i32 30 }]
+"#;
+    let (ctx, module) = parse(src).expect("parse failed");
+    let init_cid = module.globals[0].initializer.expect("initializer present");
+    let ConstantData::Array { elements, .. } = ctx.get_const(init_cid) else {
+        panic!("expected outer Array");
+    };
+    assert_eq!(elements.len(), 3);
+    // Each element should be a Struct constant with 2 fields.
+    for &eid in elements {
+        match ctx.get_const(eid) {
+            ConstantData::Struct { fields, .. } => assert_eq!(fields.len(), 2),
+            other => panic!("expected Struct element, got {other:?}"),
+        }
+    }
+}
+
 /// Parse and print the core `invoke` / `landingpad` exception-control shape.
 #[test]
 fn parse_print_invoke_landingpad() {

--- a/src/llvm-ir/src/printer.rs
+++ b/src/llvm-ir/src/printer.rs
@@ -387,11 +387,17 @@ impl<'a> Printer<'a> {
         let instr = func.instr(id);
         out.push_str("  ");
 
-        // Result name if non-void.
+        // Result name if non-void.  Named instructions print as `%name = `;
+        // anonymous instructions that produce a value print using the same
+        // `%v{id}` slot name `write_value` uses when referencing them — this
+        // is what makes parser-time constexpr hoisting (issue #207)
+        // round-trip cleanly through print → parse → print.
         if let Some(ref name) = instr.name {
             if !name.is_empty() {
                 write!(out, "%{} = ", name).unwrap();
             }
+        } else if !instr.is_terminator() && instr.ty != self.ctx.void_ty {
+            write!(out, "%v{} = ", id.0).unwrap();
         }
 
         // Emit fast-math flags helper.


### PR DESCRIPTION
Refs #207

## Summary

Unblocks the headline #207 parser gap: clang-emitted LLVM IR uses constant expressions in operand position (`getelementptr (...)`, `bitcast (...)`, `inttoptr (...)`, etc.) and aggregate literals as global initializers (`[N x T] [...]`, `T { ... }`), neither of which the parser previously accepted.

- Parser tracks `current_block`; when `parse_value` sees a constexpr keyword in operand position it parses the full constexpr grammar, materialises a fresh anonymous `Instruction`, appends it to the current block, and returns the new `InstrId` so the using instruction transparently consumes the hoisted SSA value.
- `parse_value` accepts `[ ... ]` → `ConstantData::Array`, `{ ... }` → `ConstantData::Struct`, and `<...>` disambiguating `<{ ... }>` (packed struct) from `< T v, ... >` (vector).
- Printer emits `%v{id} = ` for unnamed non-void, non-terminator instructions, matching the `%v{id}` slot name that `write_value` already used — pre-existing latent bug that constexpr hoisting now exposes on every clang-IR file.
- Four new parser regression tests cover all four bullets above.

## Root cause / Design rationale

`@dong_sensei` flagged that text-IR sanitisation alone isn't enough — even after stripping module metadata clang's output uses constructs the parser doesn't understand. A probe of `clang -O0 -S -emit-llvm` on a tiny C program with a global lookup table + struct-array vtable surfaced four distinct gaps; this PR closes the two value/constant-expression ones (PR-A of the split with @Cindy). The other two (function attribute groups + parameter attribute keywords) are Cindy's PR-C/PR-D under `feature/issue-207-real-program-ir-normalization`.

Hoisting a constexpr to a real SSA instruction at parse time avoids introducing a `ConstantExpr` variant to the IR right now (the broader follow-up — PR-B — adds `ConstantData::Expr` so global-initializer constexprs survive without hoisting; can't hoist outside a function body).

## Test plan

- [x] `cargo +stable test -p llvm-in-rust-ir-parser --test parse_basic` — 21 pass, including 4 new tests:
  - `parse_constexpr_gep_in_load_operand`
  - `parse_constexpr_cast_forms_in_operands`
  - `parse_global_array_constant_initializer`
  - `parse_global_array_of_named_struct_constants`
- [x] `cargo +stable test -p llvm-in-rust-ir` — 89 unit + 6 roundtrip, all pass
- [x] `cargo +stable test --workspace --no-fail-fast` — only the 5 pre-existing `semantic_*` differential hash mismatches fail (identical set fails on `origin/main`; machine-bound clang baselines)

## Follow-ups (already coordinated in the design thread)

- PR-B (mine): `ConstantData::Expr` for constexprs in global initializers — needed before constexprs nested inside global table initializers survive bitcode round-trip without hoisting.
- PR-C / PR-D (Cindy on `feature/issue-207-real-program-ir-normalization`): parse-and-ignore `noundef` / `nonnull` / `dereferenceable(N)` parameter attributes, plus top-level `attributes #N = { ... }` groups and `#N` function references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)