### PR TITLE
feat(x86/win64): emit __chkstk probe for large COFF frames (closes #212)

### DIFF
--- a/src/llvm-codegen/src/assembler.rs
+++ b/src/llvm-codegen/src/assembler.rs
@@ -133,6 +133,7 @@ mod tests {
                 offset: 0,
                 size: 1,
                 global: true,
+                undefined: false,
             }],
         };
         let bytes = object.to_bytes();

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -37,6 +37,10 @@ pub struct Reloc {
     pub kind: RelocKind,
     /// Addend (ELF RELA / Mach-O addend).
     pub addend: i64,
+    /// When set, `symbol` is ignored and this reloc references an external
+    /// symbol by name (e.g. `__chkstk`). `emit_object` resolves it to an
+    /// index after collecting all symbols.
+    pub external_name: Option<String>,
 }
 
 /// A single source mapping row for debug line table emission.
@@ -76,6 +80,8 @@ pub struct Symbol {
     pub size: u64,
     /// Public API for `global`.
     pub global: bool,
+    /// When `true`, this is an external undefined symbol (COFF SectionNumber=0).
+    pub undefined: bool,
 }
 
 /// Assembled object file ready to be written to disk or passed to a linker.
@@ -138,6 +144,7 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
         offset: 0,
         size,
         global: true,
+        undefined: false,
     };
     let mut sections = vec![section];
 
@@ -226,12 +233,36 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
             ObjectFormat::MachO => {}
         };
     }
+    let mut symbols: Vec<Symbol> = vec![sym];
+
+    // Resolve external_name relocs: for each reloc that names an external
+    // symbol, find or insert an undefined Symbol entry and set reloc.symbol.
+    for sec in &mut sections {
+        for reloc in &mut sec.relocs {
+            if let Some(ref ext) = reloc.external_name.clone() {
+                let idx = symbols.iter().position(|s| &s.name == ext).unwrap_or_else(|| {
+                    let i = symbols.len();
+                    symbols.push(Symbol {
+                        name: ext.clone(),
+                        section: 0,
+                        offset: 0,
+                        size: 0,
+                        global: true,
+                        undefined: true,
+                    });
+                    i
+                });
+                reloc.symbol = idx;
+            }
+        }
+    }
+
     ObjectFile {
         format: emitter.object_format(),
         elf_machine: emitter.elf_machine(),
         coff_machine: emitter.coff_machine(),
         sections,
-        symbols: vec![sym],
+        symbols,
     }
 }
 
@@ -827,11 +858,19 @@ fn build_eh_frame(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -
 fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -> (Vec<u8>, Vec<u8>) {
     // Build UNWIND_INFO from prologue facts.
     //
-    // Prologue byte layout assumed by the encoder:
+    // Normal prologue byte layout (alloc ≤ 4096):
     //   push rbp            1 byte  → CodeOffset = 1
     //   mov rbp, rsp        3 bytes → no unwind code (frame setup)
     //   sub rsp, N (imm8)   4 bytes → CodeOffset = 8  (alloc ≤ 128)
     //   sub rsp, N (imm32)  7 bytes → CodeOffset = 11 (alloc > 128)
+    //
+    // __chkstk prologue (alloc > 4096, COFF only):
+    //   push rbp            1 byte  → CodeOffset = 1
+    //   mov rbp, rsp        3 bytes
+    //   [callee-saved pushes]
+    //   mov rax, N         10 bytes
+    //   call __chkstk       5 bytes
+    //   sub rsp, rax        3 bytes → CodeOffset = 22 + callee_push_instr_bytes
     //
     // Per the Win64 ABI, UNWIND_CODE slots must be ordered by CodeOffset
     // in DESCENDING order (last prologue instruction first).
@@ -839,6 +878,14 @@ fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: 
 
     // Round frame allocation up to 16-byte boundary.
     let alloc_size: u32 = if frame_size == 0 { 0 } else { (frame_size + 15) & !15 };
+
+    // Instruction bytes consumed by callee-saved pushes (1 byte for rax-rdi, 2 for r8-r15).
+    let callee_push_instr_bytes: u32 = used_callee_saved
+        .iter()
+        .map(|pr| if pr.0 >= 8 { 2u32 } else { 1u32 })
+        .sum();
+
+    let uses_chkstk = alloc_size > 4096;
 
     // code_bytes holds raw UNWIND_CODE slots (2 bytes each) in descending offset order.
     let mut code_bytes: Vec<u8> = Vec::new();
@@ -855,7 +902,13 @@ fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: 
         // UWOP_ALLOC_LARGE (op=1, info=0): 2 slots
         // Slot 0: {CodeOffset, UWOP_ALLOC_LARGE | info=0}
         // Slot 1 (u16): alloc_size / 8
-        code_bytes.push(11); // CodeOffset: byte after `sub rsp, imm32` (7-byte encoding)
+        let alloc_code_off: u8 = if uses_chkstk {
+            // push rbp(1) + mov rbp,rsp(3) + callee_pushes + mov rax,N(10) + call(5) + sub rsp,rax(3)
+            (22 + callee_push_instr_bytes) as u8
+        } else {
+            11 // byte after `sub rsp, imm32` (7-byte encoding)
+        };
+        code_bytes.push(alloc_code_off);
         code_bytes.push(0x01); // UWOP_ALLOC_LARGE = 1, info = 0
         let sz16 = (alloc_size / 8) as u16;
         code_bytes.extend_from_slice(&sz16.to_le_bytes());
@@ -869,7 +922,9 @@ fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: 
         slot_count += 1;
     }
 
-    let prolog_size: u8 = if alloc_size > 128 {
+    let prolog_size: u8 = if uses_chkstk {
+        (22 + callee_push_instr_bytes) as u8
+    } else if alloc_size > 128 {
         11
     } else if alloc_size > 0 {
         8
@@ -1140,7 +1195,12 @@ fn serialize_coff(obj: &ObjectFile) -> Vec<u8> {
     for (i, sym) in obj.symbols.iter().enumerate() {
         write_coff_name_field(&mut buf, &sym.name, symbol_name_offs[i]);
         w32(&mut buf, sym.offset as u32); // Value
-        w16(&mut buf, (sym.section + 1) as u16); // SectionNumber (1-based)
+        if sym.undefined {
+            // SectionNumber = 0 means external/undefined
+            w16(&mut buf, 0u16);
+        } else {
+            w16(&mut buf, (sym.section + 1) as u16); // SectionNumber (1-based)
+        }
         // Type: IMAGE_SYM_DTYPE_FUNCTION (2) << 4 | IMAGE_SYM_TYPE_NULL (0) = 0x0020
         w16(&mut buf, if sym.global { 0x0020 } else { 0 });
         buf.push(if sym.global { 2 } else { 3 }); // StorageClass: EXTERNAL or STATIC
@@ -1298,6 +1358,7 @@ mod tests {
                 offset: 0,
                 size: 1,
                 global: true,
+                undefined: false,
             }],
         }
     }
@@ -1801,7 +1862,7 @@ mod tests {
             elf_machine: 0,
             coff_machine: 0x8664,
             sections: vec![Section { name: ".text".into(), data: vec![0xC3], relocs: vec![], debug_rows: vec![] }],
-            symbols: vec![Symbol { name: "fn".into(), section: 0, offset: 0, size: 1, global: true }],
+            symbols: vec![Symbol { name: "fn".into(), section: 0, offset: 0, size: 1, global: true, undefined: false }],
         };
         let bytes = obj.to_bytes();
         let symtab_ptr = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]) as usize;

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -13,7 +13,7 @@ use crate::{
     regs::{is_extended, reg_enc},
 };
 use llvm_codegen::{
-    emit::{DebugLineRow, Emitter, ObjectFormat, Reloc, Section},
+    emit::{DebugLineRow, Emitter, ObjectFormat, Reloc, RelocKind, Section},
     isel::{MInstr, MOperand, MachineFunction, PReg},
 };
 use std::collections::HashMap;
@@ -78,9 +78,36 @@ impl Emitter for X86Emitter {
                 }
                 ctx.emit(0x50 | reg_enc(pr));
             }
-            // sub rsp, sub_rsp
+            // sub rsp, sub_rsp  (or __chkstk sequence for large frames)
             if sub_rsp > 0 {
-                if sub_rsp <= 127 {
+                if sub_rsp > 4096 && self.format == ObjectFormat::Coff {
+                    // Win64 ABI requires __chkstk for frames > 4096 bytes to
+                    // probe all pages of the allocation (prevents stack overflow
+                    // from jumping over the guard page).
+                    //
+                    // Sequence: mov rax, sub_rsp  (REX.W B8 + imm64, 10 bytes)
+                    //           call __chkstk      (E8 + rel32, 5 bytes)
+                    //           sub rsp, rax       (REX.W 2B E0, 3 bytes)
+                    ctx.emit(0x48); // REX.W
+                    ctx.emit(0xB8); // MOV RAX, imm64
+                    ctx.emit64(sub_rsp as i64);
+                    let call_site = ctx.pos();
+                    ctx.emit(0xE8); // CALL rel32
+                    // rel32 placeholder — filled by linker via IMAGE_REL_AMD64_REL32
+                    ctx.emit32(0);
+                    ctx.relocs.push(Reloc {
+                        offset: (call_site + 1) as u64,
+                        symbol: 0, // resolved by emit_object via external_name
+                        kind: RelocKind::Pc32,
+                        addend: -4,
+                        external_name: Some("__chkstk".to_string()),
+                    });
+                    // SUB RSP, RAX: REX.W=48, opcode=2B (SUB r64,r/m64),
+                    // ModRM=E0 (mod=11, reg=RSP(4), rm=RAX(0) → 11_100_000)
+                    ctx.emit(0x48);
+                    ctx.emit(0x2B);
+                    ctx.emit(0xE0);
+                } else if sub_rsp <= 127 {
                     ctx.emit(0x48);
                     ctx.emit(0x83);
                     ctx.emit(0xEC);
@@ -1396,5 +1423,85 @@ mod tests {
             .data
             .windows(7)
             .any(|w| w == [0x48, 0x81, 0xC4, 0x30, 0x00, 0x00, 0x00]));
+    }
+
+    #[test]
+    fn chkstk_sequence_emitted_for_large_coff_frame() {
+        // frame_size = 8192 (> 4096) with COFF format must emit the __chkstk
+        // probe sequence: mov rax, 8192 / call __chkstk / sub rsp, rax.
+        let mut mf = MachineFunction::new("big_frame".into());
+        mf.frame_size = 8192;
+        let b0 = mf.add_block("entry");
+        mf.push(b0, MInstr::new(RET));
+
+        let mut e = X86Emitter::new(ObjectFormat::Coff);
+        let sec = e.emit_function(&mf);
+
+        // sub_rsp = (8192 + 15) & !15 = 8192 = 0x2000
+        // Expected sequence in prologue (after push rbp + mov rbp,rsp):
+        //   48 B8 00 20 00 00 00 00 00 00   (mov rax, 0x2000)
+        //   E8 00 00 00 00                  (call __chkstk, placeholder)
+        //   48 2B E0                        (sub rsp, rax)
+        let mov_rax: &[u8] = &[0x48, 0xB8, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let call_chkstk: &[u8] = &[0xE8, 0x00, 0x00, 0x00, 0x00];
+        let sub_rsp_rax: &[u8] = &[0x48, 0x2B, 0xE0];
+
+        assert!(
+            sec.data.windows(mov_rax.len()).any(|w| w == mov_rax),
+            "missing: mov rax, 8192"
+        );
+        assert!(
+            sec.data.windows(call_chkstk.len()).any(|w| w == call_chkstk),
+            "missing: call __chkstk placeholder"
+        );
+        assert!(
+            sec.data.windows(sub_rsp_rax.len()).any(|w| w == sub_rsp_rax),
+            "missing: sub rsp, rax"
+        );
+        // Must have a reloc for the __chkstk call
+        assert!(
+            sec.relocs.iter().any(|r| r.external_name.as_deref() == Some("__chkstk")),
+            "missing __chkstk reloc"
+        );
+    }
+
+    #[test]
+    fn coff_large_frame_emits_external_chkstk_symbol() {
+        // emit_object must insert an undefined Symbol for __chkstk when the
+        // prologue emits a call to it.
+        let mut mf = MachineFunction::new("big_frame2".into());
+        mf.frame_size = 8192;
+        let b0 = mf.add_block("entry");
+        mf.push(b0, MInstr::new(RET));
+
+        let mut e = X86Emitter::new(ObjectFormat::Coff);
+        let obj = emit_object(&mf, &mut e);
+
+        let chkstk_sym = obj.symbols.iter().find(|s| s.name == "__chkstk");
+        assert!(chkstk_sym.is_some(), "no __chkstk symbol in COFF object");
+        assert!(chkstk_sym.unwrap().undefined, "__chkstk must be undefined");
+    }
+
+    #[test]
+    fn elf_large_frame_does_not_emit_chkstk() {
+        // __chkstk is Win64-only; ELF large frames must use regular sub rsp, imm32.
+        let mut mf = MachineFunction::new("big_frame_elf".into());
+        mf.frame_size = 8192;
+        let b0 = mf.add_block("entry");
+        mf.push(b0, MInstr::new(RET));
+
+        let mut e = X86Emitter::new(ObjectFormat::Elf);
+        let sec = e.emit_function(&mf);
+
+        // sub rsp, 8192 (imm32 form): 48 81 EC 00 20 00 00
+        let sub_rsp_imm32: &[u8] = &[0x48, 0x81, 0xEC, 0x00, 0x20, 0x00, 0x00];
+        assert!(
+            sec.data.windows(sub_rsp_imm32.len()).any(|w| w == sub_rsp_imm32),
+            "ELF large frame must use sub rsp, imm32 (not __chkstk)"
+        );
+        assert!(
+            !sec.relocs.iter().any(|r| r.external_name.as_deref() == Some("__chkstk")),
+            "ELF must not emit __chkstk reloc"
+        );
     }
 }

--- a/src/llvm/src/lto.rs
+++ b/src/llvm/src/lto.rs
@@ -156,6 +156,7 @@ mod tests {
                 offset: 0,
                 size: 1,
                 global: true,
+                undefined: false,
             }],
         }
     }


### PR DESCRIPTION
Closes #212

## Summary

- **`Symbol::undefined`** — new bool field; `serialize_coff` emits `SectionNumber=0` for external/undefined symbols (required by lld-link for external calls like `__chkstk`)
- **`Reloc::external_name`** — new `Option<String>`; `emit_object` resolves named relocs into undefined `Symbol` table entries after `emit_function` returns
- **x86 prologue** — when `sub_rsp > 4096` and COFF format, replace `sub rsp, imm32` with the Win64-mandated three-instruction stack-probe sequence:
  ```
  mov rax, N         ; 10 bytes (REX.W + MOVABS)
  call __chkstk      ; 5 bytes (E8 + IMAGE_REL_AMD64_REL32 reloc)
  sub rsp, rax       ; 3 bytes (REX.W 2B E0)
  ```
  This probes every page in the allocation so the OS guard page isn't skipped, preventing silent stack overflow.
- **UWOP CodeOffset** — `build_coff_unwind_tables` now computes `22 + callee_push_instr_bytes` for the alloc unwind code when `__chkstk` is used, matching the actual prologue byte layout
- **3 new tests** in `encode.rs`: COFF large-frame emits the exact byte sequence, resulting `ObjectFile` has an undefined `__chkstk` symbol, ELF large-frame uses regular `sub rsp` (no `__chkstk`)

## Test plan

- [x] `cargo +stable test` — all tests pass (0 failures)
- [x] `chkstk_sequence_emitted_for_large_coff_frame` — verifies `48 B8 … E8 00000000 48 2B E0` byte pattern
- [x] `coff_large_frame_emits_external_chkstk_symbol` — verifies `Symbol { name: "__chkstk", undefined: true }` via `emit_object`
- [x] `elf_large_frame_does_not_emit_chkstk` — verifies ELF path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)