### PR TITLE
meta: establish RFC process for breaking API changes (closes #224)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rfc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rfc.md
@@ -1,0 +1,20 @@
+## RFC checklist
+
+This PR proposes an RFC.  Before requesting review, confirm:
+
+- [ ] File is named `docs/rfcs/NNNN-short-title.md` (use `0000` if the number
+      hasn't been assigned yet — a maintainer will update it before merging).
+- [ ] All template sections are filled in: Summary, Motivation, Guide-level
+      explanation, Reference-level explanation (with before/after API snippets),
+      Drawbacks, Alternatives considered, Unresolved questions.
+- [ ] The PR has the `rfc` label applied.
+- [ ] If there is an existing tracking issue, it is linked in the RFC front
+      matter and mentioned in the PR description.
+
+## What this RFC changes
+
+<!-- One sentence: what public API, IR semantics, or format is being changed? -->
+
+## Tracking issue
+
+<!-- Link to the GitHub issue, or "N/A" -->

--- a/README.md
+++ b/README.md
@@ -728,6 +728,19 @@ llvm-target-x86 = { package = "llvm-in-rust-target-x86", path = "path/to/LLVM-in
 
 ---
 
+## RFC Process
+
+Breaking changes to the public API, IR semantics (`InstrKind`/`TypeData` variants),
+object-file format compatibility, or mandatory trait methods require an RFC before
+implementation.  An RFC is a short Markdown document that describes the motivation,
+the precise before/after API change, a migration guide, and alternatives considered.
+RFCs go through at least 7 days of open review followed by a 3-day Final Comment
+Period before a maintainer merges them.  See
+[`docs/rfcs/README.md`](docs/rfcs/README.md) for the full process, triggers, and
+submission instructions.
+
+---
+
 ## Contributing
 
 1. Fork the repository and create a feature branch.

--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,89 @@
+# RFC NNNN: [Title]
+
+- **Start date**: YYYY-MM-DD
+- **RFC PR**: (leave blank until you open the PR)
+- **Tracking issue**: (link to the GitHub issue this addresses, if any)
+
+---
+
+## Summary
+
+One paragraph explaining the change.  What is being changed and what problem
+does it solve?
+
+---
+
+## Motivation
+
+Why does this change need to happen now?  What pain point, correctness issue,
+or design limitation makes the status quo unacceptable?  Include concrete
+examples where possible (e.g. code that is currently broken or confusing).
+
+---
+
+## Guide-level explanation
+
+Explain the change as you would to a new contributor.  What does the API look
+like after this RFC?  Walk through the common use case with a short code snippet
+or before/after example.  Skip internal implementation details here — focus on
+what users of the crate will see and do differently.
+
+---
+
+## Reference-level explanation
+
+Precise description of every change being made:
+
+### API changes (before / after)
+
+```rust
+// Before
+pub fn example(x: OldType) -> OldReturn;
+
+// After
+pub fn example(x: NewType) -> NewReturn;
+```
+
+List every affected type, function, trait method, or module.
+
+### IR semantics changes (if applicable)
+
+Describe any changes to `InstrKind`, `TypeData`, `ConstantData`, or related
+enums, including new variants, renamed variants, and removed variants.
+
+### Format compatibility (if applicable)
+
+Describe any changes to the LRIR binary format or ELF/Mach-O section structure.
+State whether old objects remain readable after the change and how to migrate.
+
+### Migration guide
+
+What do downstream users need to change in their code?  Provide a step-by-step
+migration path with code examples.
+
+---
+
+## Drawbacks
+
+What are the costs of this change?  Consider:
+- Churn for downstream users
+- Increased complexity in the implementation
+- Performance implications
+- Anything that might make this hard to revert later
+
+---
+
+## Alternatives considered
+
+What other designs were considered and why were they rejected?  Even if the
+alternative is "do nothing", explain why the status quo is worse than the
+proposed change.
+
+---
+
+## Unresolved questions
+
+List any open questions that must be answered before implementation begins, or
+that can be deferred to a follow-up RFC.  For example:
+- Are there edge cases in the migration path that need more thought?
+- Should a related but separable concern be addressed here or in a follow-up?

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -81,6 +81,8 @@ Draft  -->  Review (min 7 days)  -->  FCP (3 days)  -->  Accepted / Rejected
 3. Fill in every section of the template.  Leave the number as `0000` — a
    maintainer will assign the final number before merging.
 4. Open a PR against `main` targeting only `docs/rfcs/`.
+   > **Tip**: append `?template=rfc.md` to the PR creation URL so GitHub
+   > pre-loads the RFC PR checklist from `.github/PULL_REQUEST_TEMPLATE/rfc.md`.
 5. Add the `rfc` label to the PR.
 6. Post a link to the PR in the relevant issue (if one exists).
 
@@ -90,7 +92,7 @@ Draft  -->  Review (min 7 days)  -->  FCP (3 days)  -->  Accepted / Rejected
 
 Any maintainer can approve an RFC by posting `r+ fcp` to start the Final
 Comment Period, and can merge the RFC PR after FCP concludes.  Maintainers are
-listed in [AGENTS.md](../../AGENTS.md).
+GitHub org owners of the `yudongusa/LLVM-in-Rust` repository.
 
 Implementors are encouraged to volunteer to implement accepted RFCs by claiming
 the tracking issue.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,96 @@
+# RFC Process
+
+This document describes the lightweight RFC (Request for Comments) process used
+to govern breaking changes to the LLVM-in-Rust public API and IR semantics.
+
+---
+
+## When an RFC is required
+
+An RFC is required before merging any change that:
+
+- **Alters a public type or function signature** — changing parameter types,
+  return types, or generic bounds on anything `pub` in a released crate.
+- **Removes a public type, trait, function, or module** — including renaming
+  (rename = remove old + add new).
+- **Changes IR semantics** — adding, removing, or redefining a variant of
+  `InstrKind`, `TypeData`, or `ConstantData` in `llvm-ir`.
+- **Breaks object-file format compatibility** — changes to LRIR magic bytes,
+  version fields, record layout, or ELF/Mach-O section structure that would
+  make objects produced by the old code unreadable by the new code (or vice
+  versa).
+- **Adds a mandatory method to a public trait** — e.g. adding a required method
+  to `IselBackend`, `Emitter`, `FunctionPass`, or `ModulePass` that downstream
+  implementors must provide.
+
+If you are unsure, open an issue first and ask. Erring on the side of writing
+an RFC is always acceptable.
+
+---
+
+## When an RFC is NOT required
+
+No RFC is needed for:
+
+- **Purely additive changes** — new optional methods (with default impls), new
+  crates, new `pub` types that nothing existing depends on.
+- **Bug fixes that restore documented behaviour** — the fix must not change any
+  stable, intentionally-specified API surface; only bring behaviour in line with
+  what the docs already promise.
+- **Documentation-only changes** — changes to `.md` files, doc comments,
+  examples, or tests with no production-code impact.
+- **Performance improvements** with no API surface change — e.g. a faster
+  register allocator that keeps all public types and traits identical.
+- **Internal refactors** — renaming or restructuring `pub(crate)` items,
+  private helpers, or anything not exposed in public API docs.
+
+---
+
+## RFC lifecycle
+
+```
+Draft  -->  Review (min 7 days)  -->  FCP (3 days)  -->  Accepted / Rejected
+```
+
+1. **Draft**: Author opens a PR to `docs/rfcs/` with label `rfc`.  The file is
+   named `NNNN-short-title.md` where `NNNN` is the next available four-digit
+   number (use `0000` until a maintainer assigns a number).
+2. **Review**: At least 7 calendar days of open discussion.  Anyone may comment.
+   The author may revise the RFC in response to feedback; significant revisions
+   reset the 7-day clock.
+3. **Final Comment Period (FCP)**: A maintainer posts an explicit `r+ fcp` comment
+   to signal that the RFC is ready for a final decision.  FCP lasts 3 calendar
+   days to allow any last objections.
+4. **Accepted**: After FCP, a maintainer merges the RFC PR.  The RFC file is
+   now the authoritative spec for the implementation PR(s).
+5. **Rejected**: A maintainer closes the RFC PR with a brief explanation.
+   Rejection is not permanent — revised RFCs may be resubmitted.
+
+### After acceptance
+
+- Implementation PRs reference the RFC: `Implements RFC NNNN`.
+- The RFC file is updated in-place only to add an `## Implementation` section
+  linking the implementation PRs.  The rest of the RFC is immutable once merged.
+
+---
+
+## How to submit an RFC
+
+1. Fork the repository and create a branch named `rfc/short-description`.
+2. Copy `docs/rfcs/0000-template.md` to `docs/rfcs/0000-short-title.md`.
+3. Fill in every section of the template.  Leave the number as `0000` — a
+   maintainer will assign the final number before merging.
+4. Open a PR against `main` targeting only `docs/rfcs/`.
+5. Add the `rfc` label to the PR.
+6. Post a link to the PR in the relevant issue (if one exists).
+
+---
+
+## Who can approve
+
+Any maintainer can approve an RFC by posting `r+ fcp` to start the Final
+Comment Period, and can merge the RFC PR after FCP concludes.  Maintainers are
+listed in [AGENTS.md](../../AGENTS.md).
+
+Implementors are encouraged to volunteer to implement accepted RFCs by claiming
+the tracking issue.


### PR DESCRIPTION
## Summary

Establishes a lightweight RFC process so that breaking changes to public API, IR semantics, and object-file formats go through a documented review step before landing.

## Files created / modified

- **`docs/rfcs/README.md`** — the process document: when an RFC is required (and when it isn't), the Draft → Review → FCP → Accepted/Rejected lifecycle with calendar minimums, submission steps, and approval rules.
- **`docs/rfcs/0000-template.md`** — the RFC template with seven sections (Summary, Motivation, Guide-level explanation, Reference-level explanation with before/after snippets, Drawbacks, Alternatives considered, Unresolved questions).
- **`.github/PULL_REQUEST_TEMPLATE/rfc.md`** — minimal PR checklist for RFC PRs reminding authors to fill all sections and add the `rfc` label.
- **`README.md`** — added a `## RFC Process` paragraph near the Contributing section linking to `docs/rfcs/README.md`.

Total new lines (process doc + template + PR template): 205, well within the 300-line target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #224