### PR TITLE
fix: remove extra positional test-name args from windows-e2e CI

### DIFF
--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -39,9 +39,6 @@ jobs:
           cargo +stable test \
             -p llvm-in-rust-codegen \
             --test linker_compat \
-            coff_link_with_lld_link_and_run_exit_code \
-            coff_object_main_symbol_visible \
-            tool_presence_report_is_accessible \
             -- --nocapture
 
   coff_inspect:


### PR DESCRIPTION
Closes #261

## Summary

- `cargo test` only accepts **one** positional test-name filter argument; passing `coff_link_with_lld_link_and_run_exit_code coff_object_main_symbol_visible tool_presence_report_is_accessible` as three separate positional args caused an "unexpected argument" error on every Windows E2E CI run.
- Fix: remove the three individual name filters from the `coff_link_execute` job and let the test binary run all tests in the `linker_compat` integration-test file.

## Test plan
- [ ] Windows E2E CI (`coff_link_execute` + `coff_inspect` jobs) passes after this change
- [ ] All tests in `linker_compat` are still exercised (none were removed, just the broken filter args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)