### PR TITLE
fix(x86): update alloca test to 4-arg allocate_registers / 6-arg insert_spill_reloads API

### DIFF
--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -2478,11 +2478,17 @@ mod tests {
 
         // Run register allocation.
         let intervals = compute_live_intervals(&mf);
-        let allocatable = mf.allocatable_pregs.clone();
-        let mut result = allocate_registers(&intervals, &allocatable, RegAllocStrategy::LinearScan);
+        let mut result = allocate_registers(
+            &intervals,
+            &mf.allocatable_pregs,
+            &mf.allocatable_fp_pregs,
+            RegAllocStrategy::LinearScan,
+        );
         insert_spill_reloads(
             &mut mf,
             &mut result,
+            crate::instructions::MOV_LOAD_MR,
+            crate::instructions::MOV_STORE_RM,
             crate::instructions::MOV_LOAD_MR,
             crate::instructions::MOV_STORE_RM,
         );


### PR DESCRIPTION
## Summary

- The `alloca_lowering_emits_lea_frame_mr` test added in PR #296 was using the old 3-arg `allocate_registers` signature and the old 4-arg `insert_spill_reloads` signature
- PR #295 changed `allocate_registers` to 4 args (added `fp_pregs` parameter) and `insert_spill_reloads` to 6 args (added fp load/store opcodes)
- This mismatch caused CI compilation failures on all FP PRs (#302, #303, #304) that rebase onto main

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test` passes (all existing tests green, no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)