### PR TITLE
feat(transforms): strict IEEE-754 FP barriers in GVN/LICM + strictfp function attribute (closes #355)

### DIFF
--- a/src/llvm-bitcode/src/reader.rs
+++ b/src/llvm-bitcode/src/reader.rs
@@ -480,6 +480,8 @@ fn decode_function(
     let ty = map_type_id(type_id_map, ty_raw)?;
     let linkage = decode_linkage(r.u8()?)?;
     let is_declaration = r.u8()? != 0;
+    // strictfp is optional — older bitcode files may not have this byte.
+    let strictfp = r.u8().unwrap_or(0) != 0;
 
     // Arguments.
     let arg_count = r.u32()? as usize;
@@ -502,6 +504,7 @@ fn decode_function(
         Function::new(name, ty, args, linkage)
     };
     func.is_declaration = is_declaration;
+    func.strictfp = strictfp;
 
     // Read flat instruction pool first (needed for block body references).
     let block_count = r.u32()? as usize;

--- a/src/llvm-bitcode/src/writer.rs
+++ b/src/llvm-bitcode/src/writer.rs
@@ -394,6 +394,7 @@ fn encode_function(w: &mut Writer, func: &Function) {
     };
     w.u8(ltag);
     w.u8(if func.is_declaration { 1 } else { 0 });
+    w.u8(if func.strictfp { 1 } else { 0 });
 
     // Arguments.
     w.u32(func.args.len() as u32);

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -562,7 +562,8 @@ impl<'src> Parser<'src> {
         self.lex.expect(&Token::RParen)?;
 
         // Skip trailing function attributes (e.g. #0, nounwind, ...).
-        self.skip_trailing_fn_attrs()?;
+        // Returns true if "strictfp" was among the trailing attributes.
+        let has_strictfp = self.skip_trailing_fn_attrs()?;
 
         let fn_ty =
             self.ctx
@@ -593,14 +594,16 @@ impl<'src> Parser<'src> {
         }
 
         if is_declaration {
-            let func = Function::new_declaration(&name, fn_ty, args, linkage);
+            let mut func = Function::new_declaration(&name, fn_ty, args, linkage);
+            func.strictfp = has_strictfp;
             let idx = self.module.add_function(func);
             self.current_func = Some(idx.0 as usize);
             return Ok(());
         }
 
         // Parse body.
-        let func = Function::new(&name, fn_ty, args, linkage);
+        let mut func = Function::new(&name, fn_ty, args, linkage);
+        func.strictfp = has_strictfp;
         let idx = self.module.add_function(func);
         self.current_func = Some(idx.0 as usize);
 
@@ -2461,10 +2464,12 @@ impl<'src> Parser<'src> {
         Ok(())
     }
 
-    fn skip_trailing_fn_attrs(&mut self) -> Result<(), ParseError> {
+    fn skip_trailing_fn_attrs(&mut self) -> Result<bool, ParseError> {
         // Skip `#N`, bare word attrs, etc. until `{`, EOF, or next top-level token.
         // Stopping at top-level tokens prevents consuming into the next definition
         // when parsing a declaration (which has no `{`).
+        // Returns true if the "strictfp" attribute was encountered.
+        let mut has_strictfp = false;
         loop {
             match self.lex.peek()? {
                 Token::LBrace
@@ -2484,6 +2489,9 @@ impl<'src> Parser<'src> {
                 Token::LocalIdent(s) if Self::is_fn_attr_name(s) => {
                     let name = s.clone();
                     self.lex.next()?;
+                    if name == "strictfp" {
+                        has_strictfp = true;
+                    }
                     self.skip_fn_attr_payload_if_present(&name)?;
                 }
                 Token::LocalIdent(_) => break,
@@ -2500,7 +2508,7 @@ impl<'src> Parser<'src> {
                 }
             }
         }
-        Ok(())
+        Ok(has_strictfp)
     }
 
     fn skip_param_attrs(&mut self) -> Result<(), ParseError> {

--- a/src/llvm-ir/src/function.rs
+++ b/src/llvm-ir/src/function.rs
@@ -31,6 +31,10 @@ pub struct Function {
     pub is_declaration: bool,
     /// Public API for `linkage`.
     pub linkage: Linkage,
+    /// When true, the function is compiled in strict IEEE-754 mode.
+    /// Optimizers must not reorder, CSE, or constant-fold FP operations
+    /// in ways that would change observable floating-point behaviour.
+    pub strictfp: bool,
     /// Counter for generating unique names.
     next_name_id: u32,
 }
@@ -50,6 +54,7 @@ impl Function {
             arg_names: HashMap::new(),
             is_declaration: false,
             linkage,
+            strictfp: false,
             next_name_id: 0,
         };
         for arg in args {

--- a/src/llvm-ir/src/printer.rs
+++ b/src/llvm-ir/src/printer.rs
@@ -412,6 +412,10 @@ impl<'a> Printer<'a> {
         }
         out.push(')');
 
+        if func.strictfp {
+            out.push_str(" strictfp");
+        }
+
         if func.is_declaration {
             writeln!(out).unwrap();
             return;

--- a/src/llvm-transforms/src/const_prop.rs
+++ b/src/llvm-transforms/src/const_prop.rs
@@ -12,9 +12,9 @@
 //! constants) require a second pass; use `PassManager::run_until_fixed_point`
 //! when that is needed.
 
-use crate::constant_fold::try_fold;
+use crate::constant_fold::{try_fold, try_fold_fp};
 use crate::pass::FunctionPass;
-use llvm_ir::{Context, Function, InstrId, InstrKind, LandingPadClause, ValueRef};
+use llvm_ir::{ConstantData, Context, FloatKind, Function, InstrId, InstrKind, LandingPadClause, TypeData, ValueRef};
 use std::collections::{HashMap, HashSet};
 
 /// Constant propagation / constant folding pass.
@@ -29,6 +29,8 @@ impl FunctionPass for ConstProp {
         if func.blocks.is_empty() {
             return false;
         }
+
+        let strictfp = func.strictfp;
 
         // Map InstrId → its constant replacement (ValueRef::Constant).
         let mut subst: HashMap<InstrId, ValueRef> = HashMap::new();
@@ -46,6 +48,15 @@ impl FunctionPass for ConstProp {
                 let kind = func.instr(iid).kind.clone();
                 if let Some(cid) = try_fold(ctx, &kind) {
                     subst.insert(iid, ValueRef::Constant(cid));
+                } else if let Some(cid) = try_fold_fp(ctx, &kind) {
+                    // In strictfp mode, refuse to fold FP ops to NaN or Inf.
+                    // IEEE-754 requires that such exceptional results are only
+                    // produced at the exact program-order point of execution.
+                    if strictfp && fold_result_is_nan_or_inf(ctx, cid) {
+                        // Do not record the substitution.
+                    } else {
+                        subst.insert(iid, ValueRef::Constant(cid));
+                    }
                 }
             }
             // Also propagate into the terminator.
@@ -66,6 +77,30 @@ impl FunctionPass for ConstProp {
             bb.body.retain(|id| !subst.contains_key(id));
         }
         true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Strictfp helper — detect NaN / Inf folded constants
+// ---------------------------------------------------------------------------
+
+/// Return true if `cid` is a floating-point constant whose value is NaN or
+/// infinite.  Used by the strictfp constant-fold barrier to avoid
+/// materialising exceptional FP results at compile time.
+fn fold_result_is_nan_or_inf(ctx: &Context, cid: llvm_ir::ConstId) -> bool {
+    match ctx.get_const(cid) {
+        ConstantData::Float { ty, bits } => match ctx.get_type(*ty) {
+            TypeData::Float(FloatKind::Single) => {
+                let f = f32::from_bits(*bits as u32);
+                f.is_nan() || f.is_infinite()
+            }
+            TypeData::Float(FloatKind::Double) => {
+                let f = f64::from_bits(*bits);
+                f.is_nan() || f.is_infinite()
+            }
+            _ => false,
+        },
+        _ => false,
     }
 }
 

--- a/src/llvm-transforms/src/gvn.rs
+++ b/src/llvm-transforms/src/gvn.rs
@@ -194,6 +194,14 @@ fn expr_key(kind: &InstrKind) -> Option<ExprKey> {
     })
 }
 
+/// Returns true when a floating-point instruction with these flags is safe
+/// to CSE.  CSE is only semantics-preserving when the flags indicate that
+/// the result is mathematically equivalent regardless of evaluation order
+/// (`reassoc` or `fast`).
+fn fp_cse_safe(flags: &FastMathFlags) -> bool {
+    flags.reassoc || flags.fast
+}
+
 /// Global Value Numbering pass.
 pub struct Gvn;
 
@@ -221,6 +229,10 @@ impl FunctionPass for Gvn {
         let mut subst: HashMap<InstrId, ValueRef> = HashMap::new();
         let mut remove: HashSet<InstrId> = HashSet::new();
 
+        // When the function is compiled in strict IEEE-754 mode, suppress ALL
+        // FP CSE regardless of per-instruction flags.
+        let strictfp_mode = func.strictfp;
+
         rewrite_block(
             func,
             BlockId(0),
@@ -229,6 +241,7 @@ impl FunctionPass for Gvn {
             &mut HashMap::new(),
             &mut subst,
             &mut remove,
+            strictfp_mode,
         );
 
         if subst.is_empty() {
@@ -250,6 +263,40 @@ impl FunctionPass for Gvn {
     }
 }
 
+/// Return true if `kind` is a floating-point arithmetic instruction.
+fn is_fp_arith(kind: &InstrKind) -> bool {
+    matches!(
+        kind,
+        InstrKind::FAdd { .. }
+            | InstrKind::FSub { .. }
+            | InstrKind::FMul { .. }
+            | InstrKind::FDiv { .. }
+            | InstrKind::FRem { .. }
+            | InstrKind::FNeg { .. }
+    )
+}
+
+/// Return true if the instruction `kind` is safe to CSE given the current
+/// strictfp context and per-instruction flags.
+fn cse_allowed(kind: &InstrKind, strictfp_mode: bool) -> bool {
+    if !is_fp_arith(kind) {
+        return true; // Non-FP instructions are always CSE-safe.
+    }
+    if strictfp_mode {
+        return false; // strictfp function: no FP CSE at all.
+    }
+    // Per-instruction check: CSE only when reassoc or fast is set.
+    match kind {
+        InstrKind::FAdd { flags, .. }
+        | InstrKind::FSub { flags, .. }
+        | InstrKind::FMul { flags, .. }
+        | InstrKind::FDiv { flags, .. }
+        | InstrKind::FRem { flags, .. }
+        | InstrKind::FNeg { flags, .. } => fp_cse_safe(flags),
+        _ => true,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn rewrite_block(
     func: &mut Function,
@@ -259,6 +306,7 @@ fn rewrite_block(
     loads_in: &mut HashMap<ValueRef, ValueRef>,
     subst: &mut HashMap<InstrId, ValueRef>,
     remove: &mut HashSet<InstrId>,
+    strictfp_mode: bool,
 ) {
     let mut exprs = exprs_in.clone();
     let mut loads = loads_in.clone();
@@ -296,21 +344,32 @@ fn rewrite_block(
             | InstrKind::AtomicRmw { .. } => {
                 loads.clear();
                 if let Some(key) = expr_key(&rewritten) {
-                    if let Some(existing) = exprs.get(&key).copied() {
-                        subst.insert(iid, existing);
-                        remove.insert(iid);
+                    if cse_allowed(&rewritten, strictfp_mode) {
+                        if let Some(existing) = exprs.get(&key).copied() {
+                            subst.insert(iid, existing);
+                            remove.insert(iid);
+                        } else {
+                            exprs.insert(key, ValueRef::Instruction(iid));
+                        }
                     } else {
-                        exprs.insert(key, ValueRef::Instruction(iid));
+                        // Not CSE-able: still record the expression so dominated
+                        // blocks see it, but do NOT replace this use.
+                        exprs.entry(key).or_insert(ValueRef::Instruction(iid));
                     }
                 }
             }
             _ => {
                 if let Some(key) = expr_key(&rewritten) {
-                    if let Some(existing) = exprs.get(&key).copied() {
-                        subst.insert(iid, existing);
-                        remove.insert(iid);
+                    if cse_allowed(&rewritten, strictfp_mode) {
+                        if let Some(existing) = exprs.get(&key).copied() {
+                            subst.insert(iid, existing);
+                            remove.insert(iid);
+                        } else {
+                            exprs.insert(key, ValueRef::Instruction(iid));
+                        }
                     } else {
-                        exprs.insert(key, ValueRef::Instruction(iid));
+                        // Not CSE-able: record without replacing.
+                        exprs.entry(key).or_insert(ValueRef::Instruction(iid));
                     }
                 }
             }
@@ -323,7 +382,7 @@ fn rewrite_block(
     }
 
     for &child in &dom_children[bid.0 as usize] {
-        rewrite_block(func, child, dom_children, &mut exprs, &mut loads, subst, remove);
+        rewrite_block(func, child, dom_children, &mut exprs, &mut loads, subst, remove, strictfp_mode);
     }
 }
 

--- a/src/llvm-transforms/src/inline_pass.rs
+++ b/src/llvm-transforms/src/inline_pass.rs
@@ -206,7 +206,14 @@ fn do_inline(ctx: &mut Context, module: &mut Module, site: CallSite) {
         block_offset,
     );
 
+    // If the callee is strictfp, propagate that attribute to the caller so that
+    // the inlined FP instructions are still treated as strict.
+    let callee_strictfp = module.functions[callee_id.0 as usize].strictfp;
+
     let caller = &mut module.functions[caller_id.0 as usize];
+    if callee_strictfp {
+        caller.strictfp = true;
+    }
 
     // Step 1: split the caller block at the call site.
     // pre_block keeps instructions 0..instr_pos (not including the call).

--- a/src/llvm-transforms/src/licm.rs
+++ b/src/llvm-transforms/src/licm.rs
@@ -50,6 +50,10 @@ impl FunctionPass for Licm {
             return false;
         }
 
+        // When the function is compiled in strict IEEE-754 mode, no FP op can
+        // be hoisted out of a loop regardless of per-instruction flags.
+        let strictfp_mode = func.strictfp;
+
         // Process innermost loops first: sort by body length ascending.
         let mut loop_order: Vec<usize> = (0..li.loops().len()).collect();
         loop_order.sort_by_key(|&i| li.loops()[i].body.len());
@@ -66,7 +70,7 @@ impl FunctionPass for Licm {
 
             // Iteratively hoist invariant instructions until stable.
             loop {
-                let hoisted = hoist_one_round(func, &loop_body, preheader);
+                let hoisted = hoist_one_round(func, &loop_body, preheader, strictfp_mode);
                 if !hoisted {
                     break;
                 }
@@ -82,7 +86,8 @@ impl FunctionPass for Licm {
 // Invariance helpers
 // ---------------------------------------------------------------------------
 
-/// Returns true if `kind` is side-effect-free and eligible for hoisting.
+/// Returns true if `kind` is side-effect-free and eligible for hoisting
+/// from a structural (non-FP) perspective.
 ///
 /// Pure arithmetic, bitwise, comparison, cast, and select instructions are
 /// eligible.  Phi nodes are excluded — their incoming-block semantics are
@@ -131,6 +136,31 @@ fn is_hoist_safe(kind: &InstrKind) -> bool {
     )
 }
 
+/// Returns true if a floating-point instruction is safe to hoist out of a
+/// loop.  IEEE-754 requires FP operations to execute in program order unless
+/// the instruction carries `reassoc` or `fast` flags.
+///
+/// In strictfp mode (function-level attribute) ALL FP hoisting is blocked
+/// regardless of per-instruction flags, because strict mode mandates exact
+/// program-order semantics.
+fn is_fp_hoist_safe(kind: &InstrKind, strictfp_mode: bool) -> bool {
+    match kind {
+        InstrKind::FAdd { flags, .. }
+        | InstrKind::FSub { flags, .. }
+        | InstrKind::FMul { flags, .. }
+        | InstrKind::FDiv { flags, .. }
+        | InstrKind::FRem { flags, .. }
+        | InstrKind::FNeg { flags, .. } => {
+            if strictfp_mode {
+                false // strict mode: never hoist FP ops
+            } else {
+                flags.reassoc || flags.fast
+            }
+        }
+        _ => true, // non-FP instructions not affected by this check
+    }
+}
+
 /// Build a map from `InstrId` → the `BlockId` that contains it (all blocks).
 fn build_instr_to_block(func: &Function) -> Vec<Option<BlockId>> {
     let n = func.instructions.len();
@@ -153,14 +183,22 @@ fn build_instr_to_block(func: &Function) -> Vec<Option<BlockId>> {
 
 /// Returns true if `iid`'s instruction is loop-invariant with respect to
 /// `loop_body`, given a precomputed `instr_to_block` mapping.
+///
+/// `strictfp_mode` gates the IEEE-754 hoisting rule for FP instructions.
 fn is_loop_invariant(
     func: &Function,
     iid: InstrId,
     loop_body: &HashSet<BlockId>,
     instr_to_block: &[Option<BlockId>],
+    strictfp_mode: bool,
 ) -> bool {
     let instr = func.instr(iid);
     if !is_hoist_safe(&instr.kind) {
+        return false;
+    }
+    // IEEE-754 strictness check: FP instructions may not be hoisted unless
+    // their flags explicitly allow reordering.
+    if !is_fp_hoist_safe(&instr.kind, strictfp_mode) {
         return false;
     }
     for operand in instr.kind.operands() {
@@ -198,6 +236,7 @@ fn hoist_one_round(
     func: &mut Function,
     loop_body: &HashSet<BlockId>,
     preheader: BlockId,
+    strictfp_mode: bool,
 ) -> bool {
     let instr_to_block = build_instr_to_block(func);
 
@@ -213,7 +252,7 @@ fn hoist_one_round(
     for bid in sorted_body {
         let body_snapshot: Vec<InstrId> = func.blocks[bid.0 as usize].body.clone();
         for iid in body_snapshot {
-            if is_loop_invariant(func, iid, loop_body, &instr_to_block) {
+            if is_loop_invariant(func, iid, loop_body, &instr_to_block, strictfp_mode) {
                 candidates.push((bid, iid));
             }
         }

--- a/src/llvm-transforms/tests/strict_fp.rs
+++ b/src/llvm-transforms/tests/strict_fp.rs
@@ -1,0 +1,375 @@
+//! Tests for strict IEEE-754 FP mode — barriers in GVN, LICM, and
+//! constant folding, plus `strictfp` function attribute round-trip.
+
+use llvm_ir::{
+    ArgId, BlockId, Builder, Context, FastMathFlags, InstrKind, Instruction, Linkage,
+    Module, TypeId, ValueRef,
+};
+use llvm_transforms::{
+    gvn::Gvn,
+    licm::Licm,
+    pass::FunctionPass,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a minimal f64 two-arg function `f(f64 %a, f64 %b) -> f64`.
+fn make_f64_two_arg_fn() -> (Context, Module) {
+    let mut ctx = Context::new();
+    let mut module = Module::new("test");
+    let f64_ty = ctx.f64_ty;
+    let mut b = Builder::new(&mut ctx, &mut module);
+    b.add_function(
+        "f",
+        f64_ty,
+        vec![f64_ty, f64_ty],
+        vec!["a".into(), "b".into()],
+        false,
+        Linkage::External,
+    );
+    let entry = b.add_block("entry");
+    b.position_at_end(entry);
+    drop(b);
+    (ctx, module)
+}
+
+/// Append a non-terminator instruction to block 0 of function 0.
+fn push_instr(module: &mut Module, name: &str, ty: TypeId, kind: InstrKind) -> ValueRef {
+    let f = &mut module.functions[0];
+    let iid = f.alloc_instr(Instruction::new(Some(name.into()), ty, kind));
+    f.blocks[0].body.push(iid);
+    ValueRef::Instruction(iid)
+}
+
+/// Set the `ret` terminator of block 0, function 0.
+fn set_ret(ctx: &Context, module: &mut Module, val: ValueRef) {
+    let void_ty = ctx.void_ty;
+    let f = &mut module.functions[0];
+    let tid = f.alloc_instr(Instruction::new(
+        None,
+        void_ty,
+        InstrKind::Ret { val: Some(val) },
+    ));
+    f.blocks[0].set_terminator(tid);
+}
+
+/// Count body (non-terminator) instructions in block `bid` of function 0.
+fn body_len(module: &Module, bid: BlockId) -> usize {
+    module.functions[0].blocks[bid.0 as usize].body.len()
+}
+
+fn flags_none() -> FastMathFlags {
+    FastMathFlags::default()
+}
+
+fn flags_reassoc() -> FastMathFlags {
+    FastMathFlags { reassoc: true, ..Default::default() }
+}
+
+// ---------------------------------------------------------------------------
+// 1. GVN does NOT CSE two identical fadds with no fast-math flags
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gvn_does_not_cse_strict_fadd() {
+    let (mut ctx, mut module) = make_f64_two_arg_fn();
+    let f64_ty = ctx.f64_ty;
+    let a = ValueRef::Argument(ArgId(0));
+    let b = ValueRef::Argument(ArgId(1));
+
+    // %x1 = fadd double %a, %b    (no flags)
+    let _x1 = push_instr(
+        &mut module,
+        "x1",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_none(), lhs: a, rhs: b },
+    );
+    // %x2 = fadd double %a, %b    (identical, no flags)
+    let x2 = push_instr(
+        &mut module,
+        "x2",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_none(), lhs: a, rhs: b },
+    );
+    set_ret(&ctx, &mut module, x2);
+
+    // Before GVN: 2 body instructions.
+    assert_eq!(body_len(&module, BlockId(0)), 2, "before GVN: 2 fadds");
+
+    let mut pass = Gvn;
+    let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+
+    // GVN must NOT fire: strict FP forbids CSE.
+    assert!(
+        !changed,
+        "GVN must not CSE strict (no-FMF) fadds"
+    );
+    assert_eq!(
+        body_len(&module, BlockId(0)),
+        2,
+        "both fadds must remain after GVN"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. GVN DOES CSE two identical fadds that carry reassoc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gvn_cse_fadd_with_reassoc() {
+    let (mut ctx, mut module) = make_f64_two_arg_fn();
+    let f64_ty = ctx.f64_ty;
+    let a = ValueRef::Argument(ArgId(0));
+    let b = ValueRef::Argument(ArgId(1));
+
+    // %x1 = fadd reassoc double %a, %b
+    let _x1 = push_instr(
+        &mut module,
+        "x1",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+    );
+    // %x2 = fadd reassoc double %a, %b  (identical)
+    let x2 = push_instr(
+        &mut module,
+        "x2",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+    );
+    set_ret(&ctx, &mut module, x2);
+
+    assert_eq!(body_len(&module, BlockId(0)), 2, "before GVN: 2 fadds");
+
+    let mut pass = Gvn;
+    let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+
+    // GVN must fire: reassoc flag allows CSE.
+    assert!(changed, "GVN must CSE reassoc fadds");
+    assert_eq!(
+        body_len(&module, BlockId(0)),
+        1,
+        "second reassoc fadd must be eliminated by GVN"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. LICM does NOT hoist a strict fadd (no FMF)
+// ---------------------------------------------------------------------------
+
+/// Build a simple loop:
+///   entry → header → body → (back to header) / exit
+///
+/// The body contains:
+///   %fp_inv = fadd <flags> double %a, %b  (loop-invariant FP op)
+///   %i_next = add i32 %i, 1               (loop-variant)
+///
+/// Returns (ctx, module, body_block_id).
+fn build_fp_invariant_loop(flags: FastMathFlags) -> (Context, Module, BlockId) {
+    let mut ctx = Context::new();
+    let mut module = Module::new("test");
+    let f64_ty = ctx.f64_ty;
+    let i32_ty = ctx.i32_ty;
+
+    let mut b = Builder::new(&mut ctx, &mut module);
+    b.add_function(
+        "f",
+        i32_ty,
+        vec![i32_ty, f64_ty, f64_ty],
+        vec!["n".into(), "a".into(), "b".into()],
+        false,
+        Linkage::External,
+    );
+
+    let entry = b.add_block("entry");
+    let header = b.add_block("header");
+    let body = b.add_block("body");
+    let exit_bb = b.add_block("exit");
+
+    let c0 = b.const_int(i32_ty, 0);
+    let c1 = b.const_int(i32_ty, 1);
+    let n = b.get_arg(0);
+    let a_fp = b.get_arg(1);
+    let b_fp = b.get_arg(2);
+
+    b.position_at_end(entry);
+    b.build_br(header);
+
+    b.position_at_end(header);
+    let i_phi = b.build_phi("i", i32_ty, vec![(c0, entry)]);
+    let cmp = b.build_icmp("cmp", llvm_ir::IntPredicate::Slt, i_phi, n);
+    b.build_cond_br(cmp, body, exit_bb);
+
+    b.position_at_end(body);
+    // The FP op: loop-invariant (operands are function args), but only safe
+    // to hoist when flags allow it.
+    let _fp_inv = b.build_fadd("fp_inv", a_fp, b_fp);
+    let _i_next = b.build_add("i_next", i_phi, c1);
+    b.build_br(header);
+
+    b.position_at_end(exit_bb);
+    b.build_ret(c0);
+    drop(b);
+
+    // Patch back-edge into phi.
+    {
+        let i_phi_iid = module.functions[0].value_names["i"];
+        let i_next_iid = module.functions[0].value_names["i_next"];
+        if let InstrKind::Phi { incoming, .. } =
+            &mut module.functions[0].instructions[i_phi_iid.0 as usize].kind
+        {
+            incoming.push((ValueRef::Instruction(i_next_iid), body));
+        }
+    }
+
+    // Overwrite the fadd flags to the desired value.
+    {
+        let fp_inv_iid = module.functions[0].value_names["fp_inv"];
+        if let InstrKind::FAdd { flags: ref mut f, .. } =
+            &mut module.functions[0].instructions[fp_inv_iid.0 as usize].kind
+        {
+            *f = flags;
+        }
+    }
+
+    (ctx, module, body)
+}
+
+#[test]
+fn licm_does_not_hoist_strict_fadd() {
+    let (mut ctx, mut module, body) = build_fp_invariant_loop(flags_none());
+
+    // Before LICM: body has fp_inv + i_next = 2 instrs.
+    assert_eq!(
+        module.functions[0].blocks[body.0 as usize].body.len(),
+        2,
+        "before LICM: body should have 2 instrs"
+    );
+
+    let mut pass = Licm;
+    let _changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+
+    // fp_inv must NOT be hoisted: no FMF flags → strict FP semantics.
+    let fp_inv_id = module.functions[0].value_names["fp_inv"];
+    assert!(
+        module.functions[0].blocks[body.0 as usize].body.contains(&fp_inv_id),
+        "%fp_inv must NOT be hoisted out of the loop (no fast-math flags)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. LICM DOES hoist a fadd with reassoc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn licm_hoists_fadd_with_reassoc() {
+    let (mut ctx, mut module, body) = build_fp_invariant_loop(flags_reassoc());
+
+    let mut pass = Licm;
+    let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+
+    assert!(changed, "LICM must report a change when hoisting reassoc fadd");
+
+    // fp_inv must be hoisted out of the body.
+    let fp_inv_id = module.functions[0].value_names["fp_inv"];
+    assert!(
+        !module.functions[0].blocks[body.0 as usize].body.contains(&fp_inv_id),
+        "%fp_inv must be hoisted out of the loop when reassoc is set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. strictfp function attribute round-trips through printer + parser
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strictfp_function_attr_round_trips() {
+    use llvm_ir::printer::Printer;
+    use llvm_ir_parser::parser::parse;
+
+    let mut ctx = Context::new();
+    let mut module = Module::new("test");
+    let f64_ty = ctx.f64_ty;
+    {
+        let mut b = Builder::new(&mut ctx, &mut module);
+        b.add_function(
+            "strict_fn",
+            f64_ty,
+            vec![f64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
+        let entry = b.add_block("entry");
+        b.position_at_end(entry);
+        let x = b.get_arg(0);
+        b.build_ret(x);
+    }
+    // Mark the function as strictfp.
+    module.functions[0].strictfp = true;
+
+    // Print to .ll text.
+    let printer = Printer::new(&ctx);
+    let ll = printer.print_module(&module);
+
+    assert!(
+        ll.contains("strictfp"),
+        "printed .ll must contain 'strictfp' when function.strictfp = true; got:\n{}",
+        ll
+    );
+
+    // Parse back.
+    let (ctx2, module2) = parse(&ll).expect("should re-parse successfully");
+
+    assert!(
+        module2.functions[0].strictfp,
+        "parsed function must have strictfp=true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. strictfp function-level override blocks FP CSE even when reassoc is set
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strictfp_blocks_fp_cse_entirely() {
+    let (mut ctx, mut module) = make_f64_two_arg_fn();
+    let f64_ty = ctx.f64_ty;
+    let a = ValueRef::Argument(ArgId(0));
+    let b = ValueRef::Argument(ArgId(1));
+
+    // Both fadds carry reassoc (which normally makes them CSE-able).
+    push_instr(
+        &mut module,
+        "x1",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+    );
+    let x2 = push_instr(
+        &mut module,
+        "x2",
+        f64_ty,
+        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+    );
+    set_ret(&ctx, &mut module, x2);
+
+    // Mark the function as strictfp — this overrides per-instruction flags.
+    module.functions[0].strictfp = true;
+
+    assert_eq!(body_len(&module, BlockId(0)), 2, "before GVN: 2 fadds");
+
+    let mut pass = Gvn;
+    let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
+
+    // GVN must NOT fire because strictfp_mode=true overrides all FP CSE.
+    assert!(
+        !changed,
+        "GVN must not CSE any FP ops in a strictfp function, even with reassoc"
+    );
+    assert_eq!(
+        body_len(&module, BlockId(0)),
+        2,
+        "both fadds must remain in a strictfp function"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `pub strictfp: bool` to `Function` struct (printer, parser, bitcode round-trip, inline propagation)
- GVN: FP CSE blocked when per-instruction flags lack `reassoc`/`fast`; all FP CSE suppressed in `strictfp` functions
- LICM: FP hoisting blocked unless `reassoc`/`fast`; all FP hoisting suppressed in `strictfp` functions
- ConstProp: also calls `try_fold_fp`; in `strictfp` mode, refuses to fold FP ops that would produce NaN or Inf at compile time

## Changes

| File | What changed |
|------|--------------|
| `llvm-ir/src/function.rs` | `pub strictfp: bool` field, default `false` |
| `llvm-ir/src/printer.rs` | Emits `strictfp` keyword after `)` when set |
| `llvm-ir-parser/src/parser.rs` | `skip_trailing_fn_attrs` returns `bool`; sets `func.strictfp` |
| `llvm-bitcode/src/writer.rs` | Appends `strictfp` byte to function record |
| `llvm-bitcode/src/reader.rs` | Reads optional `strictfp` byte (missing → `false`) |
| `llvm-transforms/src/inline_pass.rs` | Propagates `strictfp` from callee to caller on inlining |
| `llvm-transforms/src/gvn.rs` | `fp_cse_safe`, `cse_allowed`, `strictfp_mode` parameter |
| `llvm-transforms/src/licm.rs` | `is_fp_hoist_safe`, `strictfp_mode` parameter threading |
| `llvm-transforms/src/const_prop.rs` | Calls `try_fold_fp`; rejects NaN/Inf folds in `strictfp` mode |
| `llvm-transforms/tests/strict_fp.rs` | 6 new tests |

## Test plan

- [x] `cargo test --workspace` — all green (no regressions)
- [x] `gvn_does_not_cse_strict_fadd` — two identical no-FMF `fadd`s are NOT CSE'd
- [x] `gvn_cse_fadd_with_reassoc` — `reassoc` fadds ARE CSE'd
- [x] `licm_does_not_hoist_strict_fadd` — no-FMF `fadd` stays in loop body
- [x] `licm_hoists_fadd_with_reassoc` — `reassoc` `fadd` is hoisted to preheader
- [x] `strictfp_function_attr_round_trips` — printed `.ll` contains `strictfp`; parsed back correctly
- [x] `strictfp_blocks_fp_cse_entirely` — function-level `strictfp` blocks CSE even when `reassoc` is set
- [x] All existing GVN integer-op tests still pass (CSE still fires for integer ops)
- [x] All existing LICM tests still pass (non-FP invariants still hoisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)