### PR TITLE
ir: implement PGO instrprof intrinsics as no-op lowering

### DIFF
--- a/src/llvm-codegen/tests/pgo_instrprof.rs
+++ b/src/llvm-codegen/tests/pgo_instrprof.rs
@@ -1,0 +1,148 @@
+//! Tests for PGO instrprof intrinsic no-op lowering (issue #219).
+//!
+//! Verifies that `llvm.instrprof.increment` and `llvm.instrprof.value.profile`
+//! compile without error and are lowered to NOP machine instructions.
+
+use llvm_codegen::{
+    emit_object,
+    isel::IselBackend,
+    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy},
+    ObjectFormat,
+};
+use llvm_ir::{InstrprofIntrinsic};
+use llvm_ir_parser::parser::parse;
+use llvm_target_x86::{instructions::{MOV_LOAD_MR, MOV_STORE_RM, NOP, CALL_R}, X86Backend, X86Emitter};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn compile_x86(src: &str) -> Vec<llvm_codegen::isel::MInstr> {
+    let (ctx, module) = parse(src).expect("parse failed");
+    let func = module.functions.iter().find(|f| f.name == "main" && !f.is_declaration)
+        .expect("no @main definition");
+    let mut backend = X86Backend::default();
+    let mut mf = backend.lower_function(&ctx, &module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
+    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+    apply_allocation(&mut mf, &result);
+    mf.blocks.iter().flat_map(|b| b.instrs.iter().cloned()).collect()
+}
+
+fn compile_x86_object(src: &str) -> Vec<u8> {
+    let (ctx, module) = parse(src).expect("parse failed");
+    let func = module.functions.iter().find(|f| f.name == "main" && !f.is_declaration)
+        .expect("no @main definition");
+    let mut backend = X86Backend::default();
+    let mut mf = backend.lower_function(&ctx, &module, func);
+    let intervals = compute_live_intervals(&mf);
+    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, RegAllocStrategy::LinearScan);
+    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+    apply_allocation(&mut mf, &result);
+    let mut emitter = X86Emitter::new(ObjectFormat::Elf);
+    emit_object(&mf, &mut emitter).to_bytes()
+}
+
+// ── unit tests for InstrprofIntrinsic::from_name ──────────────────────────
+
+#[test]
+fn instrprof_from_name_recognizes_increment() {
+    assert_eq!(
+        InstrprofIntrinsic::from_name("llvm.instrprof.increment"),
+        Some(InstrprofIntrinsic::Increment)
+    );
+}
+
+#[test]
+fn instrprof_from_name_recognizes_value_profile() {
+    assert_eq!(
+        InstrprofIntrinsic::from_name("llvm.instrprof.value.profile"),
+        Some(InstrprofIntrinsic::ValueProfile)
+    );
+}
+
+#[test]
+fn instrprof_from_name_returns_none_for_unknown() {
+    assert_eq!(InstrprofIntrinsic::from_name("llvm.instrprof.unknown"), None);
+    assert_eq!(InstrprofIntrinsic::from_name("llvm.lifetime.start"), None);
+    assert_eq!(InstrprofIntrinsic::from_name("llvm.vp.add.i32"), None);
+    assert_eq!(InstrprofIntrinsic::from_name(""), None);
+}
+
+// ── backend lowering tests ─────────────────────────────────────────────────
+
+const INSTRPROF_INCREMENT_IR: &str = r#"
+declare void @llvm.instrprof.increment(ptr, i64, i32, i32)
+@__profn_foo = external global i8
+
+define i32 @main() {
+entry:
+  call void @llvm.instrprof.increment(ptr @__profn_foo, i64 12345, i32 1, i32 0)
+  ret i32 0
+}
+"#;
+
+const INSTRPROF_VALUE_PROFILE_IR: &str = r#"
+declare void @llvm.instrprof.value.profile(ptr, i64, i64, i32, i32)
+@__profn_bar = external global i8
+
+define i32 @main() {
+entry:
+  %v = add i64 0, 42
+  call void @llvm.instrprof.value.profile(ptr @__profn_bar, i64 99, i64 %v, i32 0, i32 0)
+  ret i32 0
+}
+"#;
+
+const INSTRPROF_SURROUNDING_ARITHMETIC_IR: &str = r#"
+declare void @llvm.instrprof.increment(ptr, i64, i32, i32)
+@__profn_arith = external global i8
+
+define i32 @main() {
+entry:
+  %a = add i32 3, 4
+  call void @llvm.instrprof.increment(ptr @__profn_arith, i64 1, i32 1, i32 0)
+  %b = add i32 %a, 5
+  ret i32 %b
+}
+"#;
+
+#[test]
+fn instrprof_increment_compiles_without_error() {
+    // Must not panic; object bytes must be non-empty.
+    let bytes = compile_x86_object(INSTRPROF_INCREMENT_IR);
+    assert!(!bytes.is_empty(), "expected non-empty object for instrprof.increment");
+}
+
+#[test]
+fn instrprof_value_profile_compiles_without_error() {
+    let bytes = compile_x86_object(INSTRPROF_VALUE_PROFILE_IR);
+    assert!(!bytes.is_empty(), "expected non-empty object for instrprof.value.profile");
+}
+
+#[test]
+fn instrprof_increment_emits_nop_not_call() {
+    // The intrinsic must lower to NOP, not to a CALL_R instruction.
+    let instrs = compile_x86(INSTRPROF_INCREMENT_IR);
+    let has_nop = instrs.iter().any(|mi| mi.opcode == NOP);
+    let has_call_to_instrprof = instrs.iter().any(|mi| mi.opcode == CALL_R);
+    assert!(has_nop, "expected at least one NOP from instrprof.increment lowering");
+    // We allow call_r for other calls but confirm instrprof didn't sneak through as a real call.
+    // Since @main has no other calls, any CALL_R would be the intrinsic leaking through.
+    assert!(
+        !has_call_to_instrprof,
+        "instrprof.increment must not emit a CALL_R — it should be a NOP"
+    );
+}
+
+#[test]
+fn instrprof_does_not_disturb_surrounding_arithmetic() {
+    // IR: add, instrprof.increment, add, ret.
+    // After lowering the two adds must still produce ADD_RR instructions.
+    use llvm_target_x86::instructions::ADD_RR;
+    let instrs = compile_x86(INSTRPROF_SURROUNDING_ARITHMETIC_IR);
+    let add_count = instrs.iter().filter(|mi| mi.opcode == ADD_RR).count();
+    assert!(
+        add_count >= 2,
+        "expected at least 2 ADD_RR instructions around the instrprof NOP, got {add_count}"
+    );
+}

--- a/src/llvm-ir/src/instruction.rs
+++ b/src/llvm-ir/src/instruction.rs
@@ -300,6 +300,37 @@ impl VpIntrinsic {
     }
 }
 
+/// Recognized LLVM profile-guided optimization intrinsics.
+///
+/// Phase 1 lowers these to no-ops and emits a compile-time warning.
+/// Phase 2 (future) will emit actual counter-increment code and read profiles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum InstrprofIntrinsic {
+    /// `llvm.instrprof.increment` — increment a PGO counter.
+    Increment,
+    /// `llvm.instrprof.value.profile` — record a value profile sample.
+    ValueProfile,
+}
+
+impl InstrprofIntrinsic {
+    /// Recognize an `llvm.instrprof.*` symbol name.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "llvm.instrprof.increment" => Some(Self::Increment),
+            "llvm.instrprof.value.profile" => Some(Self::ValueProfile),
+            _ => None,
+        }
+    }
+
+    /// The canonical LLVM IR name for this intrinsic.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Increment => "llvm.instrprof.increment",
+            Self::ValueProfile => "llvm.instrprof.value.profile",
+        }
+    }
+}
+
 impl RmwOp {
     /// Textual IR spelling.
     pub fn as_str(self) -> &'static str {

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -32,7 +32,7 @@ pub use function::Function;
 /// Public API for `re-export`.
 pub use instruction::{
     ExactFlag, FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
-    LandingPadClause, MemOrdering, RmwOp, TailCallKind, VpIntrinsic,
+    InstrprofIntrinsic, LandingPadClause, MemOrdering, RmwOp, TailCallKind, VpIntrinsic,
 };
 /// Public API for `re-export`.
 pub use module::{DebugLocation, Module};

--- a/src/llvm-target-arm/src/lower.rs
+++ b/src/llvm-target-arm/src/lower.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MachineFunction, PReg, VReg};
 use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
-    TypeData, ValueRef,
+    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, InstrprofIntrinsic,
+    IntPredicate, Module, TypeData, ValueRef,
 };
 use std::collections::HashMap;
 
@@ -153,6 +153,16 @@ fn const_to_imm(cd: &ConstantData) -> i64 {
         ConstantData::Float { bits, .. } => *bits as i64,
         _ => 0,
     }
+}
+
+fn instrprof_from_callee(ctx: &Context, callee: ValueRef) -> Option<InstrprofIntrinsic> {
+    let ValueRef::Constant(cid) = callee else {
+        return None;
+    };
+    let ConstantData::GlobalRef { name, .. } = ctx.get_const(cid) else {
+        return None;
+    };
+    InstrprofIntrinsic::from_name(name)
 }
 
 fn inline_asm_bytes_aarch64(template: &str) -> Vec<u8> {
@@ -460,6 +470,17 @@ fn lower_instr(
 
         // ── calls ──────────────────────────────────────────────────────────
         Call { callee, args, .. } => {
+            if let Some(ip) = instrprof_from_callee(ctx, *callee) {
+                eprintln!(
+                    "warning: PGO intrinsic {} elided — counter emission not implemented",
+                    ip.as_str()
+                );
+                for &arg in args {
+                    let _ = res!(arg);
+                }
+                mf.push(mblock, MInstr::new(NOP));
+                return;
+            }
             let arg_locs = classify_aapcs64_args(args.len());
             for (i, &arg_vref) in args.iter().enumerate() {
                 let src = res!(arg_vref);

--- a/src/llvm-target-riscv/src/lower.rs
+++ b/src/llvm-target-riscv/src/lower.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MachineFunction, PReg, VReg};
 use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
-    ValueRef,
+    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, InstrprofIntrinsic,
+    IntPredicate, Module, ValueRef,
 };
 use std::collections::HashMap;
 
@@ -199,6 +199,16 @@ fn lower_icmp_to_bool(
     }
 }
 
+fn instrprof_from_callee(ctx: &Context, callee: ValueRef) -> Option<InstrprofIntrinsic> {
+    let ValueRef::Constant(cid) = callee else {
+        return None;
+    };
+    let ConstantData::GlobalRef { name, .. } = ctx.get_const(cid) else {
+        return None;
+    };
+    InstrprofIntrinsic::from_name(name)
+}
+
 fn lower_instr(
     ctx: &Context,
     _module: &Module,
@@ -298,6 +308,17 @@ fn lower_instr(
         }
 
         Call { callee, args, .. } => {
+            if let Some(ip) = instrprof_from_callee(ctx, *callee) {
+                eprintln!(
+                    "warning: PGO intrinsic {} elided — counter emission not implemented",
+                    ip.as_str()
+                );
+                for &arg in args {
+                    let _ = res!(arg);
+                }
+                mf.push(mblock, MInstr::new(NOP));
+                return;
+            }
             let arg_locs = classify_rv64_int_args(args.len());
             for (i, &arg_vref) in args.iter().enumerate() {
                 let src = res!(arg_vref);

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use llvm_codegen::isel::{DebugLoc, IselBackend, MInstr, MOperand, MachineFunction, PReg, VReg};
 use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, FloatKind, Function, InstrId, InstrKind, IntPredicate,
-    Module, TypeData, ValueRef, VpIntrinsic,
+    ArgId, BlockId, ConstantData, Context, FloatKind, Function, InstrId, InstrKind,
+    InstrprofIntrinsic, IntPredicate, Module, TypeData, ValueRef, VpIntrinsic,
 };
 use std::collections::HashMap;
 
@@ -381,6 +381,16 @@ fn vp_intrinsic_from_callee(ctx: &Context, callee: ValueRef) -> Option<VpIntrins
     VpIntrinsic::from_name(name)
 }
 
+fn instrprof_from_callee(ctx: &Context, callee: ValueRef) -> Option<InstrprofIntrinsic> {
+    let ValueRef::Constant(cid) = callee else {
+        return None;
+    };
+    let ConstantData::GlobalRef { name, .. } = ctx.get_const(cid) else {
+        return None;
+    };
+    InstrprofIntrinsic::from_name(name)
+}
+
 // ── instruction lowering ──────────────────────────────────────────────────
 
 fn lower_instr(
@@ -682,6 +692,17 @@ fn lower_instr(
 
         // ── calls ──────────────────────────────────────────────────────────
         Call { callee, args, .. } => {
+            if let Some(ip) = instrprof_from_callee(ctx, *callee) {
+                eprintln!(
+                    "warning: PGO intrinsic {} elided — counter emission not implemented",
+                    ip.as_str()
+                );
+                for &arg in args {
+                    let _ = res!(arg);
+                }
+                mf.push(mblock, MInstr::new(NOP));
+                return;
+            }
             if let Some(vp) = vp_intrinsic_from_callee(ctx, *callee) {
                 match vp {
                     VpIntrinsic::Add if args.len() >= 2 => {


### PR DESCRIPTION
Closes #219

## Summary
- Add `InstrprofIntrinsic` enum to `llvm-ir` recognizing `llvm.instrprof.increment` and `llvm.instrprof.value.profile`
- All three backends (x86_64, AArch64, RISC-V) detect these calls early in their `Call` lowering arm, emit a NOP placeholder, and print a warning to stderr: `warning: PGO intrinsic <name> elided — counter emission not implemented`
- Export `InstrprofIntrinsic` from `llvm-ir` crate root alongside `VpIntrinsic`

## Root cause / Design rationale
PGO-instrumented IR from clang/rustc contains `llvm.instrprof.*` intrinsic calls that previously caused the pipeline to treat them as real external calls (emitting `CALL_R` with an unresolved symbol). This phase-1 fix lowers them to NOPs so PGO-instrumented IR compiles cleanly. Counter emission (Phase 2) is deferred to a future issue.

## Test plan
- [x] `instrprof_from_name_recognizes_increment` — unit test for `from_name()`
- [x] `instrprof_from_name_recognizes_value_profile` — unit test for `from_name()`
- [x] `instrprof_from_name_returns_none_for_unknown` — unit test, 4 negative cases
- [x] `instrprof_increment_compiles_without_error` — full pipeline, non-empty object
- [x] `instrprof_value_profile_compiles_without_error` — full pipeline, non-empty object
- [x] `instrprof_increment_emits_nop_not_call` — verifies NOP emitted, no `CALL_R` leak
- [x] `instrprof_does_not_disturb_surrounding_arithmetic` — ADD_RR on both sides of intrinsic still present
- [x] All existing tests pass (full `cargo +stable test`)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)