### PR TITLE
feat(wasm): implement WebAssembly wasm32 backend (closes #222)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "llvm-in-rust-ir-parser",
  "llvm-in-rust-target-arm",
  "llvm-in-rust-target-riscv",
+ "llvm-in-rust-target-wasm",
  "llvm-in-rust-target-x86",
  "llvm-in-rust-transforms",
 ]
@@ -543,6 +544,17 @@ dependencies = [
 name = "llvm-in-rust-target-riscv"
 version = "0.1.0"
 dependencies = [
+ "llvm-in-rust-codegen",
+ "llvm-in-rust-ir",
+ "llvm-in-rust-ir-parser",
+ "llvm-in-rust-transforms",
+]
+
+[[package]]
+name = "llvm-in-rust-target-wasm"
+version = "0.1.0"
+dependencies = [
+ "llvm-in-rust-analysis",
  "llvm-in-rust-codegen",
  "llvm-in-rust-ir",
  "llvm-in-rust-ir-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "src/llvm-target-x86",
     "src/llvm-target-arm",
     "src/llvm-target-riscv",
+    "src/llvm-target-wasm",
     "src/llvm-bitcode",
     "src/llvm",
     "src/llvm-bench",

--- a/src/llvm-target-wasm/Cargo.toml
+++ b/src/llvm-target-wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "llvm-in-rust-target-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+description = "WebAssembly (wasm32) target backend for LLVM-in-Rust code generation."
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"
+keywords = ["llvm", "compiler", "ir", "codegen", "rust"]
+categories = ["compilers", "development-tools"]
+
+[lib]
+name = "llvm_target_wasm"
+
+[dependencies]
+llvm-ir = { package = "llvm-in-rust-ir", version = "0.1.0", path = "../llvm-ir" }
+llvm-codegen = { package = "llvm-in-rust-codegen", version = "0.1.0", path = "../llvm-codegen" }
+llvm-analysis = { package = "llvm-in-rust-analysis", version = "0.1.0", path = "../llvm-analysis" }
+llvm-ir-parser = { package = "llvm-in-rust-ir-parser", version = "0.1.0", path = "../llvm-ir-parser" }
+llvm-transforms = { package = "llvm-in-rust-transforms", version = "0.1.0", path = "../llvm-transforms" }

--- a/src/llvm-target-wasm/src/encode.rs
+++ b/src/llvm-target-wasm/src/encode.rs
@@ -1,0 +1,339 @@
+//! WebAssembly binary format encoder.
+//!
+//! Produces a complete `.wasm` module from a lowered [`WasmModule`] — no
+//! intermediate object file is needed since wasm is self-describing.
+
+use crate::instructions::*;
+use crate::lower::WasmFunction;
+use crate::types::{ir_ty_to_valtype, BLOCKTYPE_VOID};
+use llvm_ir::{Context, Module, TypeData};
+
+// ── LEB128 helpers ────────────────────────────────────────────────────────
+
+/// Encode `v` as an unsigned LEB128 integer into `buf`.
+pub fn leb128_u(buf: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let byte = (v & 0x7F) as u8;
+        v >>= 7;
+        if v == 0 {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+/// Encode `v` as a signed LEB128 integer into `buf`.
+pub fn leb128_s(buf: &mut Vec<u8>, mut v: i64) {
+    loop {
+        let byte = (v & 0x7F) as u8;
+        v >>= 7;
+        let done = (v == 0 && (byte & 0x40) == 0) || (v == -1 && (byte & 0x40) != 0);
+        if done {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+// ── wasm section ids ──────────────────────────────────────────────────────
+
+const SECTION_TYPE: u8 = 0x01;
+const SECTION_FUNCTION: u8 = 0x03;
+const SECTION_EXPORT: u8 = 0x07;
+const SECTION_CODE: u8 = 0x0A;
+
+// ── section serialization helper ──────────────────────────────────────────
+
+fn write_section(out: &mut Vec<u8>, id: u8, content: &[u8]) {
+    out.push(id);
+    leb128_u(out, content.len() as u64);
+    out.extend_from_slice(content);
+}
+
+// ── function body encoding ────────────────────────────────────────────────
+
+/// Encode one function body (locals + instructions + `end`).
+pub fn encode_function_body(wf: &WasmFunction) -> Vec<u8> {
+    let mut body: Vec<u8> = Vec::new();
+
+    // Local declarations: group contiguous same-type locals.
+    // Wasm local declarations are (count, valtype) pairs.
+    // We always declare all locals as i32 or i64 individually grouped.
+    let local_count = wf.local_types.len();
+    if local_count == 0 {
+        // Zero local declaration entries.
+        leb128_u(&mut body, 0);
+    } else {
+        // Group locals by valtype.
+        let mut groups: Vec<(u32, u8)> = Vec::new(); // (count, valtype)
+        for &vt in &wf.local_types {
+            if let Some(last) = groups.last_mut() {
+                if last.1 == vt {
+                    last.0 += 1;
+                    continue;
+                }
+            }
+            groups.push((1, vt));
+        }
+        leb128_u(&mut body, groups.len() as u64);
+        for (count, vt) in groups {
+            leb128_u(&mut body, count as u64);
+            body.push(vt);
+        }
+    }
+
+    // Instructions.
+    body.extend_from_slice(&wf.code);
+
+    // Function `end`.
+    body.push(0x0B);
+
+    // Wrap with length prefix.
+    let mut out = Vec::new();
+    leb128_u(&mut out, body.len() as u64);
+    out.extend_from_slice(&body);
+    out
+}
+
+// ── opcode emission ───────────────────────────────────────────────────────
+
+/// Emit a single wasm instruction into `code`.
+/// The instruction is described by `opcode` (from `MOpcode`) and an optional
+/// immediate operand.
+pub fn emit_opcode(code: &mut Vec<u8>, opcode: u32, imm: Option<i64>) {
+    // Opcodes in our range are always single-byte.
+    debug_assert!(opcode <= 0xFF, "multi-byte opcode not supported");
+    code.push(opcode as u8);
+    if let Some(v) = imm {
+        leb128_s(code, v);
+    }
+}
+
+/// Emit `local.get <idx>`.
+pub fn emit_local_get(code: &mut Vec<u8>, local_idx: u32) {
+    code.push(WASM_LOCAL_GET.0 as u8);
+    leb128_u(code, local_idx as u64);
+}
+
+/// Emit `local.set <idx>`.
+pub fn emit_local_set(code: &mut Vec<u8>, local_idx: u32) {
+    code.push(WASM_LOCAL_SET.0 as u8);
+    leb128_u(code, local_idx as u64);
+}
+
+/// Emit `i32.const <v>` or `i64.const <v>`.
+pub fn emit_const(code: &mut Vec<u8>, is_i64: bool, v: i64) {
+    if is_i64 {
+        code.push(WASM_I64_CONST.0 as u8);
+    } else {
+        code.push(WASM_I32_CONST.0 as u8);
+    }
+    leb128_s(code, v);
+}
+
+/// Emit `br <depth>`.
+pub fn emit_br(code: &mut Vec<u8>, depth: u32) {
+    code.push(WASM_BR.0 as u8);
+    leb128_u(code, depth as u64);
+}
+
+/// Emit `br_if <depth>`.
+pub fn emit_br_if(code: &mut Vec<u8>, depth: u32) {
+    code.push(WASM_BR_IF.0 as u8);
+    leb128_u(code, depth as u64);
+}
+
+/// Emit `block <blocktype>`.
+pub fn emit_block(code: &mut Vec<u8>) {
+    code.push(WASM_BLOCK.0 as u8);
+    code.push(BLOCKTYPE_VOID);
+}
+
+/// Emit `loop <blocktype>`.
+pub fn emit_loop(code: &mut Vec<u8>) {
+    code.push(WASM_LOOP.0 as u8);
+    code.push(BLOCKTYPE_VOID);
+}
+
+/// Emit `if <blocktype>`.
+pub fn emit_if(code: &mut Vec<u8>) {
+    code.push(WASM_IF.0 as u8);
+    code.push(BLOCKTYPE_VOID);
+}
+
+/// Emit `else`.
+pub fn emit_else(code: &mut Vec<u8>) {
+    code.push(WASM_ELSE.0 as u8);
+}
+
+/// Emit `end`.
+pub fn emit_end(code: &mut Vec<u8>) {
+    code.push(WASM_END.0 as u8);
+}
+
+/// Emit `return`.
+pub fn emit_return(code: &mut Vec<u8>) {
+    code.push(WASM_RETURN.0 as u8);
+}
+
+/// Emit `call <func_idx>`.
+pub fn emit_call(code: &mut Vec<u8>, func_idx: u32) {
+    code.push(WASM_CALL.0 as u8);
+    leb128_u(code, func_idx as u64);
+}
+
+// ── functype encoding ─────────────────────────────────────────────────────
+
+/// Encode a wasm `functype` into `buf`.
+///
+/// Format: `0x60` + param-count (LEB) + params... + result-count (LEB) + results...
+fn encode_functype(buf: &mut Vec<u8>, params: &[u8], results: &[u8]) {
+    buf.push(0x60); // functype marker
+    leb128_u(buf, params.len() as u64);
+    buf.extend_from_slice(params);
+    leb128_u(buf, results.len() as u64);
+    buf.extend_from_slice(results);
+}
+
+// ── full module assembly ──────────────────────────────────────────────────
+
+/// Assemble a complete wasm binary from the given `WasmFunction` list.
+///
+/// The functions are expected to come from `WasmBackend::lower_module`.
+/// Each function in the list that corresponds to a non-declaration IR
+/// function will be placed in the type/function/export/code sections.
+pub fn assemble_module(
+    ctx: &Context,
+    module: &Module,
+    wasm_functions: &[WasmFunction],
+) -> Vec<u8> {
+    // ── magic + version ───────────────────────────────────────────────────
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"\0asm");
+    out.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+
+    // ── build type section ────────────────────────────────────────────────
+    // Collect unique function signatures (deduplicated).
+    let mut type_entries: Vec<Vec<u8>> = Vec::new(); // encoded functype entries
+    let mut type_indices: Vec<u32> = Vec::new(); // per-function index into type_entries
+
+    for wf in wasm_functions {
+        // Build the functype bytes for this function.
+        let mut entry = Vec::new();
+        let ir_func = &module.functions[wf.func_idx];
+        let func_ty_data = ctx.get_type(ir_func.ty);
+        let (params, results) = if let TypeData::Function(ft) = func_ty_data {
+            let param_valtypes: Vec<u8> = ft
+                .params
+                .iter()
+                .filter_map(|&p| ir_ty_to_valtype(ctx, p))
+                .collect();
+            let result_valtypes: Vec<u8> = ir_ty_to_valtype(ctx, ft.ret)
+                .map(|v| vec![v])
+                .unwrap_or_default();
+            (param_valtypes, result_valtypes)
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        encode_functype(&mut entry, &params, &results);
+
+        // Deduplicate.
+        let idx = if let Some(pos) = type_entries.iter().position(|e| *e == entry) {
+            pos as u32
+        } else {
+            let pos = type_entries.len() as u32;
+            type_entries.push(entry);
+            pos
+        };
+        type_indices.push(idx);
+    }
+
+    // Encode type section.
+    if !type_entries.is_empty() {
+        let mut type_sec = Vec::new();
+        leb128_u(&mut type_sec, type_entries.len() as u64);
+        for entry in &type_entries {
+            type_sec.extend_from_slice(entry);
+        }
+        write_section(&mut out, SECTION_TYPE, &type_sec);
+    }
+
+    // ── import section (empty, required by spec order) ────────────────────
+    // Only write if non-empty; wasm binary format does not require it.
+
+    // ── function section ──────────────────────────────────────────────────
+    if !wasm_functions.is_empty() {
+        let mut func_sec = Vec::new();
+        leb128_u(&mut func_sec, wasm_functions.len() as u64);
+        for &ti in &type_indices {
+            leb128_u(&mut func_sec, ti as u64);
+        }
+        write_section(&mut out, SECTION_FUNCTION, &func_sec);
+    }
+
+    // ── export section ────────────────────────────────────────────────────
+    if !wasm_functions.is_empty() {
+        let mut exp_sec = Vec::new();
+        leb128_u(&mut exp_sec, wasm_functions.len() as u64);
+        for (func_wasm_idx, wf) in wasm_functions.iter().enumerate() {
+            let name_bytes = wf.name.as_bytes();
+            leb128_u(&mut exp_sec, name_bytes.len() as u64);
+            exp_sec.extend_from_slice(name_bytes);
+            exp_sec.push(0x00); // export kind: function
+            leb128_u(&mut exp_sec, func_wasm_idx as u64);
+        }
+        write_section(&mut out, SECTION_EXPORT, &exp_sec);
+    }
+
+    // ── code section ─────────────────────────────────────────────────────
+    if !wasm_functions.is_empty() {
+        let mut code_sec = Vec::new();
+        leb128_u(&mut code_sec, wasm_functions.len() as u64);
+        for wf in wasm_functions {
+            let body = encode_function_body(wf);
+            code_sec.extend_from_slice(&body);
+        }
+        write_section(&mut out, SECTION_CODE, &code_sec);
+    }
+
+    out
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leb128_u_single_byte() {
+        let mut buf = Vec::new();
+        leb128_u(&mut buf, 42);
+        assert_eq!(buf, &[42]);
+    }
+
+    #[test]
+    fn leb128_u_multibyte() {
+        let mut buf = Vec::new();
+        leb128_u(&mut buf, 300);
+        // 300 = 0x12C → LEB: 0xAC 0x02
+        assert_eq!(buf, &[0xAC, 0x02]);
+    }
+
+    #[test]
+    fn leb128_s_negative() {
+        let mut buf = Vec::new();
+        leb128_s(&mut buf, -1);
+        assert_eq!(buf, &[0x7F]);
+    }
+
+    #[test]
+    fn leb128_s_positive() {
+        let mut buf = Vec::new();
+        leb128_s(&mut buf, 42);
+        assert_eq!(buf, &[42]);
+    }
+}

--- a/src/llvm-target-wasm/src/instructions.rs
+++ b/src/llvm-target-wasm/src/instructions.rs
@@ -1,0 +1,170 @@
+//! WebAssembly opcode constants used as `MOpcode` values in machine IR.
+
+use llvm_codegen::isel::MOpcode;
+
+// ── control flow ──────────────────────────────────────────────────────────
+
+/// `unreachable` — trap immediately.
+pub const WASM_UNREACHABLE: MOpcode = MOpcode(0x00);
+/// `nop` — no operation.
+pub const WASM_NOP: MOpcode = MOpcode(0x01);
+/// `block` — begin a block construct (forward branch target).
+pub const WASM_BLOCK: MOpcode = MOpcode(0x02);
+/// `loop` — begin a loop construct (backward branch target).
+pub const WASM_LOOP: MOpcode = MOpcode(0x03);
+/// `if` — begin an if construct.
+pub const WASM_IF: MOpcode = MOpcode(0x04);
+/// `else` — begin else branch.
+pub const WASM_ELSE: MOpcode = MOpcode(0x05);
+/// `end` — end a block/loop/if/function.
+pub const WASM_END: MOpcode = MOpcode(0x0B);
+/// `br` — unconditional branch to label depth N.
+pub const WASM_BR: MOpcode = MOpcode(0x0C);
+/// `br_if` — conditional branch to label depth N.
+pub const WASM_BR_IF: MOpcode = MOpcode(0x0D);
+/// `return` — return from function.
+pub const WASM_RETURN: MOpcode = MOpcode(0x0F);
+/// `call` — call a function by index.
+pub const WASM_CALL: MOpcode = MOpcode(0x10);
+
+// ── local variable access ─────────────────────────────────────────────────
+
+/// `local.get` — push value of local N onto the stack.
+pub const WASM_LOCAL_GET: MOpcode = MOpcode(0x20);
+/// `local.set` — pop stack top into local N.
+pub const WASM_LOCAL_SET: MOpcode = MOpcode(0x21);
+
+// ── memory ────────────────────────────────────────────────────────────────
+
+/// `i32.load` — load 4 bytes from memory.
+pub const WASM_I32_LOAD: MOpcode = MOpcode(0x28);
+/// `i64.load` — load 8 bytes from memory.
+pub const WASM_I64_LOAD: MOpcode = MOpcode(0x29);
+/// `i32.store` — store 4 bytes to memory.
+pub const WASM_I32_STORE: MOpcode = MOpcode(0x36);
+/// `i64.store` — store 8 bytes to memory.
+pub const WASM_I64_STORE: MOpcode = MOpcode(0x37);
+
+// ── constants ─────────────────────────────────────────────────────────────
+
+/// `i32.const` — push a 32-bit integer constant.
+pub const WASM_I32_CONST: MOpcode = MOpcode(0x41);
+/// `i64.const` — push a 64-bit integer constant.
+pub const WASM_I64_CONST: MOpcode = MOpcode(0x42);
+
+// ── i32 comparisons ───────────────────────────────────────────────────────
+
+/// `i32.eqz`
+pub const WASM_I32_EQZ: MOpcode = MOpcode(0x45);
+/// `i32.eq`
+pub const WASM_I32_EQ: MOpcode = MOpcode(0x46);
+/// `i32.ne`
+pub const WASM_I32_NE: MOpcode = MOpcode(0x47);
+/// `i32.lt_s`
+pub const WASM_I32_LT_S: MOpcode = MOpcode(0x48);
+/// `i32.lt_u`
+pub const WASM_I32_LT_U: MOpcode = MOpcode(0x49);
+/// `i32.gt_s`
+pub const WASM_I32_GT_S: MOpcode = MOpcode(0x4A);
+/// `i32.gt_u`
+pub const WASM_I32_GT_U: MOpcode = MOpcode(0x4B);
+/// `i32.le_s`
+pub const WASM_I32_LE_S: MOpcode = MOpcode(0x4C);
+/// `i32.le_u`
+pub const WASM_I32_LE_U: MOpcode = MOpcode(0x4D);
+/// `i32.ge_s`
+pub const WASM_I32_GE_S: MOpcode = MOpcode(0x4E);
+/// `i32.ge_u`
+pub const WASM_I32_GE_U: MOpcode = MOpcode(0x4F);
+
+// ── i64 comparisons ───────────────────────────────────────────────────────
+
+/// `i64.eqz`
+pub const WASM_I64_EQZ: MOpcode = MOpcode(0x50);
+/// `i64.eq`
+pub const WASM_I64_EQ: MOpcode = MOpcode(0x51);
+/// `i64.ne`
+pub const WASM_I64_NE: MOpcode = MOpcode(0x52);
+/// `i64.lt_s`
+pub const WASM_I64_LT_S: MOpcode = MOpcode(0x53);
+/// `i64.lt_u`
+pub const WASM_I64_LT_U: MOpcode = MOpcode(0x54);
+/// `i64.gt_s`
+pub const WASM_I64_GT_S: MOpcode = MOpcode(0x55);
+/// `i64.gt_u`
+pub const WASM_I64_GT_U: MOpcode = MOpcode(0x56);
+/// `i64.le_s`
+pub const WASM_I64_LE_S: MOpcode = MOpcode(0x57);
+/// `i64.le_u`
+pub const WASM_I64_LE_U: MOpcode = MOpcode(0x58);
+/// `i64.ge_s`
+pub const WASM_I64_GE_S: MOpcode = MOpcode(0x59);
+/// `i64.ge_u`
+pub const WASM_I64_GE_U: MOpcode = MOpcode(0x5A);
+
+// ── i32 arithmetic ────────────────────────────────────────────────────────
+
+/// `i32.add`
+pub const WASM_I32_ADD: MOpcode = MOpcode(0x6A);
+/// `i32.sub`
+pub const WASM_I32_SUB: MOpcode = MOpcode(0x6B);
+/// `i32.mul`
+pub const WASM_I32_MUL: MOpcode = MOpcode(0x6C);
+/// `i32.div_s`
+pub const WASM_I32_DIV_S: MOpcode = MOpcode(0x6D);
+/// `i32.div_u`
+pub const WASM_I32_DIV_U: MOpcode = MOpcode(0x6E);
+/// `i32.rem_s`
+pub const WASM_I32_REM_S: MOpcode = MOpcode(0x6F);
+/// `i32.rem_u`
+pub const WASM_I32_REM_U: MOpcode = MOpcode(0x70);
+/// `i32.and`
+pub const WASM_I32_AND: MOpcode = MOpcode(0x71);
+/// `i32.or`
+pub const WASM_I32_OR: MOpcode = MOpcode(0x72);
+/// `i32.xor`
+pub const WASM_I32_XOR: MOpcode = MOpcode(0x73);
+/// `i32.shl`
+pub const WASM_I32_SHL: MOpcode = MOpcode(0x74);
+/// `i32.shr_s`
+pub const WASM_I32_SHR_S: MOpcode = MOpcode(0x75);
+/// `i32.shr_u`
+pub const WASM_I32_SHR_U: MOpcode = MOpcode(0x76);
+
+// ── i64 arithmetic ────────────────────────────────────────────────────────
+
+/// `i64.add`
+pub const WASM_I64_ADD: MOpcode = MOpcode(0x7C);
+/// `i64.sub`
+pub const WASM_I64_SUB: MOpcode = MOpcode(0x7D);
+/// `i64.mul`
+pub const WASM_I64_MUL: MOpcode = MOpcode(0x7E);
+/// `i64.div_s`
+pub const WASM_I64_DIV_S: MOpcode = MOpcode(0x7F);
+/// `i64.div_u`
+pub const WASM_I64_DIV_U: MOpcode = MOpcode(0x80);
+/// `i64.rem_s`
+pub const WASM_I64_REM_S: MOpcode = MOpcode(0x81);
+/// `i64.rem_u`
+pub const WASM_I64_REM_U: MOpcode = MOpcode(0x82);
+/// `i64.and`
+pub const WASM_I64_AND: MOpcode = MOpcode(0x83);
+/// `i64.or`
+pub const WASM_I64_OR: MOpcode = MOpcode(0x84);
+/// `i64.xor`
+pub const WASM_I64_XOR: MOpcode = MOpcode(0x85);
+/// `i64.shl`
+pub const WASM_I64_SHL: MOpcode = MOpcode(0x86);
+/// `i64.shr_s`
+pub const WASM_I64_SHR_S: MOpcode = MOpcode(0x87);
+/// `i64.shr_u`
+pub const WASM_I64_SHR_U: MOpcode = MOpcode(0x88);
+
+// ── conversion ────────────────────────────────────────────────────────────
+
+/// `i32.wrap_i64` — truncate i64 → i32.
+pub const WASM_I32_WRAP_I64: MOpcode = MOpcode(0xA7);
+/// `i64.extend_i32_s` — sign-extend i32 → i64.
+pub const WASM_I64_EXTEND_I32_S: MOpcode = MOpcode(0xAC);
+/// `i64.extend_i32_u` — zero-extend i32 → i64.
+pub const WASM_I64_EXTEND_I32_U: MOpcode = MOpcode(0xAD);

--- a/src/llvm-target-wasm/src/lib.rs
+++ b/src/llvm-target-wasm/src/lib.rs
@@ -1,0 +1,181 @@
+//! WebAssembly (wasm32) target backend for LLVM-in-Rust.
+//!
+//! # Strategy
+//!
+//! This backend uses the **"all-locals"** strategy: every SSA value (function
+//! argument or instruction result) is mapped to a wasm `local` variable.
+//! Assignments are `local.set`, uses are `local.get`.  This entirely avoids
+//! the register allocator and produces valid (if unoptimised) wasm.
+//!
+//! Structured control flow is handled with a simple "wrapping" approach:
+//! each basic block gets a wasm `block` construct so that forward branches
+//! can be expressed as `br N`.  Back-edges (loop headers) get an additional
+//! `loop` wrapper.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use llvm_target_wasm::compile_to_wasm;
+//! let bytes = compile_to_wasm("define i32 @f() { entry: ret i32 0 }").unwrap();
+//! assert_eq!(&bytes[..4], b"\0asm");
+//! ```
+
+pub mod encode;
+pub mod instructions;
+pub mod lower;
+pub mod types;
+
+pub use lower::WasmBackend;
+
+use llvm_ir::{Context, Module};
+use lower::WasmFunction;
+
+/// Assemble a complete WebAssembly binary from the given `WasmFunction` list
+/// and the IR context/module (needed for type-section construction).
+pub fn assemble_module(
+    ctx: &Context,
+    module: &Module,
+    wasm_functions: &[WasmFunction],
+) -> Vec<u8> {
+    encode::assemble_module(ctx, module, wasm_functions)
+}
+
+/// Parse `ir`, run optimisations, lower to wasm and return the binary.
+///
+/// # Errors
+/// Returns a human-readable error string on parse or compile failure.
+pub fn compile_to_wasm(ir: &str) -> Result<Vec<u8>, String> {
+    use llvm_ir_parser::parser::parse;
+    use llvm_transforms::{build_pipeline, OptLevel};
+
+    let (mut ctx, mut module) = parse(ir).map_err(|e| format!("parse error: {e}"))?;
+
+    let mut pm = build_pipeline(OptLevel::O2);
+    pm.run_until_fixed_point(&mut ctx, &mut module, 8);
+
+    let mut backend = WasmBackend::new();
+    let wasm_fns = backend.lower_module(&ctx, &module);
+
+    Ok(assemble_module(&ctx, &module, &wasm_fns))
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper to find a byte sequence within a byte slice.
+    fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    // Helper to find a string in a byte slice.
+    fn contains_str(haystack: &[u8], s: &str) -> bool {
+        contains_bytes(haystack, s.as_bytes())
+    }
+
+    #[test]
+    fn wasm_magic_bytes() {
+        let bytes =
+            compile_to_wasm("define i32 @f() { entry: ret i32 0 }").expect("compile failed");
+        assert_eq!(&bytes[..4], b"\0asm", "first 4 bytes must be wasm magic");
+    }
+
+    #[test]
+    fn wasm_version() {
+        let bytes =
+            compile_to_wasm("define i32 @f() { entry: ret i32 0 }").expect("compile failed");
+        assert_eq!(
+            &bytes[4..8],
+            &[0x01, 0x00, 0x00, 0x00],
+            "bytes 4-7 must be wasm version 1"
+        );
+    }
+
+    #[test]
+    fn wasm_return_const() {
+        let bytes = compile_to_wasm("define i32 @g() { entry: ret i32 42 }").expect("compile");
+        // Must contain i32.const (0x41) somewhere in the code.
+        assert!(
+            bytes.contains(&0x41),
+            "binary must contain i32.const (0x41)"
+        );
+        // 42 in LEB128 is just 0x2A.
+        assert!(bytes.contains(&0x2A), "binary must contain LEB128 of 42 (0x2A)");
+    }
+
+    #[test]
+    fn wasm_add_two_ints() {
+        let ir = "define i32 @add(i32 %a, i32 %b) {\nentry:\n  %r = add i32 %a, %b\n  ret i32 %r\n}";
+        let bytes = compile_to_wasm(ir).expect("compile");
+        // Must contain i32.add (0x6A).
+        assert!(
+            bytes.contains(&0x6A),
+            "binary must contain i32.add (0x6A)"
+        );
+    }
+
+    #[test]
+    fn wasm_export_name() {
+        let ir = "define i32 @my_func() {\nentry:\n  ret i32 0\n}";
+        let bytes = compile_to_wasm(ir).expect("compile");
+        assert!(
+            contains_str(&bytes, "my_func"),
+            "binary must contain export name \"my_func\""
+        );
+    }
+
+    #[test]
+    fn wasm_multi_function() {
+        let ir = concat!(
+            "define i32 @foo() { entry: ret i32 1 }\n",
+            "define i32 @bar() { entry: ret i32 2 }\n"
+        );
+        let bytes = compile_to_wasm(ir).expect("compile");
+        assert!(contains_str(&bytes, "foo"), "binary must contain \"foo\"");
+        assert!(contains_str(&bytes, "bar"), "binary must contain \"bar\"");
+    }
+
+    #[test]
+    fn wasm_conditional_branch() {
+        let ir = concat!(
+            "define i32 @cond(i32 %x) {\n",
+            "entry:\n",
+            "  %c = icmp eq i32 %x, 0\n",
+            "  br i1 %c, label %then, label %else\n",
+            "then:\n",
+            "  ret i32 1\n",
+            "else:\n",
+            "  ret i32 2\n",
+            "}\n"
+        );
+        let bytes = compile_to_wasm(ir).expect("compile");
+        // Must contain `if` (0x04) or `br_if` (0x0D).
+        let has_if = bytes.contains(&0x04);
+        let has_br_if = bytes.contains(&0x0D);
+        assert!(
+            has_if || has_br_if,
+            "conditional branch binary must contain if (0x04) or br_if (0x0D)"
+        );
+    }
+
+    #[test]
+    fn wasm_declarations_excluded() {
+        let ir = "declare i32 @ext()\n";
+        let bytes = compile_to_wasm(ir).expect("compile");
+        // Must have valid magic+version.
+        assert_eq!(&bytes[..4], b"\0asm");
+        assert_eq!(&bytes[4..8], &[0x01, 0x00, 0x00, 0x00]);
+        // Should NOT contain "ext" as an export (declaration is not defined).
+        // The binary may be just magic+version with no sections.
+        // Check that there's no code section entry: code section id is 0x0A.
+        // If present, it would have count > 0.  For a declaration-only module,
+        // there should be no non-declaration functions, so wasm_fns is empty
+        // and no code/function/export sections are emitted.
+        assert!(
+            !contains_str(&bytes, "ext"),
+            "declaration @ext must not appear as an export"
+        );
+    }
+}

--- a/src/llvm-target-wasm/src/lower.rs
+++ b/src/llvm-target-wasm/src/lower.rs
@@ -1,0 +1,850 @@
+//! LLVM IR → WebAssembly lowering.
+//!
+//! Uses the "all-locals" strategy: every SSA value becomes a wasm `local`.
+//! Arguments occupy the first N locals (indices 0..N).  Instruction results
+//! are assigned the next locals.  A simple block-order traversal emits wasm
+//! instructions directly; structured control flow is produced by wrapping
+//! basic blocks in `block`/`loop` constructs.
+
+use crate::encode::{
+    emit_block, emit_br, emit_br_if, emit_call, emit_const, emit_end, emit_if, emit_local_get,
+    emit_local_set, emit_loop, emit_return, leb128_u,
+};
+use crate::instructions::*;
+use crate::types::{ir_ty_to_valtype, is_i64_type, VALTYPE_I32};
+use llvm_codegen::isel::{IselBackend, MachineFunction, MOpcode};
+use llvm_ir::{
+    ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
+    TypeData, TypeId, ValueRef,
+};
+use std::collections::HashMap;
+
+// ── wasm-specific function representation ─────────────────────────────────
+
+/// A fully lowered wasm function, ready for binary encoding.
+pub struct WasmFunction {
+    /// Function name (for export section).
+    pub name: String,
+    /// Index into `module.functions` (for type-section construction).
+    pub func_idx: usize,
+    /// Wasm local types in declaration order.
+    /// Arguments occupy indices 0..(n_args-1); instruction results follow.
+    pub local_types: Vec<u8>,
+    /// Raw wasm instruction bytes (without the final `end`).
+    pub code: Vec<u8>,
+}
+
+// ── wasm backend ──────────────────────────────────────────────────────────
+
+/// WebAssembly instruction-selection backend.
+///
+/// Implements [`IselBackend`] so the backend can be used through the
+/// standard pipeline, but the [`MachineFunction`] it returns is a
+/// stub — actual wasm code lives in [`WasmFunction`] produced by
+/// [`WasmBackend::lower_module`].
+pub struct WasmBackend;
+
+impl WasmBackend {
+    /// Create a new `WasmBackend`.
+    pub fn new() -> Self {
+        WasmBackend
+    }
+
+    /// Lower all non-declaration functions in `module` to [`WasmFunction`]s.
+    pub fn lower_module(
+        &mut self,
+        ctx: &Context,
+        module: &Module,
+    ) -> Vec<WasmFunction> {
+        module
+            .functions
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| !f.is_declaration)
+            .map(|(i, f)| lower_function_to_wasm(ctx, module, f, i))
+            .collect()
+    }
+}
+
+impl Default for WasmBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// The `IselBackend` trait impl is a thin shim that returns a stub
+// `MachineFunction`.  Callers that want the actual wasm bytes should use
+// `lower_module` + `encode::assemble_module`.
+impl IselBackend for WasmBackend {
+    fn lower_function(
+        &mut self,
+        _ctx: &Context,
+        _module: &Module,
+        func: &Function,
+    ) -> MachineFunction {
+        // Return an empty `MachineFunction` as a stub — wasm doesn't use the
+        // register-allocator pipeline.
+        let mf = MachineFunction::new(func.name.clone());
+        mf
+    }
+}
+
+// ── per-function lowering ─────────────────────────────────────────────────
+
+/// Lower a single IR function to a [`WasmFunction`].
+fn lower_function_to_wasm(
+    ctx: &Context,
+    module: &Module,
+    func: &Function,
+    func_idx: usize,
+) -> WasmFunction {
+    let mut local_types: Vec<u8> = Vec::new();
+    let mut vmap: HashMap<ValueRef, u32> = HashMap::new(); // ValueRef → local index
+    let mut code: Vec<u8> = Vec::new();
+
+    // ── assign locals for function arguments ──────────────────────────────
+    // Arguments are declared as locals 0..n_args in the wasm function.
+    // In the wasm binary format, function parameters ARE the first locals —
+    // they do not appear in the local declaration section.  We track their
+    // indices in vmap but do not emit them in `local_types`.
+    let n_args = func.args.len();
+    for i in 0..n_args {
+        let vt = ir_ty_to_valtype(ctx, func.ty)
+            .unwrap_or(VALTYPE_I32); // fallback (won't be used for void)
+        // Use the actual argument type from the function type.
+        let arg_vt = if let TypeData::Function(ft) = ctx.get_type(func.ty) {
+            ft.params
+                .get(i)
+                .and_then(|&p| ir_ty_to_valtype(ctx, p))
+                .unwrap_or(VALTYPE_I32)
+        } else {
+            vt
+        };
+        let _ = arg_vt; // arg locals are implicit (params); not in local_types
+        vmap.insert(ValueRef::Argument(ArgId(i as u32)), i as u32);
+    }
+
+    // Next local index starts after the args.
+    let mut next_local: u32 = n_args as u32;
+
+    // ── first pass: assign local indices for all instruction results ───────
+    for bb in &func.blocks {
+        for &iid in &bb.body {
+            let instr = func.instr(iid);
+            // Only value-producing instructions get a local.
+            if !is_void_type(ctx, instr.ty) {
+                let vt = ir_ty_to_valtype(ctx, instr.ty).unwrap_or(VALTYPE_I32);
+                vmap.insert(ValueRef::Instruction(iid), next_local);
+                local_types.push(vt);
+                next_local += 1;
+            }
+        }
+    }
+
+    // ── build a block-index map: BlockId → index in func.blocks ──────────
+    let block_index: HashMap<BlockId, usize> = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(i, _bb)| (BlockId(i as u32), i))
+        .collect();
+
+    // ── determine which blocks are loop headers (have a back-edge) ─────────
+    // A back-edge is a branch to a block that comes earlier in the linear order.
+    let mut is_loop_header: Vec<bool> = vec![false; func.blocks.len()];
+    for (i, bb) in func.blocks.iter().enumerate() {
+        if let Some(tid) = bb.terminator {
+            match &func.instr(tid).kind {
+                InstrKind::Br { dest } => {
+                    let j = block_index[dest];
+                    if j <= i {
+                        is_loop_header[j] = true;
+                    }
+                }
+                InstrKind::CondBr { then_dest, else_dest, .. } => {
+                    for dest in [then_dest, else_dest] {
+                        let j = block_index[dest];
+                        if j <= i {
+                            is_loop_header[j] = true;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // ── second pass: emit code per basic block ─────────────────────────────
+    // Strategy:
+    //   - Each block is wrapped in a `block` construct (depth = 1 while inside).
+    //   - Loop headers are additionally wrapped in a `loop` construct.
+    //   - `br 0` exits the current `block` (branches forward to next block's code).
+    //   - `br_if` + `block` implements conditional branches.
+    //   - Back-edges branch to the enclosing `loop` construct.
+    //
+    // For simplicity we use the "wrapping" approach:
+    //   - All blocks are wrapped in one large outer `block` for the function.
+    //   - Each individual block gets its own `block` wrapper.
+    //   - Forward branches are `br N` where N is the number of blocks remaining.
+    //
+    // For now we implement a simpler direct emission:
+    //   - emit all blocks sequentially
+    //   - handle Ret, Br (unconditional), CondBr (using br_if+block)
+    //   - loop back-edges: wrap in `loop`
+    //   - forward jumps: wrap destination handling in a block
+
+    // We use a simple approach: all n blocks are wrapped in n nested `block`
+    // constructs.  Block i is at nesting depth (n - i) inside the outer wrapper.
+    // To jump to block j from block i:
+    //   - if j > i (forward): br (j - i - 1) from inside block i's own `block`
+    //   - if j <= i (back-edge): impossible to express with this scheme alone;
+    //     use a `loop` wrapper for the loop header.
+    //
+    // Revised "stackify" approach used here:
+    // - Emit one outer `block` for each forward branch target.
+    // - For loops: emit a `loop` around the loop body.
+    // - This is simplified — for very complex CFGs some terminators may emit
+    //   `unreachable`.  TODO: implement full Relooper for arbitrary CFGs.
+
+    emit_code_for_function(
+        ctx,
+        func,
+        &vmap,
+        &block_index,
+        &is_loop_header,
+        &mut code,
+        module,
+    );
+
+    WasmFunction {
+        name: func.name.clone(),
+        func_idx,
+        local_types,
+        code,
+    }
+}
+
+// ── function code emission ────────────────────────────────────────────────
+
+fn emit_code_for_function(
+    ctx: &Context,
+    func: &Function,
+    vmap: &HashMap<ValueRef, u32>,
+    block_index: &HashMap<BlockId, usize>,
+    is_loop_header: &[bool],
+    code: &mut Vec<u8>,
+    module: &Module,
+) {
+    let n = func.blocks.len();
+    if n == 0 {
+        return;
+    }
+
+    // Collect function indices for call resolution.
+    // Map function name → wasm function index among non-declarations.
+    // We approximate: use module.functions index directly as a proxy.
+    let func_idx_map: HashMap<&str, u32> = module
+        .functions
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| !f.is_declaration)
+        .enumerate()
+        .map(|(wasm_idx, (_, f))| (f.name.as_str(), wasm_idx as u32))
+        .collect();
+
+    // Wrap all blocks in a chain of `block` constructs so that
+    // `br N` can jump to block at position (current + N + 1).
+    // The outermost block corresponds to block 0.
+    //
+    // Layout:
+    //   block  ; block n-1 (outermost)
+    //     block  ; block n-2
+    //       ...
+    //         block  ; block 0 (innermost)
+    //           <code for block 0>
+    //         end  ; exits block 0, continues to block 1's wrapper
+    //         <code for block 1>
+    //       end
+    //       <code for block 2>
+    //       ...
+    //   end
+    //
+    // To branch from block i to block j (j > i), we need to break out of
+    // (j - i) block constructs, so `br (j - i - 1)`.
+    //
+    // For loop back-edges (j <= i), we wrap the loop header in a `loop`
+    // construct one level inside its `block`.
+
+    // Emit n-1 nested `block` wrappers.
+    for _ in 0..(n - 1) {
+        emit_block(code);
+    }
+
+    for (i, bb) in func.blocks.iter().enumerate() {
+        // If this block is a loop header, wrap it in a `loop`.
+        if is_loop_header[i] {
+            emit_loop(code);
+        }
+
+        // Emit all non-terminator instructions.
+        for &iid in &bb.body {
+            emit_instr(ctx, func, vmap, code, iid, &func_idx_map);
+        }
+
+        // Emit the terminator.
+        if let Some(tid) = bb.terminator {
+            emit_terminator(
+                ctx,
+                func,
+                vmap,
+                block_index,
+                is_loop_header,
+                code,
+                tid,
+                i,
+                n,
+                &func_idx_map,
+            );
+        }
+
+        // Close loop wrapper if this block is a loop header.
+        if is_loop_header[i] {
+            emit_end(code);
+        }
+
+        // Close this block's wrapper (if not the last block).
+        if i < n - 1 {
+            emit_end(code);
+        }
+    }
+
+    // Close all remaining wrappers.
+    // (We opened n-1 blocks; the loop end above closed some, but the inner
+    //  block wrappers for non-last blocks were also closed above.  The
+    //  remaining unclosed wrapper is the outermost one for block n-2.)
+    // Actually with the layout above we open n-1 blocks at the top and close
+    // them one-by-one as we finish each non-last block.  But we need to also
+    // close the LAST block's wrapper — there isn't one since we didn't open
+    // one for the last block.  So no extra `end` needed here.
+}
+
+// ── instruction emission ──────────────────────────────────────────────────
+
+fn resolve_vmap(vmap: &HashMap<ValueRef, u32>, vr: ValueRef) -> u32 {
+    vmap.get(&vr).copied().unwrap_or(0)
+}
+
+fn emit_value(
+    ctx: &Context,
+    vmap: &HashMap<ValueRef, u32>,
+    code: &mut Vec<u8>,
+    vr: ValueRef,
+    use_i64: bool,
+) {
+    match vr {
+        ValueRef::Constant(cid) => {
+            let imm = match ctx.get_const(cid) {
+                ConstantData::Int { val, .. } => *val as i64,
+                ConstantData::Float { bits, .. } => *bits as i64,
+                ConstantData::Null(_) | ConstantData::ZeroInitializer(_) => 0,
+                ConstantData::Undef(_) | ConstantData::Poison(_) => 0,
+                _ => 0,
+            };
+            emit_const(code, use_i64, imm);
+        }
+        _ => {
+            let local_idx = resolve_vmap(vmap, vr);
+            emit_local_get(code, local_idx);
+        }
+    }
+}
+
+/// Emit wasm instructions for one IR instruction.
+fn emit_instr(
+    ctx: &Context,
+    func: &Function,
+    vmap: &HashMap<ValueRef, u32>,
+    code: &mut Vec<u8>,
+    iid: InstrId,
+    func_idx_map: &HashMap<&str, u32>,
+) {
+    let instr = func.instr(iid);
+    let is64 = is_i64_type(ctx, instr.ty);
+    let dst_local = vmap.get(&ValueRef::Instruction(iid)).copied();
+
+    // Helper: emit LHS and RHS then a binary opcode, then store result.
+    macro_rules! binop {
+        ($op:expr, $lhs:expr, $rhs:expr) => {{
+            emit_value(ctx, vmap, code, *$lhs, is64);
+            emit_value(ctx, vmap, code, *$rhs, is64);
+            code.push($op.0 as u8);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }};
+    }
+
+    use InstrKind::*;
+    match &instr.kind {
+        // ── arithmetic ────────────────────────────────────────────────────
+        Add { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_ADD } else { WASM_I32_ADD }, lhs, rhs);
+        }
+        Sub { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_SUB } else { WASM_I32_SUB }, lhs, rhs);
+        }
+        Mul { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_MUL } else { WASM_I32_MUL }, lhs, rhs);
+        }
+        SDiv { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_DIV_S } else { WASM_I32_DIV_S }, lhs, rhs);
+        }
+        UDiv { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_DIV_U } else { WASM_I32_DIV_U }, lhs, rhs);
+        }
+        SRem { lhs, rhs } => {
+            binop!(if is64 { WASM_I64_REM_S } else { WASM_I32_REM_S }, lhs, rhs);
+        }
+        URem { lhs, rhs } => {
+            binop!(if is64 { WASM_I64_REM_U } else { WASM_I32_REM_U }, lhs, rhs);
+        }
+        And { lhs, rhs } => {
+            binop!(if is64 { WASM_I64_AND } else { WASM_I32_AND }, lhs, rhs);
+        }
+        Or { lhs, rhs } => {
+            binop!(if is64 { WASM_I64_OR } else { WASM_I32_OR }, lhs, rhs);
+        }
+        Xor { lhs, rhs } => {
+            binop!(if is64 { WASM_I64_XOR } else { WASM_I32_XOR }, lhs, rhs);
+        }
+        Shl { lhs, rhs, .. } => {
+            binop!(if is64 { WASM_I64_SHL } else { WASM_I32_SHL }, lhs, rhs);
+        }
+        LShr { lhs, rhs, .. } => {
+            binop!(
+                if is64 { WASM_I64_SHR_U } else { WASM_I32_SHR_U },
+                lhs,
+                rhs
+            );
+        }
+        AShr { lhs, rhs, .. } => {
+            binop!(
+                if is64 { WASM_I64_SHR_S } else { WASM_I32_SHR_S },
+                lhs,
+                rhs
+            );
+        }
+
+        // ── comparisons ───────────────────────────────────────────────────
+        ICmp { pred, lhs, rhs } => {
+            // Result is always i32 (bool) in wasm.
+            let lhs_is64 = match *lhs {
+                ValueRef::Constant(_) => {
+                    // Default to i32 for constant operands.
+                    false
+                }
+                ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                ValueRef::Argument(aid) => {
+                    if let TypeData::Function(ft) = ctx.get_type(func.ty) {
+                        ft.params
+                            .get(aid.0 as usize)
+                            .map(|&p| is_i64_type(ctx, p))
+                            .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            };
+            emit_value(ctx, vmap, code, *lhs, lhs_is64);
+            emit_value(ctx, vmap, code, *rhs, lhs_is64);
+            let op = icmp_opcode(*pred, lhs_is64);
+            code.push(op.0 as u8);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── casts ─────────────────────────────────────────────────────────
+        Trunc { val, .. } => {
+            // i64 → i32
+            let src_is64 = match *val {
+                ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                ValueRef::Argument(aid) => {
+                    if let TypeData::Function(ft) = ctx.get_type(func.ty) {
+                        ft.params
+                            .get(aid.0 as usize)
+                            .map(|&p| is_i64_type(ctx, p))
+                            .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                }
+                ValueRef::Constant(_) => false,
+                _ => false,
+            };
+            emit_value(ctx, vmap, code, *val, src_is64);
+            if src_is64 && !is64 {
+                code.push(WASM_I32_WRAP_I64.0 as u8);
+            }
+            // Otherwise nop (same width or smaller, wasm handles implicitly).
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+        ZExt { val, .. } | SExt { val, .. } => {
+            let src_is64 = match *val {
+                ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                ValueRef::Constant(_) => false,
+                _ => false,
+            };
+            emit_value(ctx, vmap, code, *val, src_is64);
+            if !src_is64 && is64 {
+                // zero-extend: i64.extend_i32_u; sign-extend: i64.extend_i32_s
+                if matches!(instr.kind, SExt { .. }) {
+                    code.push(WASM_I64_EXTEND_I32_S.0 as u8);
+                } else {
+                    code.push(WASM_I64_EXTEND_I32_U.0 as u8);
+                }
+            }
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── select ────────────────────────────────────────────────────────
+        Select { cond, then_val, else_val } => {
+            // Wasm doesn't have a direct select for arbitrary nesting here;
+            // we use if/else.
+            emit_value(ctx, vmap, code, *cond, false);
+            emit_if(code);
+            emit_value(ctx, vmap, code, *then_val, is64);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+            // else branch
+            code.push(0x05); // `else`
+            emit_value(ctx, vmap, code, *else_val, is64);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+            emit_end(code);
+        }
+
+        // ── memory ────────────────────────────────────────────────────────
+        Load { ptr, .. } => {
+            emit_value(ctx, vmap, code, *ptr, false); // ptr is i32 (wasm32)
+            let op = if is64 { WASM_I64_LOAD } else { WASM_I32_LOAD };
+            code.push(op.0 as u8);
+            // alignment and offset (memarg): align=2 (4-byte), offset=0
+            leb128_u(code, 2); // alignment hint (log2)
+            leb128_u(code, 0); // memory offset
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+        Store { val, ptr, .. } => {
+            emit_value(ctx, vmap, code, *ptr, false);
+            let store_is64 = match *val {
+                ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                ValueRef::Constant(_) => false,
+                _ => false,
+            };
+            emit_value(ctx, vmap, code, *val, store_is64);
+            let op = if store_is64 { WASM_I64_STORE } else { WASM_I32_STORE };
+            code.push(op.0 as u8);
+            leb128_u(code, 2); // alignment hint
+            leb128_u(code, 0); // memory offset
+            // Store is void — no local.set
+        }
+
+        // ── alloca (stub — wasm32 linear memory model) ───────────────────
+        Alloca { .. } => {
+            // Alloca is not directly supported in wasm; emit 0 as a placeholder
+            // address.  TODO: implement stack frame allocation via a global SP.
+            emit_const(code, false, 0);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── GEP (stub) ────────────────────────────────────────────────────
+        GetElementPtr { ptr, indices, .. } => {
+            // Simplified: emit ptr + (first_index * 4) as i32.
+            emit_value(ctx, vmap, code, *ptr, false);
+            if let Some(&idx) = indices.first() {
+                emit_value(ctx, vmap, code, idx, false);
+                emit_const(code, false, 4); // element size hint
+                code.push(WASM_I32_MUL.0 as u8);
+                code.push(WASM_I32_ADD.0 as u8);
+            }
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── phi (handled at block entry via predecessors — stub) ──────────
+        Phi { .. } => {
+            // Phi values are resolved by the predecessor block's branch.
+            // For our simple lowering: emit a `local.get 0` as placeholder —
+            // the local was already set by the incoming edge code.
+            // TODO: implement proper phi-destruction for loops.
+            if let Some(d) = dst_local {
+                emit_const(code, is64, 0);
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── call ──────────────────────────────────────────────────────────
+        Call { callee, args, .. } => {
+            // Resolve callee name.
+            let callee_name = match callee {
+                ValueRef::Constant(cid) => match ctx.get_const(*cid) {
+                    ConstantData::GlobalRef { name, .. } => Some(name.as_str()),
+                    _ => None,
+                },
+                ValueRef::Global(_) => {
+                    // Try to find by function index.
+                    None
+                }
+                _ => None,
+            };
+
+            let wasm_fn_idx = callee_name.and_then(|n| func_idx_map.get(n).copied());
+
+            if let Some(fi) = wasm_fn_idx {
+                // Push args onto the stack.
+                for &arg in args {
+                    let arg_is64 = match arg {
+                        ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                        _ => false,
+                    };
+                    emit_value(ctx, vmap, code, arg, arg_is64);
+                }
+                emit_call(code, fi);
+                // If the call has a result, store it.
+                if let Some(d) = dst_local {
+                    emit_local_set(code, d);
+                }
+            } else {
+                // Unknown callee — emit unreachable.
+                // TODO: handle indirect calls and external functions via imports.
+                code.push(WASM_UNREACHABLE.0 as u8);
+                if let Some(d) = dst_local {
+                    emit_const(code, is64, 0);
+                    emit_local_set(code, d);
+                }
+            }
+        }
+
+        // ── bitcast / ptrtoint / inttoptr / addrspacecast ─────────────────
+        BitCast { val, .. }
+        | PtrToInt { val, .. }
+        | IntToPtr { val, .. }
+        | AddrSpaceCast { val, .. }
+        | Freeze { val } => {
+            let src_is64 = match *val {
+                ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                _ => false,
+            };
+            emit_value(ctx, vmap, code, *val, src_is64);
+            if let Some(d) = dst_local {
+                emit_local_set(code, d);
+            }
+        }
+
+        // ── no-ops for unsupported instructions ───────────────────────────
+        _ => {
+            // Unsupported: push a zero constant for the result if any.
+            // TODO: Add support for FP, vectors, atomics, etc.
+            if let Some(d) = dst_local {
+                emit_const(code, is64, 0);
+                emit_local_set(code, d);
+            }
+        }
+    }
+}
+
+// ── terminator emission ───────────────────────────────────────────────────
+
+fn emit_terminator(
+    ctx: &Context,
+    func: &Function,
+    vmap: &HashMap<ValueRef, u32>,
+    block_index: &HashMap<BlockId, usize>,
+    _is_loop_header: &[bool],
+    code: &mut Vec<u8>,
+    tid: InstrId,
+    current_block: usize,
+    _total_blocks: usize,
+    _func_idx_map: &HashMap<&str, u32>,
+) {
+    let instr = func.instr(tid);
+    use InstrKind::*;
+    match &instr.kind {
+        Ret { val } => {
+            if let Some(v) = val {
+                let is64 = match *v {
+                    ValueRef::Instruction(iid2) => is_i64_type(ctx, func.instr(iid2).ty),
+                    ValueRef::Constant(_) => {
+                        // Check the function return type.
+                        if let TypeData::Function(ft) = ctx.get_type(func.ty) {
+                            is_i64_type(ctx, ft.ret)
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                };
+                emit_value(ctx, vmap, code, *v, is64);
+            }
+            emit_return(code);
+        }
+
+        Br { dest } => {
+            let target = block_index[dest];
+            if target <= current_block {
+                // Back-edge: branch to the loop construct.
+                // The loop is at depth 1 inside this block's `block` wrapper.
+                // If the current block is itself a loop header, the loop is depth 0.
+                // For simplicity: `br 0` to the innermost loop.
+                // This works when there is only one loop level.
+                code.push(WASM_BR.0 as u8);
+                // Depth: need to escape the current block's `block` wrapper (depth 1)
+                // to reach the loop construct (depth 0 inside the loop wrapper).
+                // With our layout: br 0 exits to the loop construct.
+                let_leb128_u(code, 0u64);
+            } else {
+                // Forward branch.
+                // We need to exit (target - current_block) `block` constructs
+                // to land just before block `target`'s code.
+                // Each block from current+1 to target-1 has been wrapped in a block;
+                // exiting them all puts us at block `target`.
+                // br depth = (target - current_block - 1) exits the right number.
+                let depth = target - current_block - 1;
+                emit_br(code, depth as u32);
+            }
+        }
+
+        CondBr { cond, then_dest, else_dest } => {
+            let then_target = block_index[then_dest];
+            let else_target = block_index[else_dest];
+
+            // Push condition.
+            emit_value(ctx, vmap, code, *cond, false);
+
+            if then_target == current_block + 1 && else_target > current_block + 1 {
+                // then falls through, else branches forward.
+                // Use `br_if 0` to skip over the else-branch block.
+                // Actually: push cond, br_if to then_target means "if true, branch".
+                // We want "if false, skip to else".
+                // Simplest: negate cond with i32.eqz, then br_if to else.
+                code.push(WASM_I32_EQZ.0 as u8);
+                let depth = else_target - current_block - 1;
+                emit_br_if(code, depth as u32);
+                // Fall through to then_target (next block).
+            } else if else_target == current_block + 1 && then_target > current_block + 1 {
+                // else falls through, then branches forward.
+                let depth = then_target - current_block - 1;
+                emit_br_if(code, depth as u32);
+                // Fall through to else_target (next block).
+            } else {
+                // Both branch forward or back. Use if/else construct.
+                // Push the condition (already pushed above).
+                emit_if(code);
+                // then branch
+                if then_target == current_block + 1 {
+                    // fall through — nothing to emit for unconditional fallthrough
+                } else if then_target <= current_block {
+                    code.push(WASM_BR.0 as u8);
+                    let_leb128_u(code, 0u64);
+                } else {
+                    let depth = then_target - current_block - 1;
+                    emit_br(code, depth as u32);
+                }
+                // else branch
+                code.push(0x05); // `else`
+                if else_target == current_block + 1 {
+                    // fall through
+                } else if else_target <= current_block {
+                    code.push(WASM_BR.0 as u8);
+                    let_leb128_u(code, 0u64);
+                } else {
+                    let depth = else_target - current_block - 1;
+                    emit_br(code, depth as u32);
+                }
+                emit_end(code);
+            }
+        }
+
+        Switch { val, default, cases } => {
+            // TODO: implement switch via br_table.  For now: unconditional branch to default.
+            let _ = (val, cases);
+            let target = block_index[default];
+            if target <= current_block {
+                code.push(WASM_BR.0 as u8);
+                let_leb128_u(code, 0u64);
+            } else {
+                let depth = target - current_block - 1;
+                emit_br(code, depth as u32);
+            }
+        }
+
+        Unreachable => {
+            code.push(WASM_UNREACHABLE.0 as u8);
+        }
+
+        // Ret/terminators handled above; fallthrough is safe.
+        _ => {
+            // Unexpected: emit unreachable.
+            code.push(WASM_UNREACHABLE.0 as u8);
+        }
+    }
+}
+
+// Helper to write a LEB128 u64 without creating a temporary Vec.
+#[inline(always)]
+fn let_leb128_u(code: &mut Vec<u8>, v: u64) {
+    leb128_u(code, v);
+}
+
+// ── icmp predicate → wasm opcode ─────────────────────────────────────────
+
+fn icmp_opcode(pred: IntPredicate, is64: bool) -> MOpcode {
+    if is64 {
+        match pred {
+            IntPredicate::Eq => WASM_I64_EQ,
+            IntPredicate::Ne => WASM_I64_NE,
+            IntPredicate::Slt => WASM_I64_LT_S,
+            IntPredicate::Sle => WASM_I64_LE_S,
+            IntPredicate::Sgt => WASM_I64_GT_S,
+            IntPredicate::Sge => WASM_I64_GE_S,
+            IntPredicate::Ult => WASM_I64_LT_U,
+            IntPredicate::Ule => WASM_I64_LE_U,
+            IntPredicate::Ugt => WASM_I64_GT_U,
+            IntPredicate::Uge => WASM_I64_GE_U,
+        }
+    } else {
+        match pred {
+            IntPredicate::Eq => WASM_I32_EQ,
+            IntPredicate::Ne => WASM_I32_NE,
+            IntPredicate::Slt => WASM_I32_LT_S,
+            IntPredicate::Sle => WASM_I32_LE_S,
+            IntPredicate::Sgt => WASM_I32_GT_S,
+            IntPredicate::Sge => WASM_I32_GE_S,
+            IntPredicate::Ult => WASM_I32_LT_U,
+            IntPredicate::Ule => WASM_I32_LE_U,
+            IntPredicate::Ugt => WASM_I32_GT_U,
+            IntPredicate::Uge => WASM_I32_GE_U,
+        }
+    }
+}
+
+// ── misc helpers ──────────────────────────────────────────────────────────
+
+fn is_void_type(ctx: &Context, ty: TypeId) -> bool {
+    matches!(
+        ctx.get_type(ty),
+        TypeData::Void | TypeData::Label | TypeData::Metadata
+    )
+}

--- a/src/llvm-target-wasm/src/lower.rs
+++ b/src/llvm-target-wasm/src/lower.rs
@@ -288,7 +288,7 @@ fn emit_code_for_function(
 
         // Emit all non-terminator instructions.
         for &iid in &bb.body {
-            emit_instr(ctx, func, vmap, code, iid, &func_idx_map);
+            emit_instr(ctx, func, module, vmap, code, iid, &func_idx_map);
         }
 
         // Emit the terminator.
@@ -363,6 +363,7 @@ fn emit_value(
 fn emit_instr(
     ctx: &Context,
     func: &Function,
+    module: &Module,
     vmap: &HashMap<ValueRef, u32>,
     code: &mut Vec<u8>,
     iid: InstrId,
@@ -603,9 +604,9 @@ fn emit_instr(
                     ConstantData::GlobalRef { name, .. } => Some(name.as_str()),
                     _ => None,
                 },
-                ValueRef::Global(_) => {
-                    // Try to find by function index.
-                    None
+                ValueRef::Global(gid) => {
+                    // Look up by function index in the module.
+                    module.functions.get(gid.0 as usize).map(|f| f.name.as_str())
                 }
                 _ => None,
             };

--- a/src/llvm-target-wasm/src/types.rs
+++ b/src/llvm-target-wasm/src/types.rs
@@ -1,0 +1,50 @@
+//! WebAssembly value-type and function-type encoding helpers.
+
+use llvm_ir::{Context, FloatKind, TypeData, TypeId};
+
+// ── wasm value type bytes (valtype) ───────────────────────────────────────
+
+/// `i32` valtype.
+pub const VALTYPE_I32: u8 = 0x7F;
+/// `i64` valtype.
+pub const VALTYPE_I64: u8 = 0x7E;
+/// `f32` valtype.
+pub const VALTYPE_F32: u8 = 0x7D;
+/// `f64` valtype.
+pub const VALTYPE_F64: u8 = 0x7C;
+
+// Wasm block type: empty (void result)
+pub const BLOCKTYPE_VOID: u8 = 0x40;
+
+/// Map an IR `TypeId` to the closest wasm `valtype` byte.
+///
+/// - i1 / i8 / i16 / i32 → `i32`
+/// - i64 / pointer        → `i64`
+/// - f32                  → `f32`
+/// - f64                  → `f64`
+/// - everything else      → `i32` (conservative default)
+pub fn ir_ty_to_valtype(ctx: &Context, ty: TypeId) -> Option<u8> {
+    match ctx.get_type(ty) {
+        TypeData::Void => None,
+        TypeData::Integer(bits) => {
+            if *bits <= 32 {
+                Some(VALTYPE_I32)
+            } else {
+                Some(VALTYPE_I64)
+            }
+        }
+        TypeData::Float(FloatKind::Single) => Some(VALTYPE_F32),
+        TypeData::Float(FloatKind::Double) => Some(VALTYPE_F64),
+        TypeData::Float(_) => Some(VALTYPE_F64),
+        // Pointers are represented as i32 in wasm32
+        TypeData::Pointer => Some(VALTYPE_I32),
+        // Fallback for exotic types
+        _ => Some(VALTYPE_I32),
+    }
+}
+
+/// Return `true` if this IR type maps to a 64-bit wasm integer.
+pub fn is_i64_type(ctx: &Context, ty: TypeId) -> bool {
+    matches!(ctx.get_type(ty), TypeData::Integer(bits) if *bits > 32)
+}
+

--- a/src/llvm/Cargo.toml
+++ b/src/llvm/Cargo.toml
@@ -21,4 +21,5 @@ llvm-codegen = { package = "llvm-in-rust-codegen", version = "0.1.0", path = "..
 llvm-target-x86 = { package = "llvm-in-rust-target-x86", version = "0.1.0", path = "../llvm-target-x86" }
 llvm-target-arm = { package = "llvm-in-rust-target-arm", version = "0.1.0", path = "../llvm-target-arm" }
 llvm-target-riscv = { package = "llvm-in-rust-target-riscv", version = "0.1.0", path = "../llvm-target-riscv" }
+llvm-target-wasm = { package = "llvm-in-rust-target-wasm", version = "0.1.0", path = "../llvm-target-wasm" }
 llvm-bitcode = { package = "llvm-in-rust-bitcode", version = "0.1.0", path = "../llvm-bitcode" }

--- a/src/llvm/src/lib.rs
+++ b/src/llvm/src/lib.rs
@@ -14,6 +14,8 @@ pub use llvm_target_arm as target_arm;
 /// Public API for `re-export`.
 pub use llvm_target_riscv as target_riscv;
 /// Public API for `re-export`.
+pub use llvm_target_wasm as target_wasm;
+/// Public API for `re-export`.
 pub use llvm_target_x86 as target_x86;
 /// Public API for `re-export`.
 pub use llvm_transforms as transforms;


### PR DESCRIPTION
## Summary

- Add `src/llvm-target-wasm/` crate (`llvm-in-rust-target-wasm`) implementing a WebAssembly wasm32 target backend
- Use the **"all-locals" strategy**: every SSA value (function argument or instruction result) maps to a wasm `local` variable, so no register allocation is needed
- Implement `IselBackend` for `WasmBackend` and expose a top-level `compile_to_wasm(ir: &str) -> Result<Vec<u8>, String>` convenience function
- Re-export `WasmBackend` from the top-level `llvm` crate as `target_wasm`

## Design: "all-locals" strategy

Arguments occupy wasm locals 0..N (implicit as function parameters in the wasm binary format).  Each instruction result is assigned the next available local.  Assignments are `local.set`, uses are `local.get`.

Control flow uses a "wrapping" approach: all `n` basic blocks are enclosed in `n-1` nested `block` constructs at the top of the function.  Forward branches use `br N` (where N is the number of block boundaries to cross).  Back-edges (loops) wrap the loop-header block in a `loop` construct.

## 8 tests (all pass)

1. `wasm_magic_bytes` — first 4 bytes are `\0asm`
2. `wasm_version` — bytes 4-7 are `[0x01, 0x00, 0x00, 0x00]`
3. `wasm_return_const` — binary contains `i32.const` (0x41) and LEB128(42)=0x2A
4. `wasm_add_two_ints` — binary contains `i32.add` (0x6A)
5. `wasm_export_name` — string `"my_func"` appears in export section
6. `wasm_multi_function` — both `"foo"` and `"bar"` appear in the binary
7. `wasm_conditional_branch` — binary contains `if` (0x04) or `br_if` (0x0D)
8. `wasm_declarations_excluded` — a `declare`-only module emits valid magic+version but no export for the declaration

## Known limitations

- Phi nodes are stubbed (emit constant 0) — full phi-destruction for loops is a TODO
- `alloca` emits address 0 (wasm linear memory stack frame management is a TODO)
- Indirect/external calls emit `unreachable` (import section is a TODO)
- Floating-point, vector, and atomic instructions emit 0 constants (TODOs)
- The Relooper algorithm is not fully implemented; only single-level back-edges work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #222