### PR TITLE
Represent constexprs in global initializers as ConstantData::Expr (#207 PR-B)

### DIFF
--- a/src/llvm-bitcode/src/reader.rs
+++ b/src/llvm-bitcode/src/reader.rs
@@ -253,6 +253,20 @@ mod const_tag {
     pub const VECTOR: u8 = 9;
     /// Public API for `GLOBAL_REF`.
     pub const GLOBAL_REF: u8 = 10;
+    /// Public API for `EXPR`.
+    pub const EXPR: u8 = 11;
+}
+
+mod constexpr_op_tag {
+    pub const GEP: u8 = 0;
+    pub const GEP_INBOUNDS: u8 = 1;
+    pub const BITCAST: u8 = 2;
+    pub const INTTOPTR: u8 = 3;
+    pub const PTRTOINT: u8 = 4;
+    pub const ADDRSPACECAST: u8 = 5;
+    pub const TRUNC: u8 = 6;
+    pub const ZEXT: u8 = 7;
+    pub const SEXT: u8 = 8;
 }
 
 fn decode_const(
@@ -339,6 +353,41 @@ fn decode_const(
                 id: GlobalId(id_raw),
                 name,
             })
+        }
+        const_tag::EXPR => {
+            use llvm_ir::ConstExprOp;
+            let ty = map_type_id(type_id_map, r.u32()? as usize)?;
+            let op_tag = r.u8()?;
+            let op = match op_tag {
+                constexpr_op_tag::GEP => {
+                    let base_ty = map_type_id(type_id_map, r.u32()? as usize)?;
+                    ConstExprOp::GetElementPtr {
+                        inbounds: false,
+                        base_ty,
+                    }
+                }
+                constexpr_op_tag::GEP_INBOUNDS => {
+                    let base_ty = map_type_id(type_id_map, r.u32()? as usize)?;
+                    ConstExprOp::GetElementPtr {
+                        inbounds: true,
+                        base_ty,
+                    }
+                }
+                constexpr_op_tag::BITCAST => ConstExprOp::BitCast,
+                constexpr_op_tag::INTTOPTR => ConstExprOp::IntToPtr,
+                constexpr_op_tag::PTRTOINT => ConstExprOp::PtrToInt,
+                constexpr_op_tag::ADDRSPACECAST => ConstExprOp::AddrSpaceCast,
+                constexpr_op_tag::TRUNC => ConstExprOp::Trunc,
+                constexpr_op_tag::ZEXT => ConstExprOp::ZExt,
+                constexpr_op_tag::SEXT => ConstExprOp::SExt,
+                other => return Err(BitcodeError::UnsupportedRecord(other as u32)),
+            };
+            let n = r.u32()? as usize;
+            let mut operands = Vec::with_capacity(n);
+            for _ in 0..n {
+                operands.push(map_const_id(const_id_map, r.u32()? as usize)?);
+            }
+            Ok(ConstantData::Expr { ty, op, operands })
         }
         other => Err(BitcodeError::UnsupportedRecord(other as u32)),
     }

--- a/src/llvm-bitcode/src/writer.rs
+++ b/src/llvm-bitcode/src/writer.rs
@@ -199,6 +199,29 @@ mod const_tag {
     pub const VECTOR: u8 = 9;
     /// Public API for `GLOBAL_REF`.
     pub const GLOBAL_REF: u8 = 10;
+    /// Public API for `EXPR`.
+    pub const EXPR: u8 = 11;
+}
+
+mod constexpr_op_tag {
+    /// `getelementptr` (without `inbounds`).
+    pub const GEP: u8 = 0;
+    /// `getelementptr inbounds`.
+    pub const GEP_INBOUNDS: u8 = 1;
+    /// Public API for `BITCAST`.
+    pub const BITCAST: u8 = 2;
+    /// Public API for `INTTOPTR`.
+    pub const INTTOPTR: u8 = 3;
+    /// Public API for `PTRTOINT`.
+    pub const PTRTOINT: u8 = 4;
+    /// Public API for `ADDRSPACECAST`.
+    pub const ADDRSPACECAST: u8 = 5;
+    /// Public API for `TRUNC`.
+    pub const TRUNC: u8 = 6;
+    /// Public API for `ZEXT`.
+    pub const ZEXT: u8 = 7;
+    /// Public API for `SEXT`.
+    pub const SEXT: u8 = 8;
 }
 
 fn encode_const(w: &mut Writer, cd: &ConstantData) {
@@ -266,6 +289,32 @@ fn encode_const(w: &mut Writer, cd: &ConstantData) {
             w.u32(ty.0);
             w.u32(id.0);
             w.string(name);
+        }
+        ConstantData::Expr { ty, op, operands } => {
+            w.u8(const_tag::EXPR);
+            w.u32(ty.0);
+            use llvm_ir::ConstExprOp;
+            match op {
+                ConstExprOp::GetElementPtr { inbounds, base_ty } => {
+                    if *inbounds {
+                        w.u8(constexpr_op_tag::GEP_INBOUNDS);
+                    } else {
+                        w.u8(constexpr_op_tag::GEP);
+                    }
+                    w.u32(base_ty.0);
+                }
+                ConstExprOp::BitCast => w.u8(constexpr_op_tag::BITCAST),
+                ConstExprOp::IntToPtr => w.u8(constexpr_op_tag::INTTOPTR),
+                ConstExprOp::PtrToInt => w.u8(constexpr_op_tag::PTRTOINT),
+                ConstExprOp::AddrSpaceCast => w.u8(constexpr_op_tag::ADDRSPACECAST),
+                ConstExprOp::Trunc => w.u8(constexpr_op_tag::TRUNC),
+                ConstExprOp::ZExt => w.u8(constexpr_op_tag::ZEXT),
+                ConstExprOp::SExt => w.u8(constexpr_op_tag::SEXT),
+            }
+            w.u32(operands.len() as u32);
+            for &c in operands {
+                w.u32(c.0);
+            }
         }
     }
 }

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -6,10 +6,10 @@ use std::collections::HashMap;
 use std::fmt;
 
 use llvm_ir::{
-    ArgId, Argument, BasicBlock, BlockId, ConstId, ConstantData, Context, FastMathFlags, FloatKind,
-    FloatPredicate, Function, GlobalId, GlobalVariable, InstrKind, Instruction, IntArithFlags,
-    IntPredicate, LandingPadClause, Linkage, MemOrdering, Module, RmwOp, TailCallKind, TypeData,
-    TypeId, ValueRef,
+    ArgId, Argument, BasicBlock, BlockId, ConstExprOp, ConstId, ConstantData, Context,
+    FastMathFlags, FloatKind, FloatPredicate, Function, GlobalId, GlobalVariable, InstrKind,
+    Instruction, IntArithFlags, IntPredicate, LandingPadClause, Linkage, MemOrdering, Module,
+    RmwOp, TailCallKind, TypeData, TypeId, ValueRef,
 };
 
 use crate::lexer::{Keyword, LexError, Lexer, Token};
@@ -1731,15 +1731,12 @@ impl<'src> Parser<'src> {
         }
     }
 
-    /// Hoist a constant `getelementptr (...)` expression to a fresh SSA
-    /// instruction inserted at the current insertion point.
+    /// Parse a constant `getelementptr (T, ptr <base>, indices...)`
+    /// expression.  Inside a function body it is hoisted to a fresh SSA
+    /// instruction (PR-A).  Outside a function body — i.e. inside a global
+    /// variable initializer — it is stored as `ConstantData::Expr` so that
+    /// later codegen / bitcode can lower or relocate it (PR-B, issue #207).
     fn parse_constexpr_gep_as_instr(&mut self) -> Result<ValueRef, ParseError> {
-        let bid = self
-            .current_block
-            .ok_or_else(|| self.err("constant getelementptr outside function body not yet supported"))?;
-        let fid = self
-            .current_func
-            .ok_or_else(|| self.err("constant getelementptr outside function body not yet supported"))?;
         self.lex.expect_kw(&Keyword::Getelementptr)?;
         let inbounds = self.lex.eat_kw(Keyword::Inbounds);
         self.lex.expect(&Token::LParen)?;
@@ -1754,20 +1751,38 @@ impl<'src> Parser<'src> {
         }
         self.lex.expect(&Token::RParen)?;
         let result_ty = self.ctx.ptr_ty;
-        let kind = InstrKind::GetElementPtr {
-            inbounds,
-            base_ty,
-            ptr,
-            indices,
-        };
-        let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, result_ty, kind));
-        self.module.functions[fid].block_mut(bid).append_instr(iid);
-        Ok(ValueRef::Instruction(iid))
+
+        if let (Some(fid), Some(bid)) = (self.current_func, self.current_block) {
+            let kind = InstrKind::GetElementPtr {
+                inbounds,
+                base_ty,
+                ptr,
+                indices,
+            };
+            let iid =
+                self.module.functions[fid].alloc_instr(Instruction::new(None, result_ty, kind));
+            self.module.functions[fid].block_mut(bid).append_instr(iid);
+            Ok(ValueRef::Instruction(iid))
+        } else {
+            // Global initializer position — store as ConstantData::Expr.
+            let mut operands = Vec::with_capacity(1 + indices.len());
+            operands.push(self.value_ref_to_const_id(ptr)?);
+            for idx in indices {
+                operands.push(self.value_ref_to_const_id(idx)?);
+            }
+            let cid = self.ctx.push_const(ConstantData::Expr {
+                ty: result_ty,
+                op: ConstExprOp::GetElementPtr { inbounds, base_ty },
+                operands,
+            });
+            Ok(ValueRef::Constant(cid))
+        }
     }
 
-    /// Hoist a constant cast expression — `bitcast / inttoptr / ptrtoint /
-    /// addrspacecast / trunc / zext / sext (<src-ty> <src-val> to <dst-ty>)`
-    /// — to a fresh SSA instruction inserted at the current insertion point.
+    /// Parse a constant cast expression — `bitcast / inttoptr / ptrtoint /
+    /// addrspacecast / trunc / zext / sext (<src-ty> <src-val> to <dst-ty>)`.
+    /// Inside a function body it is hoisted to a fresh SSA instruction;
+    /// inside a global initializer it is stored as `ConstantData::Expr`.
     fn parse_constexpr_cast_as_instr<F>(
         &mut self,
         kw: Keyword,
@@ -1776,22 +1791,42 @@ impl<'src> Parser<'src> {
     where
         F: FnOnce(ValueRef, TypeId) -> InstrKind,
     {
-        let bid = self
-            .current_block
-            .ok_or_else(|| self.err("constant cast outside function body not yet supported"))?;
-        let fid = self
-            .current_func
-            .ok_or_else(|| self.err("constant cast outside function body not yet supported"))?;
         self.lex.expect_kw(&kw)?;
         self.lex.expect(&Token::LParen)?;
         let (val, _src_ty) = self.parse_typed_value()?;
         self.lex.expect_kw(&Keyword::To)?;
         let dst_ty = self.parse_type()?;
         self.lex.expect(&Token::RParen)?;
-        let kind = make_kind(val, dst_ty);
-        let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
-        self.module.functions[fid].block_mut(bid).append_instr(iid);
-        Ok(ValueRef::Instruction(iid))
+
+        if let (Some(fid), Some(bid)) = (self.current_func, self.current_block) {
+            let kind = make_kind(val, dst_ty);
+            let iid =
+                self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
+            self.module.functions[fid].block_mut(bid).append_instr(iid);
+            Ok(ValueRef::Instruction(iid))
+        } else {
+            let op = match kw {
+                Keyword::Bitcast => ConstExprOp::BitCast,
+                Keyword::Inttoptr => ConstExprOp::IntToPtr,
+                Keyword::Ptrtoint => ConstExprOp::PtrToInt,
+                Keyword::Addrspacecast => ConstExprOp::AddrSpaceCast,
+                Keyword::Trunc => ConstExprOp::Trunc,
+                Keyword::Zext => ConstExprOp::ZExt,
+                Keyword::Sext => ConstExprOp::SExt,
+                other => {
+                    return Err(
+                        self.err(format!("unsupported constexpr cast keyword: {:?}", other))
+                    )
+                }
+            };
+            let operand_const = self.value_ref_to_const_id(val)?;
+            let cid = self.ctx.push_const(ConstantData::Expr {
+                ty: dst_ty,
+                op,
+                operands: vec![operand_const],
+            });
+            Ok(ValueRef::Constant(cid))
+        }
     }
 
     fn parse_constant(&mut self, ty: TypeId) -> Result<ConstId, ParseError> {

--- a/src/llvm-ir-parser/tests/parse_basic.rs
+++ b/src/llvm-ir-parser/tests/parse_basic.rs
@@ -1,7 +1,8 @@
 //! Integration tests: parse representative `.ll` snippets and assert structure.
 
 use llvm_ir::{
-    printer::Printer, ConstantData, InstrKind, LandingPadClause, MemOrdering, RmwOp, VpIntrinsic,
+    printer::Printer, ConstExprOp, ConstantData, InstrKind, LandingPadClause, MemOrdering, RmwOp,
+    VpIntrinsic,
 };
 use llvm_ir_parser::parser::parse;
 
@@ -376,6 +377,81 @@ declare i32 @handler(i32)
             other => panic!("expected Struct element, got {other:?}"),
         }
     }
+}
+
+/// Constexprs that appear inside a global initializer cannot be hoisted
+/// (there is no block to insert into).  They must round-trip through
+/// `ConstantData::Expr` and print as the LLVM parenthesised form.  Issue
+/// #207 PR-B.
+#[test]
+fn parse_constexpr_gep_in_global_initializer() {
+    let src = r#"
+@base = external constant [4 x i32]
+@p3 = constant ptr getelementptr inbounds ([4 x i32], ptr @base, i64 0, i64 3)
+"#;
+    let (ctx, module) = parse(src).expect("parse failed");
+    let init = module.globals[1]
+        .initializer
+        .expect("@p3 must have an initializer");
+    match ctx.get_const(init) {
+        ConstantData::Expr { op, operands, .. } => {
+            assert!(matches!(
+                op,
+                ConstExprOp::GetElementPtr {
+                    inbounds: true,
+                    ..
+                }
+            ));
+            assert_eq!(operands.len(), 3, "base + 2 indices");
+        }
+        other => panic!("expected ConstantData::Expr GEP, got {other:?}"),
+    }
+    let printed = Printer::new(&ctx).print_module(&module);
+    assert!(
+        printed
+            .contains("@p3 = constant ptr getelementptr inbounds ([4 x i32], ptr @base, i64 0, i64 3)"),
+        "constexpr GEP did not print in canonical form:\n{printed}"
+    );
+
+    // Re-parse the printed output to assert print → parse idempotence.
+    let (_ctx2, module2) = parse(&printed).expect("re-parse of printed IR failed");
+    let printed2 = Printer::new(&_ctx2).print_module(&module2);
+    assert_eq!(printed, printed2);
+}
+
+/// Constexpr `bitcast` and `inttoptr` in global initializer position.  Also
+/// covers the cast tag path.  Issue #207 PR-B.
+#[test]
+fn parse_constexpr_casts_in_global_initializer() {
+    let src = r#"
+@h = external constant i64
+@bc = constant ptr bitcast (ptr @h to ptr)
+@itp = constant ptr inttoptr (i64 4096 to ptr)
+"#;
+    let (ctx, module) = parse(src).expect("parse failed");
+    let bc_init = module.globals[1].initializer.unwrap();
+    assert!(matches!(
+        ctx.get_const(bc_init),
+        ConstantData::Expr {
+            op: ConstExprOp::BitCast,
+            ..
+        }
+    ));
+    let itp_init = module.globals[2].initializer.unwrap();
+    assert!(matches!(
+        ctx.get_const(itp_init),
+        ConstantData::Expr {
+            op: ConstExprOp::IntToPtr,
+            ..
+        }
+    ));
+
+    let printed = Printer::new(&ctx).print_module(&module);
+    assert!(printed.contains("@bc = constant ptr bitcast (ptr @h to ptr)"), "{printed}");
+    assert!(
+        printed.contains("@itp = constant ptr inttoptr (i64 4096 to ptr)"),
+        "{printed}"
+    );
 }
 
 /// Parse and print the core `invoke` / `landingpad` exception-control shape.

--- a/src/llvm-ir/src/context.rs
+++ b/src/llvm-ir/src/context.rs
@@ -397,6 +397,7 @@ impl Context {
             ConstantData::Struct { ty, .. } => *ty,
             ConstantData::Vector { ty, .. } => *ty,
             ConstantData::GlobalRef { ty, .. } => *ty, // name field ignored here
+            ConstantData::Expr { ty, .. } => *ty,
         }
     }
 }

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -41,4 +41,4 @@ pub use printer::Printer;
 /// Public API for `re-export`.
 pub use types::{FloatKind, FunctionType, StructType, TypeData};
 /// Public API for `re-export`.
-pub use value::{Argument, ConstantData, GlobalVariable, Linkage};
+pub use value::{Argument, ConstExprOp, ConstantData, GlobalVariable, Linkage};

--- a/src/llvm-ir/src/printer.rs
+++ b/src/llvm-ir/src/printer.rs
@@ -257,6 +257,56 @@ impl<'a> Printer<'a> {
             ConstantData::GlobalRef { name, .. } => {
                 write!(out, "@{}", name).unwrap();
             }
+            ConstantData::Expr { ty, op, operands } => {
+                self.write_const_expr(out, *op, *ty, operands);
+            }
+        }
+    }
+
+    /// Print an LLVM constant expression in its parenthesised form, e.g.
+    /// `getelementptr inbounds (T, ptr <base>, i64 N, ...)` or
+    /// `bitcast (T <c> to U)`.  Issue #207 PR-B.
+    fn write_const_expr(
+        &self,
+        out: &mut String,
+        op: crate::value::ConstExprOp,
+        result_ty: TypeId,
+        operands: &[ConstId],
+    ) {
+        use crate::value::ConstExprOp;
+        match op {
+            ConstExprOp::GetElementPtr { inbounds, base_ty } => {
+                out.push_str("getelementptr");
+                if inbounds {
+                    out.push_str(" inbounds");
+                }
+                out.push_str(" (");
+                self.write_type(out, base_ty);
+                if let Some(&base) = operands.first() {
+                    out.push_str(", ");
+                    self.write_const_with_type(out, base);
+                }
+                for &idx in operands.iter().skip(1) {
+                    out.push_str(", ");
+                    self.write_const_with_type(out, idx);
+                }
+                out.push(')');
+            }
+            op if op.is_cast() => {
+                out.push_str(op.as_str());
+                out.push_str(" (");
+                if let Some(&src) = operands.first() {
+                    self.write_const_with_type(out, src);
+                }
+                out.push_str(" to ");
+                self.write_type(out, result_ty);
+                out.push(')');
+            }
+            _ => {
+                // Unreachable for the variant set we currently support.
+                out.push_str(op.as_str());
+                out.push_str(" (...)");
+            }
         }
     }
 

--- a/src/llvm-ir/src/value.rs
+++ b/src/llvm-ir/src/value.rs
@@ -32,6 +32,77 @@ pub enum ConstantData {
         id: GlobalId,
         name: String,
     },
+    /// LLVM constant expression — e.g. `getelementptr (T, ptr @gv, i64 3)`
+    /// inside a global initializer that can't be hoisted to an SSA
+    /// instruction.  Issue #207 PR-B.
+    Expr {
+        /// Result type of the expression.
+        ty: TypeId,
+        /// Public API for `op`.
+        op: ConstExprOp,
+        /// Constant operands.  For `GetElementPtr`, operands[0] is the base
+        /// pointer; operands[1..] are the indices.  For unary casts,
+        /// operands[0] is the source value.
+        operands: Vec<ConstId>,
+    },
+}
+
+/// Operation tag for [`ConstantData::Expr`].  Only the constexpr forms
+/// emitted by clang at `-O0` are represented; richer ops (`add`, `select`,
+/// `icmp`, etc.) are a follow-up if compatibility surveys turn them up.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConstExprOp {
+    /// `getelementptr [inbounds] (T, ptr <base>, indices...)`
+    GetElementPtr {
+        /// Whether the constexpr GEP carries the `inbounds` flag.
+        inbounds: bool,
+        /// Aggregate / source-element type for index arithmetic.
+        base_ty: TypeId,
+    },
+    /// `bitcast (T C to U)`
+    BitCast,
+    /// `inttoptr (iN C to ptr)`
+    IntToPtr,
+    /// `ptrtoint (ptr C to iN)`
+    PtrToInt,
+    /// `addrspacecast (T C to U)`
+    AddrSpaceCast,
+    /// `trunc (T C to U)`
+    Trunc,
+    /// `zext (T C to U)`
+    ZExt,
+    /// `sext (T C to U)`
+    SExt,
+}
+
+impl ConstExprOp {
+    /// Textual opcode spelling (no parentheses / operands).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConstExprOp::GetElementPtr { .. } => "getelementptr",
+            ConstExprOp::BitCast => "bitcast",
+            ConstExprOp::IntToPtr => "inttoptr",
+            ConstExprOp::PtrToInt => "ptrtoint",
+            ConstExprOp::AddrSpaceCast => "addrspacecast",
+            ConstExprOp::Trunc => "trunc",
+            ConstExprOp::ZExt => "zext",
+            ConstExprOp::SExt => "sext",
+        }
+    }
+
+    /// `true` for cast-shaped ops (single operand, written `<op> (T C to U)`).
+    pub fn is_cast(self) -> bool {
+        matches!(
+            self,
+            ConstExprOp::BitCast
+                | ConstExprOp::IntToPtr
+                | ConstExprOp::PtrToInt
+                | ConstExprOp::AddrSpaceCast
+                | ConstExprOp::Trunc
+                | ConstExprOp::ZExt
+                | ConstExprOp::SExt
+        )
+    }
 }
 
 /// A function argument (SSA value produced by function entry).


### PR DESCRIPTION
Refs #207

## Summary

Second half of the #207 parser unblock split. PR-A (merged in #249) handled constexpr operands inside function bodies via parse-time hoisting. PR-B handles the case that can't be hoisted: constexprs in global-initializer position (no block to insert into).

- New `ConstantData::Expr { ty, op, operands }` + `enum ConstExprOp { GetElementPtr { inbounds, base_ty }, BitCast, IntToPtr, PtrToInt, AddrSpaceCast, Trunc, ZExt, SExt }`.
- Parser produces hoisted SSA instructions inside function bodies (PR-A) and `ConstantData::Expr` in global initializers (new).
- Printer emits the canonical LLVM parenthesised form: `getelementptr inbounds (T, ptr <base>, i64 N, ...)` and `bitcast (T <c> to U)` / `inttoptr / ...`.
- Bitcode reader/writer encode/decode the new variant under a new `EXPR=11` tag.
- Two new parser regression tests cover global-init GEP and global-init casts including print → parse round-trip.

## Root cause / Design rationale

A probe of `clang -O0 -S -emit-llvm` flagged that clang emits constexprs like `@p3 = constant ptr getelementptr inbounds (...)` directly inside global initializers — these can't be lowered to SSA because there is no function body to host them. PR-B gives them a real IR representation so the rest of the pipeline (printer, bitcode, eventually codegen relocations) can reason about them uniformly.

The variant intentionally stays small: only the constexpr ops clang's `-O0` output uses are represented. If `#211`'s compatibility runner surfaces other ops (`select`, `add` over consts, `icmp`, etc.) they can be added incrementally without changing the encoding shape.

## Test plan

- [x] `cargo +stable test -p llvm-in-rust-ir-parser --test parse_basic` — 23 pass, including 2 new:
  - `parse_constexpr_gep_in_global_initializer`
  - `parse_constexpr_casts_in_global_initializer`
- [x] `cargo +stable test -p llvm-in-rust-ir` — 89 unit + 6 roundtrip, all pass
- [x] `cargo +stable test -p llvm-in-rust-bitcode` — 8 pass (no new tests; the bitcode codec doesn't yet preserve `module.globals` at all — see follow-up)
- [x] `cargo +stable test --workspace --no-fail-fast` — only the 5 pre-existing `semantic_*` differential hash mismatches fail (identical set fails on `origin/main`; machine-bound clang baselines)

## Follow-ups

- The bitcode codec doesn't yet preserve `module.globals` at all. The `ConstantData::Expr` encode/decode paths added here are in place so once globals get bitcode coverage the constexpr round-trip will work without further changes. **Will file an issue.**
- Codegen for globals containing `ConstantData::Expr` initializers is still a TODO — the IR pipeline accepts and propagates them, but actual relocation emission for a constant `getelementptr` into a global's `.rodata` payload needs proper target-side support. **Will file an issue.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)