### PR TITLE
[codex] Add backend support contract matrix for Milestone Y

### DIFF
--- a/.github/workflows/backend-support-contract.yml
+++ b/.github/workflows/backend-support-contract.yml
@@ -1,0 +1,35 @@
+name: Backend Support Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  backend_contract:
+    name: Backend support matrix + release smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Rust stable toolchain
+        run: |
+          rustup set profile minimal
+          rustup toolchain install stable
+          rustup default stable
+
+      - name: Validate backend support matrix
+        run: scripts/backend_support_contract.sh validate
+
+      - name: Run rustc backend stable smoke
+        run: scripts/backend_support_contract.sh rustc-smoke
+
+      - name: Run LTO release smoke
+        run: scripts/backend_support_contract.sh lto-smoke

--- a/docs/backend_support_matrix.json
+++ b/docs/backend_support_matrix.json
@@ -1,0 +1,391 @@
+{
+  "schema_version": 1,
+  "policy": "docs/backend_support_matrix.md",
+  "issue": 384,
+  "axes": [
+    "abi",
+    "calls",
+    "varargs",
+    "structs_by_value_aggregates",
+    "atomics",
+    "fp_simd",
+    "eh_unwind",
+    "debug_info",
+    "object_format",
+    "relocations",
+    "linker_execution"
+  ],
+  "targets": {
+    "x86_64": {
+      "display": "x86-64 native backend",
+      "cells": {
+        "abi": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-x86/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 abi -- --nocapture"}
+          ],
+          "notes": "SysV AMD64 and Windows x64 ABI helpers are covered by backend ABI tests."
+        },
+        "calls": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-x86/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 --lib -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/linker_compat.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test linker_compat -- --nocapture"}
+          ],
+          "notes": "Direct calls, external call relocations, and linked execution are represented in lowering/linker tests."
+        },
+        "varargs": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-ir-parser/tests/parse_basic.rs", "command": "cargo +stable test -p llvm-in-rust-ir-parser --test parse_basic parse_declaration_variadic -- --nocapture"}
+          ],
+          "limitations": "Variadic declarations and calls parse, but full va_start/va_arg lowering is not production-supported."
+        },
+        "structs_by_value_aggregates": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-x86/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 abi -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/global_emit.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test global_emit -- --nocapture"}
+          ],
+          "limitations": "Aggregate layout and ABI classification have targeted coverage; exhaustive by-value aggregate interop remains scoped by the matrix."
+        },
+        "atomics": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-x86/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 atomic -- --nocapture"},
+            {"path": "src/llvm-jit/tests/atomic_threads.rs", "command": "cargo +stable test -p llvm-in-rust-jit --test atomic_threads -- --nocapture"}
+          ],
+          "notes": "LOCK cmpxchg/xadd/xchg paths and a JIT spinlock smoke test cover the supported atomic subset."
+        },
+        "fp_simd": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-x86/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 --lib -- --nocapture"},
+            {"path": "src/llvm-target-x86/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-x86 --lib -- --nocapture"}
+          ],
+          "notes": "Scalar FP and feature-gated SIMD lowering are covered by target tests."
+        },
+        "eh_unwind": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/lsda.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test lsda -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/unwind_verify.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test unwind_verify -- --nocapture"}
+          ],
+          "limitations": "Object metadata and LSDA paths are tested; cross-language runtime throw/catch interop is still experimental."
+        },
+        "debug_info": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/dwarf_line.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test dwarf_line -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/codeview_coff.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test codeview_coff -- --nocapture"}
+          ],
+          "notes": "DWARF and CodeView/COFF debug section tests cover the documented metadata paths."
+        },
+        "object_format": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/linker_compat.rs", "command": "scripts/interoperability_conformance.sh link"},
+            {"path": "src/llvm-codegen/tests/thinlto.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test thinlto -- --nocapture"}
+          ],
+          "notes": "ELF, Mach-O, and COFF object paths are exercised by object/link and ThinLTO tests."
+        },
+        "relocations": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/global_emit.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test global_emit -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/golden_codegen.rs", "command": "LLVM_IN_RUST_DETERMINISTIC=1 cargo +stable test -p llvm-in-rust-codegen golden -- --nocapture"}
+          ],
+          "limitations": "Global and external-call relocations are tested; exotic relocation/linker combinations require explicit known-issue entries before release."
+        },
+        "linker_execution": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/linker_compat.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test linker_compat -- --nocapture"},
+            {"path": ".github/workflows/windows-e2e.yml", "command": "scripts/windows_e2e.sh"}
+          ],
+          "notes": "Linux/macOS/Windows linker execution is covered by conformance and Windows E2E workflows where tools are available."
+        }
+      }
+    },
+    "aarch64": {
+      "display": "AArch64 backend",
+      "cells": {
+        "abi": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm abi -- --nocapture"}
+          ],
+          "limitations": "AAPCS64 and HFA helpers have tests; full cross-platform runtime ABI interop is still scoped by Milestone Y."
+        },
+        "calls": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm --lib -- --nocapture"}
+          ],
+          "notes": "Direct calls lower through BLR and are covered in target lowering tests."
+        },
+        "varargs": {
+          "status": "unsupported",
+          "marker": "not_supported:aarch64-varargs",
+          "limitations": "AArch64 va_start/va_arg lowering is not part of the current production contract."
+        },
+        "structs_by_value_aggregates": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm abi -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/global_emit.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test global_emit -- --nocapture"}
+          ],
+          "limitations": "Aggregate layout and HFA classification are covered; exhaustive by-value interop remains scoped."
+        },
+        "atomics": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm atomic -- --nocapture"},
+            {"path": "src/llvm-target-arm/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm atomic -- --nocapture"}
+          ],
+          "notes": "LSE and LL/SC atomic paths are represented in lowering/encoding tests."
+        },
+        "fp_simd": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm --lib -- --nocapture"},
+            {"path": "src/llvm-target-arm/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm --lib -- --nocapture"}
+          ],
+          "limitations": "Scalar FP and selected NEON paths are covered; full SIMD/vector throughput coverage remains iterative."
+        },
+        "eh_unwind": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/lsda.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test lsda -- --nocapture"},
+            {"path": "docs/unwind_compatibility_matrix.md", "command": "scripts/interoperability_conformance.sh debug"}
+          ],
+          "limitations": "IR edge preservation and LSDA metadata are represented; runtime language EH interop is experimental."
+        },
+        "debug_info": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/dwarf_line.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test dwarf_line -- --nocapture"}
+          ],
+          "notes": "DWARF section emission has target-aware tests."
+        },
+        "object_format": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-arm/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-arm encode -- --nocapture"},
+            {"path": "scripts/platform_matrix.sh", "command": "scripts/platform_matrix.sh target-aarch64"}
+          ],
+          "limitations": "Artifact generation is gated; linked execution coverage is narrower than x86-64."
+        },
+        "relocations": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/global_emit.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test global_emit -- --nocapture"}
+          ],
+          "limitations": "Shared global relocation tests cover object-model behavior; target-specific relocation/linker gaps require known-issue entries."
+        },
+        "linker_execution": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-codegen/tests/linker_compat.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test linker_compat -- --nocapture"}
+          ],
+          "limitations": "Host/tool availability determines whether AArch64 linked execution runs; cross-host execution is not required for every PR."
+        }
+      }
+    },
+    "riscv64": {
+      "display": "RISC-V RV64GC backend",
+      "cells": {
+        "abi": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv abi -- --nocapture"}
+          ],
+          "limitations": "Integer and hardware-FP ABI subsets have tests; full psABI aggregate/varargs coverage is not complete."
+        },
+        "calls": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --lib -- --nocapture"}
+          ],
+          "limitations": "Direct calls are lowered; dynamic/runtime link execution is not a Tier-1 release requirement yet."
+        },
+        "varargs": {
+          "status": "unsupported",
+          "marker": "not_supported:riscv64-varargs",
+          "limitations": "RV64 va_start/va_arg lowering is not part of the current production contract."
+        },
+        "structs_by_value_aggregates": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/abi.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv abi -- --nocapture"},
+            {"path": "src/llvm-codegen/tests/global_emit.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test global_emit -- --nocapture"}
+          ],
+          "limitations": "Basic layout helpers are covered; exhaustive by-value aggregate interop remains scoped."
+        },
+        "atomics": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv atomic -- --nocapture"}
+          ],
+          "notes": "RISC-V A-extension lowering tests cover lr/sc and amo* paths."
+        },
+        "fp_simd": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --lib -- --nocapture"}
+          ],
+          "limitations": "F/D scalar FP paths are covered; vector extension support is outside the current production contract."
+        },
+        "eh_unwind": {
+          "status": "experimental",
+          "marker": "experimental:riscv64-eh-unwind",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --lib -- --nocapture"}
+          ],
+          "limitations": "IR edge propagation exists, but object/runtime unwind interop is not production-supported."
+        },
+        "debug_info": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/lower.rs", "command": "scripts/platform_matrix.sh target-rv64gc"}
+          ],
+          "limitations": "Debug-location propagation exists; tool-backed debugger verification is not yet equivalent to x86-64."
+        },
+        "object_format": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/encode.rs", "command": "scripts/platform_matrix.sh target-rv64gc"},
+            {"path": "src/llvm-target-riscv/tests/e2e_objdump.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --test e2e_objdump -- --nocapture"}
+          ],
+          "notes": "RV64GC ELF artifact generation is gated by the platform matrix."
+        },
+        "relocations": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --lib -- --nocapture"}
+          ],
+          "limitations": "Supported relocation forms are target-test scoped; unsupported linker combinations need explicit known issues."
+        },
+        "linker_execution": {
+          "status": "experimental",
+          "marker": "experimental:riscv64-linker-execution",
+          "evidence": [
+            {"path": "src/llvm-target-riscv/tests/e2e_objdump.rs", "command": "cargo +stable test -p llvm-in-rust-target-riscv --test e2e_objdump -- --nocapture"}
+          ],
+          "limitations": "Object inspection is tested; runtime execution is not required on every Tier-1 host."
+        }
+      }
+    },
+    "wasm32": {
+      "display": "WebAssembly backend",
+      "cells": {
+        "abi": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-wasm/src/types.rs", "command": "cargo +stable test -p llvm-in-rust-target-wasm --lib -- --nocapture"}
+          ],
+          "limitations": "Simple wasm32 value types and function locals are supported; host ABI/import contracts are not."
+        },
+        "calls": {
+          "status": "partial",
+          "evidence": [
+            {"path": "src/llvm-target-wasm/src/lower.rs", "command": "cargo +stable test -p llvm-in-rust-target-wasm --lib -- --nocapture"}
+          ],
+          "limitations": "Direct internal calls are supported; indirect calls and external imports are explicit TODOs."
+        },
+        "varargs": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-varargs",
+          "limitations": "Variadic lowering is not part of the wasm32 production contract."
+        },
+        "structs_by_value_aggregates": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-aggregates",
+          "limitations": "Aggregate ABI and by-value struct passing are not production-supported."
+        },
+        "atomics": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-atomics",
+          "limitations": "Wasm atomics are not implemented in the backend contract."
+        },
+        "fp_simd": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-fp-simd",
+          "limitations": "The wasm backend currently scopes out FP, vector, and SIMD lowering."
+        },
+        "eh_unwind": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-eh-unwind",
+          "limitations": "WebAssembly EH/unwind metadata and runtime interop are not implemented."
+        },
+        "debug_info": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-debug-info",
+          "limitations": "DWARF/source-map style debug emission is outside the current wasm support contract."
+        },
+        "object_format": {
+          "status": "supported",
+          "evidence": [
+            {"path": "src/llvm-target-wasm/src/encode.rs", "command": "cargo +stable test -p llvm-in-rust-target-wasm --lib -- --nocapture"}
+          ],
+          "notes": "The backend emits a wasm module binary, not a native object container."
+        },
+        "relocations": {
+          "status": "unsupported",
+          "marker": "not_supported:wasm32-relocations",
+          "limitations": "External imports and relocation linking are not production-supported."
+        },
+        "linker_execution": {
+          "status": "experimental",
+          "marker": "experimental:wasm32-linker-execution",
+          "evidence": [
+            {"path": "src/llvm-target-wasm/src/lib.rs", "command": "cargo +stable test -p llvm-in-rust-target-wasm --lib -- --nocapture"}
+          ],
+          "limitations": "Module encoding smoke tests exist; a wasm runtime execution lane is not release-blocking yet."
+        }
+      }
+    }
+  },
+  "release_blocking_e2e": {
+    "c_frontend": {
+      "workflow": ".github/workflows/c-frontend-integration.yml",
+      "evidence": [
+        {"path": "src/llvm/tests/compile_pipeline.rs", "command": "cargo +stable test -p llvm-in-rust --test compile_pipeline"},
+        {"path": "scripts/frontend_integration.sh", "command": "bash scripts/frontend_integration.sh"}
+      ],
+      "scope": "Representative clang -> LLVM IR -> LLVM-in-Rust codegen -> execute path."
+    },
+    "rustc_backend_smoke": {
+      "workflow": ".github/workflows/backend-support-contract.yml",
+      "evidence": [
+        {"path": "src/llvm-rustc-backend/tests/driver.rs", "command": "cargo +stable test -p llvm-in-rust-rustc-backend"},
+        {"path": "bench/rustc-backend-validation/Cargo.toml", "command": "cargo +stable test -p llvm-in-rust-rustc-backend"}
+      ],
+      "scope": "Stable shim smoke is release-blocking; nightly rustc_private wiring remains experimental."
+    },
+    "lto": {
+      "workflow": ".github/workflows/backend-support-contract.yml",
+      "evidence": [
+        {"path": "src/llvm/tests/lto_multi_tu.rs", "command": "cargo +stable test -p llvm-in-rust --test lto_multi_tu"},
+        {"path": "src/llvm-codegen/tests/thinlto.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test thinlto"}
+      ],
+      "scope": "LRIR payload embedding/recovery and top-level LTO facade smoke."
+    },
+    "debug_unwind": {
+      "workflow": ".github/workflows/interoperability-conformance.yml",
+      "evidence": [
+        {"path": "src/llvm-codegen/tests/dwarf_line.rs", "command": "scripts/interoperability_conformance.sh debug"},
+        {"path": "src/llvm-codegen/tests/unwind_verify.rs", "command": "cargo +stable test -p llvm-in-rust-codegen --test unwind_verify"}
+      ],
+      "scope": "DWARF/CodeView and unwind-object metadata checks."
+    },
+    "sanitizer_instrumented": {
+      "workflow": ".github/workflows/sanitizers.yml",
+      "evidence": [
+        {"path": "scripts/sanitizer_matrix.sh", "command": "scripts/sanitizer_matrix.sh asan-core"},
+        {"path": "scripts/sanitizer_matrix.sh", "command": "scripts/sanitizer_matrix.sh miri-core"}
+      ],
+      "scope": "PR-blocking ASan/Miri lanes plus scheduled/manual TSan lane."
+    }
+  }
+}

--- a/docs/backend_support_matrix.md
+++ b/docs/backend_support_matrix.md
@@ -1,0 +1,68 @@
+# Backend Support Matrix
+
+Issue #384 tracks the production-readiness requirement that backend maturity
+claims are explicit, test-backed, and machine-checkable.
+
+The CI-readable source of truth is
+[`docs/backend_support_matrix.json`](backend_support_matrix.json). This Markdown
+file explains how to read and maintain that fixture.
+
+## Status Values
+
+| Status | Meaning | Required fixture data |
+|---|---|---|
+| `supported` | The capability is in the scoped pilot support contract for that backend. | At least one evidence command and path. |
+| `partial` | A tested subset exists, but limitations remain. | Evidence plus a `limitations` field. |
+| `experimental` | Useful for tests or pilots, but not production-supported. | A marker such as `experimental:<area>` plus limitations. |
+| `unsupported` | Not part of the production contract. | A marker such as `not_supported:<area>` plus limitations. |
+
+The validator rejects missing cells, unsupported cells without explicit markers,
+and supported/partial cells without evidence.
+
+## Backend Matrix Summary
+
+| Target | ABI | Calls | Varargs | Aggregates | Atomics | FP/SIMD | EH/unwind | Debug info | Object format | Relocations | Link/run |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| x86-64 | supported | supported | partial | partial | supported | supported | partial | supported | supported | partial | supported |
+| AArch64 | partial | supported | unsupported | partial | supported | partial | partial | supported | partial | partial | partial |
+| RISC-V RV64GC | partial | partial | unsupported | partial | supported | partial | experimental | partial | supported | partial | experimental |
+| WebAssembly | partial | partial | unsupported | unsupported | unsupported | unsupported | unsupported | unsupported | supported | unsupported | experimental |
+
+## Release-Blocking End-to-End Evidence
+
+The fixture also names the workflows and commands that make end-to-end coverage
+visible in CI:
+
+| Area | Workflow | Scope |
+|---|---|---|
+| C frontend | `.github/workflows/c-frontend-integration.yml` | clang -> LLVM IR -> LLVM-in-Rust codegen -> execute fixtures. |
+| rustc backend smoke | `.github/workflows/backend-support-contract.yml` | Stable rustc-backend shim tests are release-blocking; nightly `rustc_private` wiring stays experimental. |
+| LTO | `.github/workflows/backend-support-contract.yml` | Top-level LTO facade and ThinLTO object payload tests. |
+| Debug/unwind | `.github/workflows/interoperability-conformance.yml` | DWARF/CodeView and unwind-object metadata checks. |
+| Sanitizer-instrumented output | `.github/workflows/sanitizers.yml` | PR-blocking ASan/Miri lanes and scheduled/manual TSan lane. |
+
+## Known Scope Decisions
+
+- Wasm TODOs are explicitly scoped as unsupported or experimental in the JSON
+  fixture: arbitrary CFG/relooper completeness, stack-frame allocation for
+  `alloca`, loop phi destruction, indirect calls, external imports, FP/SIMD, and
+  atomics are not production-supported yet.
+- rustc backend TODOs are scoped as experimental. The stable shim smoke is
+  release-blocking, but real `rustc_private`/`rustc_codegen_ssa` nightly-driver
+  wiring is not a stable production contract.
+- CFI/unwind and relocation gaps must either appear as `partial`/`experimental`
+  cells with limitations or be promoted to known issues before a release
+  manager can sign off the corresponding backend.
+
+## Maintenance Rules
+
+Run the validator after changing any backend support claim:
+
+```bash
+scripts/backend_support_contract.sh validate
+```
+
+When promoting a cell from `partial`, `experimental`, or `unsupported` to
+`supported`, add a concrete evidence command and path in the JSON fixture in the
+same PR. Do not update README or roadmap status before the corresponding support
+contract check is green.

--- a/docs/platform_support_policy.md
+++ b/docs/platform_support_policy.md
@@ -17,6 +17,10 @@ The `Platform Matrix Gate` workflow provides the M2 merge gate:
 - `Tier-1 host matrix`: runs core checks on `ubuntu-24.04`, `macos-14`, and `windows-2022`.
 - `Tier-1 artifact generation`: validates target-specific crates for x86-64, AArch64, and RV64GC target triples.
 - `Known-issues registry validation`: enforces that tracked Tier-2 or waived Tier-1 breakages include category, owner, and ETA.
+- `Backend Support Contract`: validates `docs/backend_support_matrix.json` and runs release-blocking rustc-backend stable smoke plus LTO smoke tests.
+
+Backend-level support claims, unsupported cells, and release-blocking evidence
+are documented in [`docs/backend_support_matrix.md`](backend_support_matrix.md).
 
 ## Release sign-off checklist
 
@@ -25,8 +29,9 @@ Before tagging a release:
 1. Confirm the latest `main` run of `Platform Matrix Gate` is green.
 2. Confirm all Tier-1 host jobs are passing.
 3. Confirm x86-64, AArch64, and RV64GC artifact-generation checks are passing.
-4. Review `docs/platform_known_issues.json`; no Tier-1 issue may remain open without an explicit owner, ETA, and release-manager acceptance.
-5. Link the green workflow run and known-issues review in the release notes.
+4. Confirm the backend support contract workflow is passing and the matrix has no unsupported production cell without an explicit marker.
+5. Review `docs/platform_known_issues.json`; no Tier-1 issue may remain open without an explicit owner, ETA, and release-manager acceptance.
+6. Link the green workflow run and known-issues review in the release notes.
 
 ## Known-issues categories
 

--- a/scripts/backend_support_contract.py
+++ b/scripts/backend_support_contract.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate the backend support contract fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "docs" / "backend_support_matrix.json"
+DOC = ROOT / "docs" / "backend_support_matrix.md"
+
+REQUIRED_AXES = [
+    "abi",
+    "calls",
+    "varargs",
+    "structs_by_value_aggregates",
+    "atomics",
+    "fp_simd",
+    "eh_unwind",
+    "debug_info",
+    "object_format",
+    "relocations",
+    "linker_execution",
+]
+REQUIRED_TARGETS = ["x86_64", "aarch64", "riscv64", "wasm32"]
+VALID_STATUSES = {"supported", "partial", "experimental", "unsupported"}
+REQUIRED_E2E = {
+    "c_frontend",
+    "rustc_backend_smoke",
+    "lto",
+    "debug_unwind",
+    "sanitizer_instrumented",
+}
+
+
+def rel_exists(path: str) -> bool:
+    return (ROOT / path).exists()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def validate_evidence(owner: str, evidence: object, required: bool) -> int:
+    if evidence is None:
+        evidence = []
+    require(isinstance(evidence, list), f"{owner}: evidence must be a list")
+    if required:
+        require(evidence, f"{owner}: evidence is required")
+
+    count = 0
+    for idx, item in enumerate(evidence):
+        where = f"{owner}.evidence[{idx}]"
+        require(isinstance(item, dict), f"{where}: evidence item must be an object")
+        path = item.get("path")
+        command = item.get("command")
+        require(isinstance(path, str) and path.strip(), f"{where}: path is required")
+        require(rel_exists(path), f"{where}: referenced path does not exist: {path}")
+        require(
+            isinstance(command, str) and command.strip(),
+            f"{where}: command is required",
+        )
+        count += 1
+    return count
+
+
+def validate_matrix() -> None:
+    require(MATRIX.exists(), f"missing {MATRIX.relative_to(ROOT)}")
+    require(DOC.exists(), f"missing {DOC.relative_to(ROOT)}")
+
+    data = json.loads(MATRIX.read_text())
+    require(data.get("schema_version") == 1, "schema_version must be 1")
+    require(data.get("policy") == "docs/backend_support_matrix.md", "policy path mismatch")
+    require(data.get("issue") == 384, "issue must be 384")
+    require(data.get("axes") == REQUIRED_AXES, "axes changed without updating validator")
+
+    targets = data.get("targets")
+    require(isinstance(targets, dict), "targets must be an object")
+    require(sorted(targets) == sorted(REQUIRED_TARGETS), "target set mismatch")
+
+    status_counts = {status: 0 for status in VALID_STATUSES}
+    evidence_count = 0
+    for target in REQUIRED_TARGETS:
+        target_obj = targets[target]
+        require(isinstance(target_obj.get("display"), str), f"{target}: display is required")
+        cells = target_obj.get("cells")
+        require(isinstance(cells, dict), f"{target}: cells must be an object")
+        require(sorted(cells) == sorted(REQUIRED_AXES), f"{target}: cell axes mismatch")
+
+        for axis in REQUIRED_AXES:
+            owner = f"{target}.{axis}"
+            cell = cells[axis]
+            require(isinstance(cell, dict), f"{owner}: cell must be an object")
+            status = cell.get("status")
+            require(status in VALID_STATUSES, f"{owner}: invalid status {status!r}")
+            status_counts[status] += 1
+
+            needs_evidence = status in {"supported", "partial"}
+            evidence_count += validate_evidence(owner, cell.get("evidence"), needs_evidence)
+
+            if status == "partial":
+                require(
+                    str(cell.get("limitations", "")).strip(),
+                    f"{owner}: partial cells need limitations",
+                )
+            if status in {"experimental", "unsupported"}:
+                marker = cell.get("marker")
+                prefix = "not_supported:" if status == "unsupported" else "experimental:"
+                require(
+                    isinstance(marker, str) and marker.startswith(prefix),
+                    f"{owner}: {status} cells need marker prefix {prefix}",
+                )
+                require(
+                    str(cell.get("limitations", "")).strip(),
+                    f"{owner}: {status} cells need limitations",
+                )
+
+    e2e = data.get("release_blocking_e2e")
+    require(isinstance(e2e, dict), "release_blocking_e2e must be an object")
+    require(set(e2e) == REQUIRED_E2E, "release_blocking_e2e key mismatch")
+    for key in sorted(REQUIRED_E2E):
+        item = e2e[key]
+        owner = f"release_blocking_e2e.{key}"
+        require(isinstance(item, dict), f"{owner}: entry must be an object")
+        workflow = item.get("workflow")
+        require(
+            isinstance(workflow, str) and rel_exists(workflow),
+            f"{owner}: workflow path missing: {workflow}",
+        )
+        require(str(item.get("scope", "")).strip(), f"{owner}: scope is required")
+        evidence_count += validate_evidence(owner, item.get("evidence"), required=True)
+
+    print(
+        "validated backend support matrix: "
+        f"{len(REQUIRED_TARGETS)} targets, {len(REQUIRED_AXES)} axes, "
+        f"{evidence_count} evidence item(s), statuses={status_counts}"
+    )
+
+
+def main() -> None:
+    global MATRIX
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        default=str(MATRIX),
+        help="matrix path; defaults to docs/backend_support_matrix.json",
+    )
+    args = parser.parse_args()
+
+    MATRIX = (ROOT / args.matrix).resolve() if not Path(args.matrix).is_absolute() else Path(args.matrix)
+    validate_matrix()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backend_support_contract.sh
+++ b/scripts/backend_support_contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/backend_support_contract.sh <lane>
+
+Lanes:
+  validate     Validate docs/backend_support_matrix.json shape and evidence paths.
+  rustc-smoke  Run release-blocking stable rustc-backend shim tests.
+  lto-smoke    Run release-blocking LTO smoke tests.
+  release      Run all lanes used by the Backend Support Contract workflow.
+USAGE
+}
+
+lane="${1:-}"
+if [[ -z "$lane" || "$lane" == "-h" || "$lane" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+validate() {
+  python3 scripts/backend_support_contract.py
+}
+
+rustc_smoke() {
+  cargo +stable test -p llvm-in-rust-rustc-backend
+}
+
+lto_smoke() {
+  cargo +stable test -p llvm-in-rust --test lto_multi_tu
+  cargo +stable test -p llvm-in-rust-codegen --test thinlto
+}
+
+case "$lane" in
+  validate) validate ;;
+  rustc-smoke) rustc_smoke ;;
+  lto-smoke) lto_smoke ;;
+  release)
+    validate
+    rustc_smoke
+    lto_smoke
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/platform_matrix.sh
+++ b/scripts/platform_matrix.sh
@@ -11,6 +11,7 @@ Lanes:
   target-aarch64  Validate AArch64 artifact-generation crates.
   target-rv64gc   Validate RV64GC artifact-generation crates.
   known-issues   Validate docs/platform_known_issues.json shape.
+  backend-contract Validate backend support contract fixture shape.
 USAGE
 }
 
@@ -75,6 +76,7 @@ case "$lane" in
   target-aarch64) run_target_aarch64 ;;
   target-rv64gc) run_target_rv64gc ;;
   known-issues) validate_known_issues ;;
+  backend-contract) scripts/backend_support_contract.sh validate ;;
   *)
     usage >&2
     exit 2


### PR DESCRIPTION
Closes #384.

## Summary
- add a CI-readable backend support matrix covering x86-64, AArch64, RISC-V RV64GC, and WebAssembly support claims
- add a validator and Backend Support Contract workflow that enforce evidence, explicit unsupported markers, rustc-backend stable smoke, and LTO smoke
- document the human-readable matrix and wire the backend-contract lane into the platform support policy

## Validation
- `scripts/backend_support_contract.sh validate`
- `scripts/platform_matrix.sh backend-contract`
- `scripts/backend_support_contract.sh release`
- `python3 -m py_compile scripts/backend_support_contract.py`
- `git diff --check`

Local release smoke passed with the existing `llvm-ir-parser` unreachable-pattern warnings already present on main.