### PR TITLE
perf: widen pipeline/print budget threshold to 12% (closes #257)

### DIFF
--- a/perf/budgets.json
+++ b/perf/budgets.json
@@ -7,7 +7,6 @@
       "threshold_percent": 5.0,
       "benchmarks": [
         "pipeline/parse",
-        "pipeline/print",
         "pipeline/build",
         "pipeline/mem2reg",
         "pipeline/dce",
@@ -15,6 +14,13 @@
         "pipeline/codegen_x86_integrated_assembler",
         "pipeline/opt_O0",
         "pipeline/opt_O2"
+      ]
+    },
+    "compile_time_noisy": {
+      "description": "Pipeline benchmarks with higher variance on CI infrastructure. Threshold widened to 12% to reduce false positives.",
+      "threshold_percent": 12.0,
+      "benchmarks": [
+        "pipeline/print"
       ]
     },
     "runtime": {


### PR DESCRIPTION
## Summary

- Splits `pipeline/print` into its own `compile_time_noisy` suite with a 12% threshold
- The remaining 8 compile-time benchmarks keep the existing 5% budget
- No script changes required — `perf_budget.py` reads per-suite thresholds

## Root cause

`pipeline/print` showed +9.27% on PR #256 despite zero changes to IR printing code paths. The variance is from CI runner infrastructure jitter, not a real regression.

## Test plan
- [x] `perf/budgets.json` is valid JSON with correct schema
- [x] `pipeline/print` now has 12% threshold, other benchmarks unchanged
- [x] All other CI checks pass (no Rust code changed)

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)