### PR TITLE
[codex] Document production support boundaries for Milestone W

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Release-readiness documentation for the first public crate release.
 - A SemVer policy covering the pre-1.0 series, the 1.0 readiness bar, and post-1.0 compatibility rules.
+- Production support-boundary documentation covering constrained pilots, unsupported general LLVM replacement use, unsupported untrusted-input use, backend/platform limits, and the pre-1.0 API stability matrix.
+- Documentation-truth checks for stale README/changelog status markers and release metadata.
 
 ### Milestone L — API & documentation polish
 
@@ -22,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `hello_world.rs` and `opt_pipeline.rs` examples to the `llvm-in-rust` crate (`src/llvm/examples/`).
 - Added a "Quick Start" section to `README.md` with a 30-line end-to-end builder + optimizer snippet.
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2026-05-13
 
 Initial public release candidate for the safe-Rust LLVM pipeline.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ members = [
     "examples/tikv_jit",
     "bench/fuzz",
 ]
+
+[workspace.package]
+license = "Apache-2.0"
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"

--- a/LICENSE
+++ b/LICENSE
@@ -162,6 +162,17 @@
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
    Copyright 2024 LLVM-in-Rust Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -50,24 +50,25 @@ elimination (`opt_pipeline.rs`) and a full hello-world IR program (`hello_world.
 
 ## Status
 
-Core roadmap phases are implemented and actively extended. Current workspace test inventory is **523 tests (all passing)**.
+LLVM-in-Rust is in a production-readiness stage, not a general drop-in LLVM
+replacement. Milestones A-U in the production roadmap are complete; the
+2026-05-26 audit added release-blocking follow-up Milestones V-Z before any
+general production-ready declaration.
 
-| Phase | What | Status |
-|-------|------|--------|
-| 1 | IR foundation — types, values, instructions, builder, printer, `.ll` parser | Done |
-| 2 | Analysis — CFG, dominator tree, use-def chains, loop detection | Done |
-| 3 | Optimization — mem2reg, DCE, constant folding/propagation, inlining | Done |
-| 4 | x86_64 backend — instruction selection, register allocation, object emission | Done |
-| 5 | AArch64 backend + LRIR reader/writer | Done |
-| 6 | Debug + unwind hardening (DWARF5 sections, `.eh_frame`, `.xdata/.pdata`, verifier-oriented tests) | Done |
-| 7 | SIMD/FP expansion (feature-gated SSE4.2/AVX2/AVX-512F vector lowering paths) | Done |
-| 8 | LTO baseline (IR payload embedding in objects + link-time cross-module re-optimization path) | Done |
+| Use case | Status | Boundary |
+|---|---|---|
+| Constrained production pilots | Supported with controls | Trusted LLVM 15+ opaque-pointer IR, pinned commits/releases, green release-blocking CI, and an explicitly supported backend/object-format combination. |
+| General LLVM replacement | Not supported yet | The project still has open V-Z audit follow-ups, backend contract gaps, and RC burn-in requirements. |
+| Untrusted or adversarial input | Not supported without sandboxing | Parser, optimizer, codegen, and JIT paths must run behind external process/container isolation, CPU/memory limits, and JIT disablement where inputs are not trusted. |
 
-### Recently completed milestones
+The workspace test inventory changes frequently and is intentionally not
+hard-coded here. Treat CI plus the validation commands in
+[`docs/production_operations.md`](docs/production_operations.md) as the current
+source of truth for release-blocking quality status.
 
-- **DWARF / unwind completeness:** frame-aware unwind metadata emission with structural and tool-backed verification (`readelf`, `llvm-dwarfdump`, `llvm-readobj` where available).
-- **SIMD/FP widening:** x86 lowering now includes explicit width/feature gating for SSE4.2, AVX2, and AVX-512F paths with fallback safety tests.
-- **LTO-ready flow:** top-level `llvm::lto` helpers now support embedding/recovering LRIR payloads and running cross-module optimization at link time.
+See [`docs/production_support_boundaries.md`](docs/production_support_boundaries.md)
+for the public support contract, API stability matrix, and backend/platform
+boundaries.
 
 ---
 
@@ -76,10 +77,13 @@ Core roadmap phases are implemented and actively extended. Current workspace tes
 LLVM-in-Rust follows [Semantic Versioning](https://semver.org/) with an explicit pre-1.0 stability policy:
 
 - **`0.x.y` releases:** no public API stability guarantee. Any `0.x` minor-version bump may include breaking public API changes as the IR model, pass interfaces, and backend traits continue to mature.
-- **`1.0.0` readiness:** the project will not declare a stable 1.0 API until at least one real compiler frontend integration is validated end-to-end, all Milestone B IR coverage gaps are closed, and COFF object emission is complete.
+- **`1.0.0` readiness:** the project will not declare a stable 1.0 API until the production-readiness roadmap's V-Z follow-up milestones are complete, release-candidate burn-in has passed, and maintainers have signed off at least one constrained production pilot with documented fallback.
 - **Post-1.0 releases:** standard SemVer rules apply. Breaking API changes are reserved for major versions and include a documented deprecation/migration cycle.
 
-Release notes live in [CHANGELOG.md](CHANGELOG.md); the `v0.1.0` GitHub release should link to the [`0.1.0` changelog entry](CHANGELOG.md#010---unreleased).
+The pre-1.0 API stability matrix lives in
+[`docs/production_support_boundaries.md`](docs/production_support_boundaries.md#pre-10-api-stability-matrix).
+Release notes live in [CHANGELOG.md](CHANGELOG.md); the `v0.1.0` GitHub release
+links to the [`0.1.0` changelog entry](CHANGELOG.md#010---2026-05-13).
 
 ---
 
@@ -137,8 +141,10 @@ Benchmarks use Criterion and run on stable Rust; no nightly-only bench harness i
   of IR instructions). At that scale LLVM's mature optimisations will outperform this project.
   These benchmarks target the small-module embedded-library use case.
 
-- **Code quality**: this project does not attempt to produce code as optimised as LLVM `-O2`.
-  The codegen benchmarks compare `-O0` (unoptimised) compilation speed only.
+- **Code quality**: the repository has deterministic codegen, large-program,
+  and performance-budget gates, but it does not claim broad LLVM `-O2` parity.
+  Treat output quality as scoped to the backend and workload contract documented
+  in the production support boundaries.
 
 ---
 
@@ -156,7 +162,8 @@ This project is a **standalone re-implementation**, not a wrapper around LLVM. "
 | 17 | Compatible | Compatible |
 | 18 – 22 | Compatible | Compatible |
 
-**Current LLVM stable release:** 22.1.0 (February 2026)
+This table records the parser/printer compatibility target, not a claim about
+the latest upstream LLVM release.
 
 ### Key IR feature versions
 
@@ -170,13 +177,17 @@ This project is a **standalone re-implementation**, not a wrapper around LLVM. "
 | Fast-math flags (`nnan`, `ninf`, `fast`, …) | **Yes** | LLVM 3.1 |
 | Tail-call kinds (`tail`, `musttail`, `notail`) | **Yes** | LLVM 3.0 |
 | `fneg` instruction | **Yes** | LLVM 9 |
-| `freeze` instruction | **No** | LLVM 10 |
-| `vp.*` vector-predication intrinsics | **No** | LLVM 11 |
+| `freeze` instruction | **Yes** | LLVM 10 |
+| `vp.*` vector-predication intrinsics | **Yes** — recognized as intrinsic calls and lowered through implemented vector paths | LLVM 11 |
+| Inline assembly | **Partial** — parse/print plus `nop` template lowering on x86-64/AArch64 | LLVM IR feature |
+| Atomics (`fence`, `cmpxchg`, `atomicrmw`) | **Yes** — backend coverage varies by target and operation | LLVM IR feature |
+| EH paths (`invoke`, `landingpad`, funclet pads) | **Partial** — IR round-trip and metadata/object support are present; runtime language interop remains experimental | LLVM IR feature |
 
 ### What this means in practice
 
 - **Reading LLVM 15+ output:** `.ll` files generated by `clang -S -emit-llvm` with LLVM 15 or
-  later can be parsed directly by `llvm-ir-parser`.
+  later are accepted for the implemented subset. Unsupported IR constructs should fail with
+  diagnostics rather than being treated as a production-supported path.
 - **Reading LLVM ≤14 output:** Not supported. LLVM 14 and earlier emit typed-pointer syntax
   (`i32*`, `i8**`) that this parser does not recognise. Pass those files through
   `opt --opaque-pointers -S` with LLVM 15 to upgrade them first.
@@ -694,17 +705,14 @@ Inline assembly support is intentionally small in v0.1.x: textual IR can parse
 and print LLVM-style inline asm calls such as `call void asm sideeffect "nop", ""()`,
 and x86-64/AArch64 lowering recognizes `nop` templates for direct machine-byte
 emission. Constraint solving, output operands, and register allocation across
-asm operands are not implemented yet; unsupported templates conservatively emit
-NOP bytes instead of attempting to assemble arbitrary text.
+general asm operands remain outside the production support contract.
 
-Exception-handling IR support covers the core `invoke`/`landingpad` shape used
-by Itanium-style unwinding: the parser, printer, binary IR round-trip, CFG
-successors, value rewriting, and tier-1 backends all preserve the normal and
-unwind edges. Lowering emits a normal call edge and keeps landingpad values
-defined conservatively while `.eh_frame`/personality integration matures.
-Windows SEH remains limited to the existing `.pdata`/`.xdata` and CodeView/PDB
-building blocks; full `landingpad` lowering to SEH funclets is not implemented
-yet.
+Exception-handling IR support covers the core `invoke`/`landingpad` and funclet
+shapes used by Itanium-style and Windows-style unwinding: the parser, printer,
+binary IR round-trip, CFG successors, value rewriting, LSDA/xdata builders, and
+tier-1 backends preserve the relevant edges and metadata. Cross-language runtime
+throw/catch behavior remains experimental and is scoped in
+[`docs/unwind_compatibility_matrix.md`](docs/unwind_compatibility_matrix.md).
 
 macOS (Mach-O):
 

--- a/bench/fuzz/Cargo.toml
+++ b/bench/fuzz/Cargo.toml
@@ -6,6 +6,8 @@ license = "Apache-2.0"
 publish = false
 
 description = "Differential fuzzing harness: random IR generation + JIT output comparison."
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"
 
 [lib]
 name = "fuzz_diff"

--- a/bench/rustc-backend-validation/Cargo.toml
+++ b/bench/rustc-backend-validation/Cargo.toml
@@ -2,6 +2,11 @@
 name = "rustc-backend-validation"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+publish = false
+description = "Validation fixture for the LLVM-in-Rust rustc backend smoke path."
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"
 
 [profile.dev]
 codegen-units = 1

--- a/docs/production_operations.md
+++ b/docs/production_operations.md
@@ -8,6 +8,9 @@ Issue #186 tracks the operator and contributor playbooks for running LLVM-in-Rus
 - **Contributors** triaging parser, optimizer, codegen, performance, or compatibility reports.
 - **Release owners** connecting incident response back to RC and rollback decisions.
 
+Before using this guide for a production pilot, review the scoped support
+contract in [`docs/production_support_boundaries.md`](production_support_boundaries.md).
+
 ## Build and validation quick start
 
 Use locked dependencies and the same gates CI runs:
@@ -116,6 +119,7 @@ Minimize with `scripts/reduce_ci_failure.sh`, attach the evidence package, and s
 
 ## Runbook index
 
+- Production support boundaries: `docs/production_support_boundaries.md`
 - Release artifacts: `docs/release_artifact_pipeline.md`
 - RC and rollback: `docs/release_candidate_protocol.md`
 - Crash and miscompilation triage: `docs/crash_triage_runbook.md`

--- a/docs/production_support_boundaries.md
+++ b/docs/production_support_boundaries.md
@@ -1,0 +1,54 @@
+# Production Support Boundaries
+
+This document is the public support contract for the pre-1.0 series. It
+distinguishes constrained production pilots from general production readiness
+and from unsupported deployment modes.
+
+## Production Scope
+
+| Scenario | Status | Requirements and limits |
+|---|---|---|
+| Constrained internal or pilot workload | Supported with controls | Trusted LLVM 15+ opaque-pointer IR; pinned LLVM-in-Rust commit or release; target/backend selected from the matrix below; release-blocking CI green on that commit; fallback to upstream LLVM documented by the embedding project. |
+| General drop-in replacement for LLVM | Not supported | LLVM IR, backend, runtime, and platform coverage are broad but not complete. Milestones V-Z in #93 must complete before a general production-ready declaration. |
+| Untrusted or adversarial IR/object input | Not supported without sandboxing | Run parser, optimizer, codegen, and JIT paths in a separate process/container with CPU, memory, file-system, and wall-clock limits. Disable JIT for hostile input unless the host already has a hardened executable-memory policy. |
+| Research, benchmarking, and compiler experiments | Supported | APIs and behavior may change across `0.x` minor releases; pin revisions and record validation commands when publishing results. |
+
+## Pre-1.0 API Stability Matrix
+
+| Surface | Stability | Breaking-change policy |
+|---|---|---|
+| Core IR data model (`llvm-ir` types, values, modules, builder, printer) | Stable enough for pinned pilot use | Patch releases avoid intentional breaks. `0.x` minor releases may rename fields, variants, or builders when needed for correctness; migration notes go in the changelog. |
+| LLVM text parser and printer (`llvm-ir-parser`, `Printer`) | Stable enough for the documented LLVM 15+ subset | Accepted syntax may expand in patch/minor releases. Rejections for unsupported constructs are not considered API breaks. |
+| Pass manager and public transforms (`llvm-transforms`) | Experimental | Pass ordering, analysis invalidation, and optimization behavior may change in any `0.x` minor release. |
+| Codegen, backend, object emission, and JIT crates | Experimental | Machine IR, relocation handling, register allocation, and executable-memory behavior can change while backend support contracts are finalized. |
+| LRIR binary format and LLVM bitstream reader | Experimental | Format versions may change before 1.0. Persist text `.ll` when long-term compatibility is required. |
+| rustc backend, Wasm backend, sanitizer passes, PGO/LTO helpers | Experimental | Usable for smoke tests and pilots only where the corresponding support table cell says "pilot" or "experimental". |
+| Internal crates, scripts, fixtures, and golden baselines | Internal | No compatibility promise. These can change whenever CI, minimization, or benchmark infrastructure changes. |
+
+## Backend and Platform Boundaries
+
+| Area | Current production contract | Known limits |
+|---|---|---|
+| x86-64 native backend | Pilot-supported for trusted IR through the tested integer, FP/SIMD, atomics, calls, object emission, debug, unwind, LTO, and JIT paths. SysV and Win64 ABI coverage are both represented in tests. | Not a general LLVM `-O2` quality replacement. Inline asm constraints, exotic relocations, and cross-language EH runtime behavior remain scoped/experimental. |
+| AArch64 backend | Pilot-supported for trusted IR object generation and tested integer, FP/SIMD, atomics, calls, debug, unwind metadata, and LTO payload paths. | Runtime execution coverage is narrower than x86-64. Full platform-linker and language EH interop require the Milestone Y support-contract matrix. |
+| RISC-V RV64GC backend | Experimental pilot support for artifact generation, integer/FP calling convention subsets, atomics, object emission, and backend tests. | Runtime linker/execution coverage and some lowering quality paths remain under Milestone Y. |
+| WebAssembly backend | Experimental. Can emit wasm modules for simple functions and supported control-flow shapes. | Arbitrary CFG/relooper completeness, stack-frame allocation for `alloca`, loop phi destruction, indirect calls, external imports, FP/vector/atomic breadth, and host execution contracts are not production-supported yet. |
+| JIT execution engine | Experimental x86-64 pilot surface for trusted IR in controlled hosts. | Uses executable memory. Do not expose to untrusted input without process isolation and host-level memory-execution policy. Keep JIT smoke and differential tests green before any pilot sign-off. |
+| rustc backend | Experimental proof-of-concept/staged backend driver. Stable-compatible shim tests and nightly lanes exist. | Real `rustc_private`/`rustc_codegen_ssa` integration and nightly-driver support are not a general production backend contract. |
+| LTO | Pilot-supported for embedding and recovering LRIR payloads in ELF/COFF (`.llvmbc`, `.llvmcmd`) and Mach-O (`__LLVM,__bitcode`, `__LLVM,__cmdline`) objects. | LRIR is project-specific and not LLVM bitcode. Cross-toolchain LTO compatibility with upstream LLVM is not supported. |
+| Debug and unwind | Pilot-supported metadata/object sections include DWARF line/info/loclist paths, ELF `.eh_frame`, COFF `.pdata`/`.xdata`, and CodeView `.debug$S` where implemented. | Unwind data is not a full language-runtime EH guarantee. Mach-O unwind parity and cross-language throw/catch interop remain experimental. |
+| ELF | Pilot-supported for the primary native-object paths and CI/tool-backed checks. | Unsupported or target-specific relocations must be documented as known issues before release sign-off. |
+| Mach-O | Pilot-supported for object emission and selected debug/LTO paths. | Unwind parity is narrower than ELF/COFF, and platform execution coverage must be explicitly checked for each pilot. |
+| COFF | Pilot-supported for x86-64/Windows object emission, Win64 ABI hardening, CodeView/PDB milestones, `.pdata`/`.xdata`, and Windows CI paths. | Full SEH funclet runtime parity and non-x86 Windows targets remain outside the current production contract. |
+| Known unsupported cases | Unsupported unless a linked issue or known-issue entry says otherwise | LLVM <=14 typed-pointer IR, arbitrary unsupported intrinsics, unrestricted inline asm, hostile inputs without sandboxing, unsupported relocation/linker combinations, and production use of any matrix cell marked experimental. |
+
+## Documentation Truth Policy
+
+- README status language must stay scoped: "pilot-supported" and "production-ready"
+  are not interchangeable.
+- Hard-coded test counts are avoided in public status text. CI and the validation
+  commands in `docs/production_operations.md` are the current quality signal.
+- Feature tables must distinguish IR parse/round-trip support from backend
+  lowering, runtime execution, and platform-linker support.
+- Each production-readiness milestone in #93 should close only after its PRs are
+  merged, tests are green, and the roadmap issue is updated with the final status.

--- a/docs/rustc-backend-gap-analysis.md
+++ b/docs/rustc-backend-gap-analysis.md
@@ -1,5 +1,10 @@
 # rustc Codegen Backend Gap Analysis
 
+> Historical note: this document records the original gap analysis that guided
+> the staged rustc-backend work. For the current production support contract and
+> pre-1.0 stability boundaries, see
+> [`docs/production_support_boundaries.md`](production_support_boundaries.md).
+
 This document records the gap between the current LLVM-in-Rust pipeline and a
 production-grade `rustc_codegen_ssa` backend, capturing every blocking item and
 the estimated effort to close it.

--- a/examples/tikv_jit/Cargo.toml
+++ b/examples/tikv_jit/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 description = "Example: using LLVM-in-Rust as a JIT backend for expression evaluation (TiKV-style coprocessor predicates)"
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"
 
 [dependencies]
 llvm-ir         = { version = "0.1.0", package = "llvm-in-rust-ir", path = "../../src/llvm-ir" }

--- a/scripts/production_ops_docs.sh
+++ b/scripts/production_ops_docs.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOC="$ROOT/docs/production_operations.md"
+SUPPORT_DOC="$ROOT/docs/production_support_boundaries.md"
 README="$ROOT/README.md"
+CHANGELOG="$ROOT/CHANGELOG.md"
+LICENSE_FILE="$ROOT/LICENSE"
+MANIFEST="$ROOT/Cargo.toml"
 
 require_in_doc() {
   local needle="$1"
@@ -21,7 +25,26 @@ require_in_readme() {
   fi
 }
 
+require_in_file() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "$(basename "$file") missing required text: $needle" >&2
+    exit 1
+  fi
+}
+
+reject_in_file() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    echo "$(basename "$file") contains stale text: $needle" >&2
+    exit 1
+  fi
+}
+
 [[ -f "$DOC" ]] || { echo "missing $DOC" >&2; exit 1; }
+[[ -f "$SUPPORT_DOC" ]] || { echo "missing $SUPPORT_DOC" >&2; exit 1; }
 
 require_in_doc "## Build and validation quick start"
 require_in_doc "## Observability checklist"
@@ -31,8 +54,28 @@ require_in_doc "## FAQ: common integration failures"
 require_in_doc "## Runbook index"
 require_in_doc "scripts/reduce_ci_failure.sh"
 require_in_doc "scripts/release_artifacts.sh verify"
+require_in_doc "docs/production_support_boundaries.md"
 require_in_doc "docs/release_candidate_protocol.md"
 require_in_doc "docs/crash_triage_runbook.md"
 require_in_readme "docs/production_operations.md"
+require_in_readme "docs/production_support_boundaries.md"
+
+require_in_file "$SUPPORT_DOC" "## Production Scope"
+require_in_file "$SUPPORT_DOC" "## Pre-1.0 API Stability Matrix"
+require_in_file "$SUPPORT_DOC" "## Backend and Platform Boundaries"
+require_in_file "$SUPPORT_DOC" "| x86-64 native backend |"
+require_in_file "$SUPPORT_DOC" "| WebAssembly backend |"
+require_in_file "$SUPPORT_DOC" "| Known unsupported cases |"
+require_in_file "$CHANGELOG" "## [0.1.0] - 2026-05-13"
+require_in_file "$LICENSE_FILE" "APPENDIX: How to apply the Apache License to your work."
+require_in_file "$MANIFEST" "[workspace.package]"
+require_in_file "$MANIFEST" 'license = "Apache-2.0"'
+require_in_file "$MANIFEST" 'repository = "https://github.com/yudongusa/LLVM-in-Rust"'
+
+reject_in_file "$README" "523 tests"
+reject_in_file "$README" "1,076 tests"
+reject_in_file "$README" '| `freeze` instruction | **No**'
+reject_in_file "$README" '| `vp.*` vector-predication intrinsics | **No**'
+reject_in_file "$CHANGELOG" "## [0.1.0] - Unreleased"
 
 echo "production operations docs are complete"

--- a/src/llvm-bench/Cargo.toml
+++ b/src/llvm-bench/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+description = "Criterion benchmark harness for LLVM-in-Rust pipeline stages."
+repository = "https://github.com/yudongusa/LLVM-in-Rust"
+homepage = "https://github.com/yudongusa/LLVM-in-Rust"
 
 [lib]
 name = "llvm_bench"


### PR DESCRIPTION
## Summary

Closes #382.

This PR makes the public documentation agree on the same production-readiness contract:

- rewrites the README status section around constrained production pilots, unsupported general LLVM replacement use, and unsupported untrusted-input use without sandboxing
- adds `docs/production_support_boundaries.md` with the pre-1.0 API stability matrix and backend/platform support boundaries
- updates stale README feature support for `freeze`, `vp.*`, inline asm, atomics, and EH paths
- fixes `v0.1.0` changelog wording from `Unreleased` to the published release date
- adds docs checks that reject stale status markers and require the support-boundaries doc
- normalizes Apache-2.0 license/repository metadata across remaining workspace/fixture manifests and restores the canonical Apache appendix in `LICENSE`

## Validation

```bash
scripts/production_ops_docs.sh
cargo +stable metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.license != "Apache-2.0" or .repository != "https://github.com/yudongusa/LLVM-in-Rust" or .homepage != "https://github.com/yudongusa/LLVM-in-Rust") | [.name, .license, .repository, .homepage] | @tsv'
rg -n '523|1,076|1076|0\.1\.0\] - Unreleased|all milestones complete|Current LLVM stable release|\| `freeze` instruction \| \*\*No\*\*|\| `vp\.\*` vector-predication intrinsics \| \*\*No\*\*' README.md CHANGELOG.md docs Cargo.toml bench/fuzz/Cargo.toml bench/rustc-backend-validation/Cargo.toml examples/tikv_jit/Cargo.toml src/llvm-bench/Cargo.toml
cargo +stable test --locked --doc
git diff --check
```

The metadata and stale-marker commands produced no output.