### PR TITLE
fix(transforms): bounds-safe remap_block_ids to fix OOB panic in CfgSimplify

### DIFF
--- a/src/llvm-transforms/src/cfg_simplify.rs
+++ b/src/llvm-transforms/src/cfg_simplify.rs
@@ -227,53 +227,38 @@ fn compute_reachable(func: &Function) -> HashSet<BlockId> {
 /// `new_idx[old.0]` = `Some(new_index)` for kept blocks, `None` for removed.
 /// Removed-block references in phi incoming lists should have been dropped
 /// before calling this function.
+///
+/// Uses `.get()` for bounds-safe access: the flat instruction pool retains
+/// dead instructions (those no longer referenced by any block) across
+/// iterations, and their stale BlockIds may fall outside `new_idx`.  Dead
+/// instructions are ignored here because no live block will ever execute them.
 fn remap_block_ids(func: &mut Function, new_idx: &[Option<u32>]) {
+    let remap = |blk: &mut BlockId| {
+        if let Some(&Some(n)) = new_idx.get(blk.0 as usize) {
+            *blk = BlockId(n);
+        }
+        // Out-of-bounds or None → leave as-is (dead instruction, harmless).
+    };
     for instr in &mut func.instructions {
         match &mut instr.kind {
-            InstrKind::Br { dest } => {
-                if let Some(n) = new_idx[dest.0 as usize] {
-                    *dest = BlockId(n);
-                }
-            }
-            InstrKind::CondBr {
-                then_dest,
-                else_dest,
-                ..
-            } => {
-                if let Some(n) = new_idx[then_dest.0 as usize] {
-                    *then_dest = BlockId(n);
-                }
-                if let Some(n) = new_idx[else_dest.0 as usize] {
-                    *else_dest = BlockId(n);
-                }
+            InstrKind::Br { dest } => remap(dest),
+            InstrKind::CondBr { then_dest, else_dest, .. } => {
+                remap(then_dest);
+                remap(else_dest);
             }
             InstrKind::Switch { default, cases, .. } => {
-                if let Some(n) = new_idx[default.0 as usize] {
-                    *default = BlockId(n);
-                }
+                remap(default);
                 for (_, blk) in cases.iter_mut() {
-                    if let Some(n) = new_idx[blk.0 as usize] {
-                        *blk = BlockId(n);
-                    }
+                    remap(blk);
                 }
             }
-            InstrKind::Invoke {
-                normal_dest,
-                unwind_dest,
-                ..
-            } => {
-                if let Some(n) = new_idx[normal_dest.0 as usize] {
-                    *normal_dest = BlockId(n);
-                }
-                if let Some(n) = new_idx[unwind_dest.0 as usize] {
-                    *unwind_dest = BlockId(n);
-                }
+            InstrKind::Invoke { normal_dest, unwind_dest, .. } => {
+                remap(normal_dest);
+                remap(unwind_dest);
             }
             InstrKind::Phi { incoming, .. } => {
                 for (_, blk) in incoming.iter_mut() {
-                    if let Some(n) = new_idx[blk.0 as usize] {
-                        *blk = BlockId(n);
-                    }
+                    remap(blk);
                 }
             }
             _ => {}


### PR DESCRIPTION
## Problem

`remap_block_ids` iterates over every instruction in the flat pool (`func.instructions`), including **dead instructions** — those no longer referenced by any block's `body` or `terminator`. These dead instructions accumulate across fixed-point iterations: when `prune_unreachable` removes blocks and renumbers surviving ones, dead instructions keep stale `BlockId`s whose numeric values may exceed the smaller `new_idx` built by the next sub-pass.

Result: on a multi-iteration O3 run (e.g. IPCP-specialized functions), `merge_fallthrough` calls `remap_block_ids` with a `new_idx` shorter than the stale BlockId, causing:
```
thread 'tests::ipa_fixture_o3_reduces_call_arg_pressure_vs_o2' panicked at cfg_simplify.rs:234:
index out of bounds: the len is 4 but the index is 5
```

## Fix

Replace `new_idx[dest.0 as usize]` with `new_idx.get(dest.0 as usize)` everywhere in `remap_block_ids`. Out-of-bounds or `None` entries leave the BlockId unchanged — correct and harmless for dead instructions that no live block will ever execute.

## Test plan

- [x] `cargo test -p llvm-in-rust-bench ipa_fixture_o3_reduces_call_arg_pressure_vs_o2` — passes (was panicking)
- [x] `cargo test -p llvm-in-rust-transforms` — 82 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)