### PR TITLE
fix(x86): emit 32-bit LOCK XADD for i32 atomicrmw (closes #240)

### DIFF
--- a/src/llvm-jit/tests/atomic_threads.rs
+++ b/src/llvm-jit/tests/atomic_threads.rs
@@ -66,16 +66,18 @@ entry:
         let f: fn(*mut i32) = unsafe { std::mem::transmute(ptr) };
 
         let t1 = {
-            let p = ctr_ptr;
+            let addr = ctr_ptr as usize;
             std::thread::spawn(move || {
+                let p = addr as *mut i32;
                 for _ in 0..N {
                     f(p);
                 }
             })
         };
         let t2 = {
-            let p = ctr_ptr;
+            let addr = ctr_ptr as usize;
             std::thread::spawn(move || {
+                let p = addr as *mut i32;
                 for _ in 0..N {
                     f(p);
                 }
@@ -115,8 +117,9 @@ entry:
 
         let threads: Vec<_> = (0..4)
             .map(|_| {
-                let p = ctr_ptr;
+                let addr = ctr_ptr as usize;
                 std::thread::spawn(move || {
+                    let p = addr as *mut i32;
                     for _ in 0..1000 {
                         f(p);
                     }

--- a/src/llvm-jit/tests/atomic_threads.rs
+++ b/src/llvm-jit/tests/atomic_threads.rs
@@ -5,6 +5,10 @@
 //! then drives two or more OS threads against the resulting function pointer and
 //! checks that no increment is lost.
 //!
+//! The backend must emit `F0 0F C1` (32-bit LOCK XADD, no REX.W) for i32 element
+//! types. If REX.W (0x48) is mistakenly inserted, the instruction becomes a 64-bit
+//! load/add and reads 8 bytes from the counter, corrupting the result.
+//!
 //! Only runs on x86-64 because `SimpleJit` only emits x86-64 machine code.
 
 // Everything in this file is x86-64-only: gate the entire module contents so

--- a/src/llvm-jit/tests/atomic_threads.rs
+++ b/src/llvm-jit/tests/atomic_threads.rs
@@ -1,0 +1,133 @@
+//! Multithreaded spinlock smoke test for `atomicrmw add` via JIT.
+//!
+//! Parses a tiny IR snippet containing `atomicrmw add ptr %ctr, i32 1 seq_cst`,
+//! JIT-compiles it through the full pipeline (parse → O2 → x86 regalloc → mmap),
+//! then drives two or more OS threads against the resulting function pointer and
+//! checks that no increment is lost.
+//!
+//! Only runs on x86-64 because `SimpleJit` only emits x86-64 machine code.
+
+// Everything in this file is x86-64-only: gate the entire module contents so
+// the compiler doesn't warn about unused items on other architectures.
+#[cfg(target_arch = "x86_64")]
+mod x86_64_tests {
+    use llvm_ir_parser::parser::parse;
+    use llvm_jit::{ExecutionEngine, SimpleJit};
+    use std::sync::atomic::{AtomicI32, Ordering};
+    use std::sync::Arc;
+
+    const N: i32 = 500;
+
+    /// IR for `void @increment(ptr %ctr)` — atomically adds 1 to the pointed-to i32.
+    const SPINLOCK_IR: &str = r#"
+define void @increment(ptr %ctr) {
+entry:
+  %old = atomicrmw add ptr %ctr, i32 1 seq_cst
+  ret void
+}
+"#;
+
+    // ── helper ──────────────────────────────────────────────────────────────
+
+    /// Parse `SPINLOCK_IR`, JIT-compile it, and return the engine.
+    ///
+    /// Separated into a helper so both tests can share the setup logic without
+    /// duplicating the parse/compile boilerplate.
+    fn build_jit() -> SimpleJit {
+        let (mut ctx, mut module) = parse(SPINLOCK_IR).expect("parse failed");
+        let mut jit = SimpleJit::new();
+        jit.add_module(&mut ctx, &mut module)
+            .expect("JIT compilation failed");
+        jit
+    }
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    /// Two threads each call `increment` N times; final counter must equal 2 × N.
+    ///
+    /// Verifies that the JIT-compiled `atomicrmw add seq_cst` produces a real
+    /// atomic LOCK XADD instruction that prevents lost updates under contention.
+    #[test]
+    fn multithreaded_atomic_counter_no_lost_updates() {
+        let jit = build_jit();
+
+        let ptr = jit.get_function_ptr("increment").expect("symbol not found");
+
+        // Shared counter — heap-allocated so both threads can hold a raw pointer.
+        // The Arc keeps the allocation alive until after both threads have joined.
+        let counter = Arc::new(AtomicI32::new(0));
+        let ctr_ptr = counter.as_ref() as *const AtomicI32 as *mut i32;
+
+        // SAFETY: `ptr` points to JIT-compiled x86-64 `void @increment(ptr %ctr)`.
+        // The `SimpleJit` owns the mmap pages and outlives all threads in this
+        // function (it is not moved into the threads). `ctr_ptr` is valid for
+        // the full duration because the Arc is kept alive by `counter` in this
+        // scope and both threads are joined before this scope exits.
+        let f: fn(*mut i32) = unsafe { std::mem::transmute(ptr) };
+
+        let t1 = {
+            let p = ctr_ptr;
+            std::thread::spawn(move || {
+                for _ in 0..N {
+                    f(p);
+                }
+            })
+        };
+        let t2 = {
+            let p = ctr_ptr;
+            std::thread::spawn(move || {
+                for _ in 0..N {
+                    f(p);
+                }
+            })
+        };
+
+        t1.join().expect("t1 panicked");
+        t2.join().expect("t2 panicked");
+
+        let final_count = counter.load(Ordering::SeqCst);
+        assert_eq!(
+            final_count,
+            2 * N,
+            "atomic counter: expected {} increments, got {}",
+            2 * N,
+            final_count,
+        );
+    }
+
+    /// Four threads × 1000 iterations = 4000 — stress test for atomicity.
+    ///
+    /// A higher iteration count and more threads increase the window for data
+    /// races; any lost update will cause the final assertion to fail.
+    #[test]
+    fn multithreaded_atomic_counter_large_n() {
+        let jit = build_jit();
+
+        let ptr = jit.get_function_ptr("increment").expect("symbol not found");
+
+        let counter = Arc::new(AtomicI32::new(0));
+        let ctr_ptr = counter.as_ref() as *const AtomicI32 as *mut i32;
+
+        // SAFETY: same invariants as in `multithreaded_atomic_counter_no_lost_updates`.
+        // `jit` outlives all spawned threads (they are joined below before this
+        // function returns). `counter` keeps `ctr_ptr` valid for the full duration.
+        let f: fn(*mut i32) = unsafe { std::mem::transmute(ptr) };
+
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                let p = ctr_ptr;
+                std::thread::spawn(move || {
+                    for _ in 0..1000 {
+                        f(p);
+                    }
+                })
+            })
+            .collect();
+
+        for t in threads {
+            t.join().expect("thread panicked");
+        }
+
+        assert_eq!(counter.load(Ordering::SeqCst), 4000);
+    }
+}

--- a/src/llvm-jit/tests/atomic_threads.rs
+++ b/src/llvm-jit/tests/atomic_threads.rs
@@ -43,6 +43,31 @@ entry:
 
     // ── tests ────────────────────────────────────────────────────────────────
 
+    /// Single-threaded correctness check: one call must add exactly 1.
+    ///
+    /// Confirms the JIT-compiled `atomicrmw add i32` uses a 32-bit LOCK XADD
+    /// (no REX.W) so that exactly 4 bytes are read/written — preventing the
+    /// bug where REX.W made it a 64-bit operation and read adjacent memory.
+    #[test]
+    fn single_threaded_increment_correctness() {
+        let jit = build_jit();
+        let ptr = jit.get_function_ptr("increment").expect("symbol not found");
+        let counter = Arc::new(AtomicI32::new(0));
+        let ctr_ptr = counter.as_ref() as *const AtomicI32 as *mut i32;
+        // SAFETY: ptr points to JIT-compiled x86-64 `void @increment(ptr %ctr)`.
+        let f: fn(*mut i32) = unsafe { std::mem::transmute(ptr) };
+        f(ctr_ptr);
+        assert_eq!(counter.load(Ordering::SeqCst), 1, "single call should increment by 1");
+        for _ in 0..999 {
+            f(ctr_ptr);
+        }
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1000,
+            "1000 sequential calls should increment by 1000"
+        );
+    }
+
     /// Two threads each call `increment` N times; final counter must equal 2 × N.
     ///
     /// Verifies that the JIT-compiled `atomicrmw add seq_cst` produces a real

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -260,6 +260,18 @@ fn rex_mem(ctx: &mut EncodeCtx, val_reg: PReg, ptr_reg: PReg) {
     ctx.emit(rex);
 }
 
+/// Emit an optional REX prefix for 32-bit memory-operand instructions (no REX.W).
+/// Only emitted when at least one of val_reg or ptr_reg is an extended register (R8-R15).
+fn rex_mem32_opt(ctx: &mut EncodeCtx, val_reg: PReg, ptr_reg: PReg) {
+    let need_rex = is_extended(val_reg) || is_extended(ptr_reg);
+    if need_rex {
+        let rex = 0x40
+            | (if is_extended(val_reg) { 0x04 } else { 0 })
+            | (if is_extended(ptr_reg) { 0x01 } else { 0 });
+        ctx.emit(rex);
+    }
+}
+
 /// Extract the PReg at a given operand index.
 fn preg_at(instr: &MInstr, idx: usize) -> Option<PReg> {
     match instr.operands.get(idx) {
@@ -781,6 +793,20 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
             if let (Some(ptr), Some(val)) = (preg_at(instr, 0), preg_at(instr, 1)) {
                 ctx.emit(0xF0);
                 rex_mem(ctx, val, ptr);
+                ctx.emit(0x0F);
+                ctx.emit(0xC1);
+                emit_mem_modrm(ctx, val, ptr);
+            } else {
+                ctx.emit(0x90);
+            }
+        }
+
+        // LOCK XADD [ptr], val  (F0 [REX] 0F C1 /r) — 32-bit, no REX.W
+        // operands[0]=ptr_preg, operands[1]=val_preg
+        LOCK_XADD32_MR => {
+            if let (Some(ptr), Some(val)) = (preg_at(instr, 0), preg_at(instr, 1)) {
+                ctx.emit(0xF0);
+                rex_mem32_opt(ctx, val, ptr);
                 ctx.emit(0x0F);
                 ctx.emit(0xC1);
                 emit_mem_modrm(ctx, val, ptr);

--- a/src/llvm-target-x86/src/instructions.rs
+++ b/src/llvm-target-x86/src/instructions.rs
@@ -147,9 +147,12 @@ pub const MFENCE: MOpcode = MOpcode(0x90);
 /// `lock cmpxchg [ptr], new_val` — compare-and-swap (F0 REX.W 0F B1 /r).
 /// operands[0]=ptr_preg, operands[1]=RAX (comparand, pre-loaded), operands[2]=new_val_preg.
 pub const LOCK_CMPXCHG_MR: MOpcode = MOpcode(0x91);
-/// `lock xadd [ptr], val` — atomic exchange-add (F0 REX.W 0F C1 /r).
+/// `lock xadd [ptr], val` — atomic exchange-add, 64-bit (F0 REX.W 0F C1 /r).
 /// operands[0]=ptr_preg, operands[1]=val_preg; old value returned in val_preg.
 pub const LOCK_XADD_MR: MOpcode = MOpcode(0x92);
+/// `lock xadd [ptr], val` — atomic exchange-add, 32-bit (F0 [REX] 0F C1 /r, no REX.W).
+/// operands[0]=ptr_preg, operands[1]=val_preg; old value returned in val_preg.
+pub const LOCK_XADD32_MR: MOpcode = MOpcode(0x9A);
 /// `xchg [ptr], val` — atomic exchange, implicitly LOCK (REX.W 87 /r).
 /// operands[0]=ptr_preg, operands[1]=val_preg; old value returned in val_preg.
 pub const XCHG_MR: MOpcode = MOpcode(0x93);

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -851,8 +851,13 @@ fn lower_instr(
             use llvm_ir::RmwOp;
             let ptr_vr = res!(*ptr);
             let val_vr = res!(*val);
+            // Use 32-bit opcodes (no REX.W) when the element type is narrower than 64 bits.
+            // `instr.ty` is the element type of the atomicrmw (e.g. i32).
+            let is_64bit = instr.ty == ctx.i64_ty;
             let (opcode, result_in_val) = match op {
-                RmwOp::Add | RmwOp::Sub => (LOCK_XADD_MR, true),
+                RmwOp::Add | RmwOp::Sub => {
+                    if is_64bit { (LOCK_XADD_MR, true) } else { (LOCK_XADD32_MR, true) }
+                }
                 RmwOp::Xchg => (XCHG_MR, true),
                 RmwOp::And | RmwOp::Nand => (LOCK_AND_MR, false),
                 RmwOp::Or => (LOCK_OR_MR, false),
@@ -1199,7 +1204,12 @@ mod tests {
     use crate::encode::X86Emitter;
     use llvm_codegen::emit::{Emitter, ObjectFormat};
     use llvm_codegen::isel::MOperand;
-    use llvm_ir::{Builder, ConstantData, Context, GlobalId, Linkage, Module, ValueRef};
+    use llvm_codegen::regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    };
+    use llvm_ir::{Builder, ConstantData, Context, GlobalId, Linkage, MemOrdering, Module,
+                  RmwOp, ValueRef};
 
     fn make_add_fn() -> (Context, Module) {
         let mut ctx = Context::new();
@@ -1347,12 +1357,13 @@ mod tests {
             .any(|i| i.opcode == LOCK_CMPXCHG_MR);
         assert!(has_cmpxchg, "CmpXchg must lower to LOCK_CMPXCHG_MR opcode");
 
+        // i32 atomicrmw add → 32-bit LOCK_XADD32_MR (no REX.W).
         let has_xadd = mf
             .blocks
             .iter()
             .flat_map(|b| &b.instrs)
-            .any(|i| i.opcode == LOCK_XADD_MR);
-        assert!(has_xadd, "AtomicRmw Add must lower to LOCK_XADD_MR opcode");
+            .any(|i| i.opcode == LOCK_XADD32_MR);
+        assert!(has_xadd, "i32 AtomicRmw Add must lower to LOCK_XADD32_MR opcode");
 
         // No INLINE_ASM should appear for atomic ops anymore.
         let inline_asm_count = mf
@@ -2238,6 +2249,124 @@ mod tests {
                 .flat_map(|b| &b.instrs)
                 .all(|i| i.opcode != PADDD_RR),
             "without AVX-512F, <16 x i32> should avoid AVX-512-gated SIMD opcode path"
+        );
+    }
+
+    /// Diagnostic test: build `void @increment(ptr %ctr)` — atomicrmw add ptr %ctr, i32 1 —
+    /// run the full pipeline (lower → regalloc → apply_allocation → emit_object), then
+    /// inspect the bytes of the text section.
+    ///
+    /// Regression test for two bugs:
+    /// 1. LOCK XADD must be present (val_reg must survive regalloc with a real PReg).
+    /// 2. For i32 atomicrmw, LOCK XADD32 (no REX.W) must be emitted — not the 64-bit
+    ///    LOCK XADD (REX.W), which reads 8 bytes from the counter and causes the
+    ///    multithreaded counter to accumulate 249500 instead of 1000.
+    #[test]
+    fn atomics_increment_full_pipeline_emits_lock_xadd() {
+        // Build `void @increment(ptr %ctr) { %old = atomicrmw add ptr %ctr, i32 1 seq_cst; ret void }`
+        let mut ctx = Context::new();
+        let mut module = Module::new("increment_test");
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "increment",
+            b.ctx.void_ty,
+            vec![b.ctx.ptr_ty],
+            vec!["ctr".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let ptr_arg = b.get_arg(0);
+        let i32_ty = b.ctx.i32_ty;
+        let one = b.const_int(i32_ty, 1);
+        b.build_atomicrmw("old", RmwOp::Add, i32_ty, ptr_arg, one, MemOrdering::SeqCst, false);
+        b.build_ret_void();
+        drop(b);
+
+        // Lower
+        let mut be = X86Backend::new(TargetFeatures::baseline());
+        let mut mf = be.lower_function(&ctx, &module, &module.functions[0]);
+
+        // i32 atomicrmw add must lower to LOCK_XADD32_MR (32-bit, no REX.W).
+        let has_xadd32 = mf
+            .blocks
+            .iter()
+            .flat_map(|b| &b.instrs)
+            .any(|i| i.opcode == LOCK_XADD32_MR);
+        assert!(has_xadd32, "i32 atomicrmw add must lower to LOCK_XADD32_MR (not LOCK_XADD_MR)");
+
+        // Must NOT use the 64-bit opcode for an i32 element type.
+        let has_xadd64 = mf
+            .blocks
+            .iter()
+            .flat_map(|b| &b.instrs)
+            .any(|i| i.opcode == LOCK_XADD_MR);
+        assert!(!has_xadd64, "i32 atomicrmw must not emit the 64-bit LOCK_XADD_MR opcode");
+
+        // Run register allocation
+        let intervals = compute_live_intervals(&mf);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            RegAllocStrategy::LinearScan,
+        );
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            crate::instructions::MOV_LOAD_MR,
+            crate::instructions::MOV_STORE_RM,
+        );
+        apply_allocation(&mut mf, &result);
+
+        // Emit the function to bytes
+        let mut emitter = X86Emitter::new(ObjectFormat::Elf);
+        let section = emitter.emit_function(&mf);
+
+        // Print the bytes for diagnosis
+        eprintln!("increment text section bytes ({} bytes):", section.data.len());
+        for (i, chunk) in section.data.chunks(16).enumerate() {
+            eprint!("  {:04x}: ", i * 16);
+            for b in chunk {
+                eprint!("{b:02X} ");
+            }
+            eprintln!();
+        }
+
+        // LOCK prefix (F0) must be present — the XADD must have been emitted
+        assert!(
+            section.data.contains(&0xF0),
+            "LOCK prefix (0xF0) not found — LOCK XADD was not emitted (got NOP instead). \
+             This means preg_at(instr, 0) or preg_at(instr, 1) returned None after regalloc. \
+             bytes: {:02X?}",
+            section.data,
+        );
+
+        // For i32 atomicrmw: LOCK XADD32 = F0 [no REX.W] 0F C1 /r.
+        // With typical registers (RAX/RCX/RDX — not R8-R15), no REX byte is emitted.
+        // Check that 0xF0 0x0F 0xC1 appears (no REX.W = 0x48 between F0 and 0F).
+        let has_32bit_lock_xadd = section
+            .data
+            .windows(3)
+            .any(|w| w == [0xF0, 0x0F, 0xC1]);
+        assert!(
+            has_32bit_lock_xadd,
+            "32-bit LOCK XADD sequence F0 0F C1 not found in emitted bytes — \
+             did REX.W (0x48) sneak in between F0 and 0F? \
+             bytes: {:02X?}",
+            section.data,
+        );
+
+        // Double-check: 64-bit sequence F0 48 0F C1 must NOT appear.
+        let has_64bit_lock_xadd = section
+            .data
+            .windows(4)
+            .any(|w| w == [0xF0, 0x48, 0x0F, 0xC1]);
+        assert!(
+            !has_64bit_lock_xadd,
+            "64-bit LOCK XADD sequence F0 48 0F C1 must not appear for i32 atomicrmw. \
+             bytes: {:02X?}",
+            section.data,
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds multithreaded JIT smoke test for `atomicrmw add ptr %ctr, i32 1 seq_cst` (#240)
- Fixes `thread::spawn` closure by passing counter address as `usize` (Send bound)
- Fixes `rex_mem()` unconditionally setting REX.W — for i32 atomicrmw this made LOCK XADD a 64-bit operation, reading 8 bytes instead of 4 and producing 249500 instead of 1000

## Root cause

`rex_mem()` in `encode.rs` always emitted `0x48` (REX.W), turning every `LOCK XADD` into a 64-bit operation regardless of the IR element type. For `atomicrmw add ptr %p, i32 1` the 64-bit XADD read adjacent heap memory alongside the 4-byte counter, causing the two-thread test to see 249500 (= 2 × T(499)) instead of 1000.

## Fix

- Added `LOCK_XADD32_MR` opcode (F0 [optional REX, no W] 0F C1 /r)
- Added `rex_mem32_opt()` helper: emits REX only when R8-R15 registers are involved, never sets REX.W
- `lower.rs` now dispatches `LOCK_XADD32_MR` vs `LOCK_XADD_MR` based on `instr.ty == ctx.i64_ty`
- New unit test asserts `F0 0F C1` is emitted (32-bit) and `F0 48 0F C1` is absent for i32 atomicrmw

## Test plan

- [x] `single_threaded_increment_correctness` — 1000 sequential JIT calls → counter == 1000
- [x] `multithreaded_atomic_counter_no_lost_updates` — 2 threads × 500 → counter == 1000
- [x] `multithreaded_atomic_counter_large_n` — 4 threads × 1000 → counter == 4000
- [x] `atomics_increment_full_pipeline_emits_lock_xadd` — asserts byte sequence F0 0F C1 present, F0 48 0F C1 absent

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)