### PR TITLE
style: cargo fmt workspace-wide + fmt CI gate — Milestone V

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,33 @@
+name: Quality Gates
+
+# Release-blocking source-quality gates (roadmap Milestone V / issue #381).
+# Formatting is enforced here; clippy `-D warnings` is added in a follow-up
+# once the existing warnings are cleared.
+
+on:
+  push:
+    branches: [main, "fix/**", "feat/**", "feature/**"]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  rustfmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Rust stable toolchain with rustfmt
+        run: |
+          rustup set profile minimal
+          rustup toolchain install stable --component rustfmt
+          rustup default stable
+
+      - name: Check workspace formatting
+        run: cargo +stable fmt --all -- --check

--- a/bench/fuzz/src/bin/fuzz-diff.rs
+++ b/bench/fuzz/src/bin/fuzz-diff.rs
@@ -11,14 +11,8 @@ use fuzz_diff::run_campaign_from;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let count: u32 = args
-        .get(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(100);
-    let seed: u64 = args
-        .get(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(42);
+    let count: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(100);
+    let seed: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(42);
 
     println!(
         "Running {} differential fuzz programs (base_seed={})...",

--- a/bench/fuzz/src/gen.rs
+++ b/bench/fuzz/src/gen.rs
@@ -45,11 +45,7 @@ impl FuzzGen {
     ///
     /// The function body has 3–12 arithmetic instructions (no branches).
     /// Returns the `FunctionId` of the generated function.
-    pub fn gen_function(
-        &mut self,
-        ctx: &mut Context,
-        module: &mut Module,
-    ) -> FunctionId {
+    pub fn gen_function(&mut self, ctx: &mut Context, module: &mut Module) -> FunctionId {
         let n_args: usize = self.rng.random_range(1..=3);
         let n_instrs: usize = self.rng.random_range(3..=12);
 
@@ -71,9 +67,7 @@ impl FuzzGen {
         b.position_at_end(entry);
 
         // `defined` holds all ValueRefs we can use as operands.
-        let mut defined: Vec<ValueRef> = (0..n_args as u32)
-            .map(|i| b.get_arg(i))
-            .collect();
+        let mut defined: Vec<ValueRef> = (0..n_args as u32).map(|i| b.get_arg(i)).collect();
 
         for idx in 0..n_instrs {
             // Pick two random operands from the currently defined values.
@@ -90,7 +84,7 @@ impl FuzzGen {
                 BinOp::Sub => b.build_sub(name, lhs, rhs),
                 BinOp::Mul => b.build_mul(name, lhs, rhs),
                 BinOp::And => b.build_and(name, lhs, rhs),
-                BinOp::Or  => b.build_or(name, lhs, rhs),
+                BinOp::Or => b.build_or(name, lhs, rhs),
                 BinOp::Xor => b.build_xor(name, lhs, rhs),
             };
 
@@ -125,19 +119,18 @@ impl FuzzGen {
             std::collections::HashMap::new();
 
         // Helper: resolve a ValueRef to an i64.
-        let resolve = |vref: ValueRef,
-                       values: &std::collections::HashMap<llvm_ir::InstrId, i64>|
-         -> i64 {
-            match vref {
-                ValueRef::Argument(aid) => arg_vals.get(aid.0 as usize).copied().unwrap_or(0),
-                ValueRef::Instruction(iid) => *values.get(&iid).expect("use before def"),
-                ValueRef::Constant(cid) => match ctx.get_const(cid) {
-                    llvm_ir::ConstantData::Int { val, .. } => *val as i64,
-                    _ => 0,
-                },
-                ValueRef::Global(_) => 0,
-            }
-        };
+        let resolve =
+            |vref: ValueRef, values: &std::collections::HashMap<llvm_ir::InstrId, i64>| -> i64 {
+                match vref {
+                    ValueRef::Argument(aid) => arg_vals.get(aid.0 as usize).copied().unwrap_or(0),
+                    ValueRef::Instruction(iid) => *values.get(&iid).expect("use before def"),
+                    ValueRef::Constant(cid) => match ctx.get_const(cid) {
+                        llvm_ir::ConstantData::Int { val, .. } => *val as i64,
+                        _ => 0,
+                    },
+                    ValueRef::Global(_) => 0,
+                }
+            };
 
         // Interpret body instructions.
         for &iid in &entry.body {
@@ -152,16 +145,13 @@ impl FuzzGen {
                 InstrKind::Mul { lhs, rhs, .. } => {
                     resolve(*lhs, &values).wrapping_mul(resolve(*rhs, &values))
                 }
-                InstrKind::And { lhs, rhs } => {
-                    resolve(*lhs, &values) & resolve(*rhs, &values)
-                }
-                InstrKind::Or { lhs, rhs } => {
-                    resolve(*lhs, &values) | resolve(*rhs, &values)
-                }
-                InstrKind::Xor { lhs, rhs } => {
-                    resolve(*lhs, &values) ^ resolve(*rhs, &values)
-                }
-                _ => panic!("unexpected instruction kind in generated function: {:?}", instr.kind),
+                InstrKind::And { lhs, rhs } => resolve(*lhs, &values) & resolve(*rhs, &values),
+                InstrKind::Or { lhs, rhs } => resolve(*lhs, &values) | resolve(*rhs, &values),
+                InstrKind::Xor { lhs, rhs } => resolve(*lhs, &values) ^ resolve(*rhs, &values),
+                _ => panic!(
+                    "unexpected instruction kind in generated function: {:?}",
+                    instr.kind
+                ),
             };
             values.insert(iid, result);
         }
@@ -196,7 +186,9 @@ mod tests {
         let func = module.function(fid);
         assert!(!func.blocks.is_empty(), "function should have blocks");
         let entry = &func.blocks[0];
-        let tid = entry.terminator.expect("entry block must have a terminator");
+        let tid = entry
+            .terminator
+            .expect("entry block must have a terminator");
         match &func.instr(tid).kind {
             InstrKind::Ret { .. } => {}
             other => panic!("expected ret terminator, got {:?}", other),

--- a/examples/tikv_jit/src/main.rs
+++ b/examples/tikv_jit/src/main.rs
@@ -155,7 +155,14 @@ fn main() {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     // ── Step 5: Emit ELF object file ──────────────────────────────────────────

--- a/src/llvm-analysis/src/alias.rs
+++ b/src/llvm-analysis/src/alias.rs
@@ -18,8 +18,8 @@
 //! [`AliasResult`].  [`CombinedAliasAnalysis`] runs BasicAA first and returns
 //! its answer (TBAA can be layered on later if `!tbaa` metadata is parsed).
 
-use llvm_ir::{ArgId, Function, GlobalId, InstrId, Module, ValueRef};
 use llvm_ir::instruction::InstrKind;
+use llvm_ir::{ArgId, Function, GlobalId, InstrId, Module, ValueRef};
 
 // ---------------------------------------------------------------------------
 // AliasResult
@@ -141,8 +141,7 @@ impl TbaaHierarchy {
         }
 
         // Rule 2: shared type lineage.
-        if self.is_ancestor(a.base_type, b.base_type)
-            || self.is_ancestor(b.base_type, a.base_type)
+        if self.is_ancestor(a.base_type, b.base_type) || self.is_ancestor(b.base_type, a.base_type)
         {
             return AliasResult::MayAlias;
         }
@@ -204,11 +203,7 @@ pub enum UnderlyingObject {
 ///
 /// The recursion is bounded implicitly because SSA is acyclic (no infinite
 /// chains in well-formed IR).
-pub fn underlying_object(
-    val: ValueRef,
-    func: &Function,
-    _module: &Module,
-) -> UnderlyingObject {
+pub fn underlying_object(val: ValueRef, func: &Function, _module: &Module) -> UnderlyingObject {
     match val {
         ValueRef::Global(gid) => UnderlyingObject::Global(gid),
         ValueRef::Argument(aid) => UnderlyingObject::Arg(aid),
@@ -327,10 +322,10 @@ impl<'a> AliasAnalysis for CombinedAliasAnalysis<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{
-        BasicBlock, Context, Function, Instruction, InstrKind, Linkage, Module, ValueRef,
-    };
     use llvm_ir::value::GlobalVariable;
+    use llvm_ir::{
+        BasicBlock, Context, Function, InstrKind, Instruction, Linkage, Module, ValueRef,
+    };
 
     // -----------------------------------------------------------------------
     // Helper: build a minimal 1-block function with the provided instructions
@@ -356,9 +351,21 @@ mod tests {
         // root (id=0) -> int (id=1), float (id=2)
         TbaaHierarchy {
             nodes: vec![
-                TbaaNode { id: 0, name: "TBAA root".to_string(), parent: None },
-                TbaaNode { id: 1, name: "int".to_string(), parent: Some(0) },
-                TbaaNode { id: 2, name: "float".to_string(), parent: Some(0) },
+                TbaaNode {
+                    id: 0,
+                    name: "TBAA root".to_string(),
+                    parent: None,
+                },
+                TbaaNode {
+                    id: 1,
+                    name: "int".to_string(),
+                    parent: Some(0),
+                },
+                TbaaNode {
+                    id: 2,
+                    name: "float".to_string(),
+                    parent: Some(0),
+                },
             ],
         }
     }
@@ -388,8 +395,16 @@ mod tests {
         let h = make_hierarchy();
         // int (1) and float (2) share only the root ancestor, but neither is
         // an ancestor of the other, so they do not alias.
-        let a = TbaaAccessTag { base_type: 1, access_type: 1, offset: 0 };
-        let b = TbaaAccessTag { base_type: 2, access_type: 2, offset: 0 };
+        let a = TbaaAccessTag {
+            base_type: 1,
+            access_type: 1,
+            offset: 0,
+        };
+        let b = TbaaAccessTag {
+            base_type: 2,
+            access_type: 2,
+            offset: 0,
+        };
         assert_eq!(h.may_alias(&a, &b), AliasResult::NoAlias);
     }
 
@@ -398,14 +413,34 @@ mod tests {
         // A node named "omnipotent char" must alias with everything.
         let h = TbaaHierarchy {
             nodes: vec![
-                TbaaNode { id: 0, name: "TBAA root".to_string(), parent: None },
-                TbaaNode { id: 1, name: "int".to_string(), parent: Some(0) },
-                TbaaNode { id: 2, name: "omnipotent char".to_string(), parent: Some(0) },
+                TbaaNode {
+                    id: 0,
+                    name: "TBAA root".to_string(),
+                    parent: None,
+                },
+                TbaaNode {
+                    id: 1,
+                    name: "int".to_string(),
+                    parent: Some(0),
+                },
+                TbaaNode {
+                    id: 2,
+                    name: "omnipotent char".to_string(),
+                    parent: Some(0),
+                },
             ],
         };
         // char (2) vs int (1) — char wins.
-        let a = TbaaAccessTag { base_type: 2, access_type: 2, offset: 0 };
-        let b = TbaaAccessTag { base_type: 1, access_type: 1, offset: 0 };
+        let a = TbaaAccessTag {
+            base_type: 2,
+            access_type: 2,
+            offset: 0,
+        };
+        let b = TbaaAccessTag {
+            base_type: 1,
+            access_type: 1,
+            offset: 0,
+        };
         assert_eq!(h.may_alias(&a, &b), AliasResult::MayAlias);
         // Also works in reverse.
         assert_eq!(h.may_alias(&b, &a), AliasResult::MayAlias);
@@ -434,7 +469,10 @@ mod tests {
 
         let iid = func.value_names["a"];
         let val = ValueRef::Instruction(iid);
-        assert_eq!(underlying_object(val, &func, &module), UnderlyingObject::Alloca(iid));
+        assert_eq!(
+            underlying_object(val, &func, &module),
+            UnderlyingObject::Alloca(iid)
+        );
     }
 
     #[test]
@@ -453,7 +491,10 @@ mod tests {
         let func = Function::new("f", fn_ty, vec![], Linkage::External);
 
         let val = ValueRef::Global(gid);
-        assert_eq!(underlying_object(val, &func, &module), UnderlyingObject::Global(gid));
+        assert_eq!(
+            underlying_object(val, &func, &module),
+            UnderlyingObject::Global(gid)
+        );
     }
 
     #[test]
@@ -548,8 +589,14 @@ mod tests {
         });
         let aa = BasicAliasAnalysis::new(&func, &module);
         let aref = ValueRef::Instruction(func.value_names["a"]);
-        let ma = MemAccess { ptr: aref, size_bytes: 4 };
-        let mb = MemAccess { ptr: aref, size_bytes: 4 };
+        let ma = MemAccess {
+            ptr: aref,
+            size_bytes: 4,
+        };
+        let mb = MemAccess {
+            ptr: aref,
+            size_bytes: 4,
+        };
         // Same alloca — could be same bytes, so MayAlias.
         assert_eq!(aa.may_alias(&ma, &mb), AliasResult::MayAlias);
     }
@@ -586,7 +633,10 @@ mod tests {
             ptr: ValueRef::Instruction(func.value_names["a"]),
             size_bytes: 4,
         };
-        let mb = MemAccess { ptr: ValueRef::Global(gid), size_bytes: 4 };
+        let mb = MemAccess {
+            ptr: ValueRef::Global(gid),
+            size_bytes: 4,
+        };
         assert_eq!(aa.may_alias(&ma, &mb), AliasResult::NoAlias);
     }
 

--- a/src/llvm-analysis/src/call_graph.rs
+++ b/src/llvm-analysis/src/call_graph.rs
@@ -213,7 +213,14 @@ mod tests {
         let i64_ty = b.ctx.i64_ty;
         let fn_ty = b.ctx.mk_fn_type(i64_ty, vec![i64_ty], false);
 
-        b.add_function("a", i64_ty, vec![i64_ty], vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "a",
+            i64_ty,
+            vec![i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let a_entry = b.add_block("a.entry");
         b.position_at_end(a_entry);
         let x = b.get_arg(0);
@@ -222,14 +229,28 @@ mod tests {
         let sum = b.build_add("sum", c1, c2);
         b.build_ret(sum);
 
-        b.add_function("b", i64_ty, vec![i64_ty], vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "b",
+            i64_ty,
+            vec![i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let b_entry = b.add_block("b.entry");
         b.position_at_end(b_entry);
         let bx = b.get_arg(0);
         let bcall = b.build_call("r", i64_ty, fn_ty, ValueRef::Global(GlobalId(2)), vec![bx]);
         b.build_ret(bcall);
 
-        b.add_function("c", i64_ty, vec![i64_ty], vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "c",
+            i64_ty,
+            vec![i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let c_entry = b.add_block("c.entry");
         b.position_at_end(c_entry);
         let cx = b.get_arg(0);
@@ -257,7 +278,14 @@ mod tests {
         let i64_ty = b.ctx.i64_ty;
         let fn_ty = b.ctx.mk_fn_type(i64_ty, vec![i64_ty], false);
         for name in ["a", "b", "c"] {
-            b.add_function(name, i64_ty, vec![i64_ty], vec!["x".into()], false, Linkage::External);
+            b.add_function(
+                name,
+                i64_ty,
+                vec![i64_ty],
+                vec!["x".into()],
+                false,
+                Linkage::External,
+            );
             let entry = b.add_block(format!("{name}.entry"));
             b.position_at_end(entry);
             let x = b.get_arg(0);
@@ -272,10 +300,9 @@ mod tests {
 
         let cg = CallGraph::build(&ctx, &module);
         let sccs = cg.sccs();
-        assert!(
-            sccs.iter()
-                .any(|s| s.len() == 2 && s.contains(&FunctionId(0)) && s.contains(&FunctionId(1)))
-        );
+        assert!(sccs
+            .iter()
+            .any(|s| s.len() == 2 && s.contains(&FunctionId(0)) && s.contains(&FunctionId(1))));
     }
 
     #[test]
@@ -287,7 +314,14 @@ mod tests {
         let fn_ty = b.ctx.mk_fn_type(i64_ty, vec![i64_ty], false);
         b.add_declaration("ext", i64_ty, vec![i64_ty], false);
 
-        b.add_function("f", i64_ty, vec![i64_ty], vec!["x".into()], false, Linkage::External);
+        b.add_function(
+            "f",
+            i64_ty,
+            vec![i64_ty],
+            vec!["x".into()],
+            false,
+            Linkage::External,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let x = b.get_arg(0);

--- a/src/llvm-analysis/src/lib.rs
+++ b/src/llvm-analysis/src/lib.rs
@@ -14,8 +14,8 @@ pub mod use_def;
 
 /// Public API for `re-export`.
 pub use alias::{
-    AliasAnalysis, AliasResult, BasicAliasAnalysis, CombinedAliasAnalysis, MemAccess,
-    TbaaAccessTag, TbaaHierarchy, TbaaNode, UnderlyingObject, underlying_object,
+    underlying_object, AliasAnalysis, AliasResult, BasicAliasAnalysis, CombinedAliasAnalysis,
+    MemAccess, TbaaAccessTag, TbaaHierarchy, TbaaNode, UnderlyingObject,
 };
 /// Public API for `re-export`.
 pub use call_graph::{CallEdge, CallEdgeKind, CallGraph};

--- a/src/llvm-bench/benches/pipeline.rs
+++ b/src/llvm-bench/benches/pipeline.rs
@@ -16,7 +16,11 @@ use llvm_target_x86::{
     instructions::{MOV_LOAD_MR, MOV_STORE_RM},
     X86Backend, X86Emitter,
 };
-use llvm_transforms::{build_pipeline, pass::{FunctionPass, PassManager}, DeadCodeElim, Mem2Reg, OptLevel};
+use llvm_transforms::{
+    build_pipeline,
+    pass::{FunctionPass, PassManager},
+    DeadCodeElim, Mem2Reg, OptLevel,
+};
 
 const FIXTURE: &str = include_str!("../fixtures/sample.ll");
 
@@ -39,7 +43,14 @@ fn codegen_module(ctx: &Context, module: &Module) {
             &mf.allocatable_fp_pregs,
             RegAllocStrategy::LinearScan,
         );
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);
         emit_object(&mf, &mut emitter);
@@ -61,7 +72,14 @@ fn codegen_module_integrated_assembler(ctx: &Context, module: &Module) {
             &mf.allocatable_fp_pregs,
             RegAllocStrategy::LinearScan,
         );
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);
         let assembled = assemble_with_report(&mf, &mut emitter);

--- a/src/llvm-bench/src/lib.rs
+++ b/src/llvm-bench/src/lib.rs
@@ -13,9 +13,9 @@
 
 #[cfg(test)]
 mod tests {
+    use llvm_ir::InstrKind;
     use llvm_ir::{Builder, GlobalId, Linkage, Module, ValueRef};
     use llvm_ir_parser::parser::parse;
-    use llvm_ir::InstrKind;
     use llvm_transforms::{build_pipeline, pass::PassManager, OptLevel};
 
     const FIXTURE: &str = include_str!("../fixtures/sample.ll");

--- a/src/llvm-bitcode/src/lib.rs
+++ b/src/llvm-bitcode/src/lib.rs
@@ -20,9 +20,9 @@
 //! let (_ctx2, _module2) = read_bitcode(&bytes).expect("round-trip failed");
 //! ```
 
-pub mod error;
 /// Low-level LLVM bitstream decoder (VBR, blocks, abbreviations).
 pub mod bitstream;
+pub mod error;
 /// Standard LLVM `.bc` file reader.
 pub mod llvm_reader;
 /// Public API for `reader`.
@@ -351,9 +351,18 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         // Build [i32 1, i32 2, i32 3].
-        let e0 = ctx.push_const(ConstantData::Int { ty: ctx.i32_ty, val: 1 });
-        let e1 = ctx.push_const(ConstantData::Int { ty: ctx.i32_ty, val: 2 });
-        let e2 = ctx.push_const(ConstantData::Int { ty: ctx.i32_ty, val: 3 });
+        let e0 = ctx.push_const(ConstantData::Int {
+            ty: ctx.i32_ty,
+            val: 1,
+        });
+        let e1 = ctx.push_const(ConstantData::Int {
+            ty: ctx.i32_ty,
+            val: 2,
+        });
+        let e2 = ctx.push_const(ConstantData::Int {
+            ty: ctx.i32_ty,
+            val: 3,
+        });
         let arr_ty = ctx.mk_array(ctx.i32_ty, 3);
         let init = ctx.push_const(ConstantData::Array {
             ty: arr_ty,
@@ -409,14 +418,20 @@ mod tests {
 
     #[test]
     fn test_globals_round_trip_with_expr_init() {
-        use llvm_ir::{ConstantData, ConstExprOp, GlobalId, GlobalVariable};
+        use llvm_ir::{ConstExprOp, ConstantData, GlobalId, GlobalVariable};
         let mut ctx = Context::new();
         let mut module = Module::new("test");
         // Declare an i8 array global first (GlobalId(0)).
         let i8_ty = ctx.mk_int(8);
         let arr_ty = ctx.mk_array(i8_ty, 4);
-        let e0 = ctx.push_const(ConstantData::Int { ty: i8_ty, val: b'h' as u64 });
-        let e1 = ctx.push_const(ConstantData::Int { ty: i8_ty, val: b'i' as u64 });
+        let e0 = ctx.push_const(ConstantData::Int {
+            ty: i8_ty,
+            val: b'h' as u64,
+        });
+        let e1 = ctx.push_const(ConstantData::Int {
+            ty: i8_ty,
+            val: b'i' as u64,
+        });
         let e2 = ctx.push_const(ConstantData::Int { ty: i8_ty, val: 0 });
         let e3 = ctx.push_const(ConstantData::Int { ty: i8_ty, val: 0 });
         let arr_init = ctx.push_const(ConstantData::Array {
@@ -436,10 +451,16 @@ mod tests {
             id: gid0,
             name: "str_data".into(),
         });
-        let idx0 = ctx.push_const(ConstantData::Int { ty: ctx.i64_ty, val: 0 });
+        let idx0 = ctx.push_const(ConstantData::Int {
+            ty: ctx.i64_ty,
+            val: 0,
+        });
         let gep_expr = ctx.push_const(ConstantData::Expr {
             ty: ctx.ptr_ty,
-            op: ConstExprOp::GetElementPtr { inbounds: true, base_ty: arr_ty },
+            op: ConstExprOp::GetElementPtr {
+                inbounds: true,
+                base_ty: arr_ty,
+            },
             operands: vec![base_ptr, idx0, idx0],
         });
         // Second global: a pointer initialized with the GEP expression.

--- a/src/llvm-bitcode/src/llvm_reader.rs
+++ b/src/llvm-bitcode/src/llvm_reader.rs
@@ -1,5 +1,13 @@
 //! Standard LLVM bitcode (`.bc`) reader.
-#![allow(dead_code, unused_variables, unused_mut, unused_assignments, clippy::ptr_arg, clippy::cloned_ref_to_slice_refs, dropping_references)]
+#![allow(
+    dead_code,
+    unused_variables,
+    unused_mut,
+    unused_assignments,
+    clippy::ptr_arg,
+    clippy::cloned_ref_to_slice_refs,
+    dropping_references
+)]
 //!
 //! Parses files produced by `clang -emit-llvm -c` and reconstructs a
 //! `(Context, Module)` using the same IR types as the rest of LLVM-in-Rust.
@@ -482,9 +490,7 @@ fn parse_module_block(
                         MODULE_CODE_FUNCTION => {
                             parse_function_decl_record(&fields[1..], state)?;
                         }
-                        MODULE_CODE_TRIPLE
-                        | MODULE_CODE_DATALAYOUT
-                        | MODULE_CODE_ALIAS => {
+                        MODULE_CODE_TRIPLE | MODULE_CODE_DATALAYOUT | MODULE_CODE_ALIAS => {
                             // Ignore
                         }
                         _ => {}
@@ -512,7 +518,11 @@ fn parse_module_block(
         let args: Vec<Argument> = param_tys
             .iter()
             .enumerate()
-            .map(|(i, &pty)| Argument { name: format!("arg{}", i), ty: pty, index: i as u32 })
+            .map(|(i, &pty)| Argument {
+                name: format!("arg{}", i),
+                ty: pty,
+                index: i as u32,
+            })
             .collect();
         let func = Function::new_declaration(name, ty, args, linkage);
         state.module.add_function(func);
@@ -786,9 +796,10 @@ fn parse_constants_block(
                             });
                             state.value_table.push(ValueRef::Constant(cid));
                         } else {
-                            let cid = state
-                                .ctx
-                                .push_const(ConstantData::IntWide { ty: cur_type, words });
+                            let cid = state.ctx.push_const(ConstantData::IntWide {
+                                ty: cur_type,
+                                words,
+                            });
                             state.value_table.push(ValueRef::Constant(cid));
                         }
                     }
@@ -826,12 +837,10 @@ fn parse_constants_block(
                                 ty: cur_type,
                                 fields: elems,
                             }),
-                            TypeData::Vector { .. } => {
-                                state.ctx.push_const(ConstantData::Vector {
-                                    ty: cur_type,
-                                    elements: elems,
-                                })
-                            }
+                            TypeData::Vector { .. } => state.ctx.push_const(ConstantData::Vector {
+                                ty: cur_type,
+                                elements: elems,
+                            }),
                             _ => state.ctx.push_const(ConstantData::Array {
                                 ty: cur_type,
                                 elements: elems,
@@ -847,9 +856,10 @@ fn parse_constants_block(
                         let arr_ty = state.ctx.mk_array(i8_ty, n);
                         let mut elems = Vec::new();
                         for b in bytes {
-                            let ec = state
-                                .ctx
-                                .push_const(ConstantData::Int { ty: i8_ty, val: b as u64 });
+                            let ec = state.ctx.push_const(ConstantData::Int {
+                                ty: i8_ty,
+                                val: b as u64,
+                            });
                             elems.push(ec);
                         }
                         let cid = state.ctx.push_const(ConstantData::Array {
@@ -976,10 +986,7 @@ fn decode_sign_rotated(encoded: u64) -> u64 {
 
 // ── GLOBALVAR record ───────────────────────────────────────────────────────────
 
-fn parse_globalvar_record(
-    fields: &[u64],
-    state: &mut LlvmReader,
-) -> Result<(), BitcodeError> {
+fn parse_globalvar_record(fields: &[u64], state: &mut LlvmReader) -> Result<(), BitcodeError> {
     if fields.len() < 6 {
         return Ok(());
     }
@@ -1046,10 +1053,7 @@ fn module_add_global(
 
 // ── FUNCTION declaration record ────────────────────────────────────────────────
 
-fn parse_function_decl_record(
-    fields: &[u64],
-    state: &mut LlvmReader,
-) -> Result<(), BitcodeError> {
+fn parse_function_decl_record(fields: &[u64], state: &mut LlvmReader) -> Result<(), BitcodeError> {
     // fields: [ty_idx, calling_conv, is_declaration, linkage, ...]
     if fields.len() < 3 {
         return Ok(());
@@ -1227,12 +1231,7 @@ fn parse_function_block(
                 let saved = bs.abbrevs.clone();
                 match block_id {
                     CONSTANTS_BLOCK_ID => {
-                        parse_constants_block(
-                            bs,
-                            state,
-                            &saved,
-                            Some(state.value_table.len()),
-                        )?;
+                        parse_constants_block(bs, state, &saved, Some(state.value_table.len()))?;
                     }
                     VALUE_SYMTAB_BLOCK_ID => {
                         // Function-local VST — skip for now.
@@ -1269,8 +1268,16 @@ fn parse_function_block(
                     }
                     FUNC_CODE_INST_BINOP => {
                         // [code, lhs, rhs, opcode, {flags}]
-                        let lhs = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                        let rhs = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                        let lhs = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
+                        let rhs = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(2).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let opcode = fields.get(3).copied().unwrap_or(0);
                         let flags = fields.get(4).copied().unwrap_or(0);
 
@@ -1278,18 +1285,36 @@ fn parse_function_block(
                         let result_ty = type_of_vref(&lhs, &func, state);
 
                         let kind = binop_kind(opcode, flags, lhs, rhs, result_ty)?;
-                        let iid = emit_instr(&mut func, &mut basic_blocks, cur_block_idx, None, result_ty, kind);
+                        let iid = emit_instr(
+                            &mut func,
+                            &mut basic_blocks,
+                            cur_block_idx,
+                            None,
+                            result_ty,
+                            kind,
+                        );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
                     }
                     FUNC_CODE_INST_CAST => {
                         // [code, val, ty_idx, opcode]
-                        let val = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                        let val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let ty_idx = fields.get(2).copied().unwrap_or(0) as usize;
                         let to_ty = state.get_type(ty_idx)?;
                         let opcode = fields.get(3).copied().unwrap_or(0);
                         let kind = cast_kind(opcode, val, to_ty)?;
-                        let iid = emit_instr(&mut func, &mut basic_blocks, cur_block_idx, None, to_ty, kind);
+                        let iid = emit_instr(
+                            &mut func,
+                            &mut basic_blocks,
+                            cur_block_idx,
+                            None,
+                            to_ty,
+                            kind,
+                        );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
                     }
@@ -1331,7 +1356,9 @@ fn parse_function_block(
                         } else {
                             // Unconditional
                             let dest = fields.get(1).copied().unwrap_or(0) as u32;
-                            InstrKind::Br { dest: BlockId(dest) }
+                            InstrKind::Br {
+                                dest: BlockId(dest),
+                            }
                         };
                         let iid = emit_instr(
                             &mut func,
@@ -1395,7 +1422,10 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             phi_ty,
-                            InstrKind::Phi { ty: phi_ty, incoming },
+                            InstrKind::Phi {
+                                ty: phi_ty,
+                                incoming,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
@@ -1429,7 +1459,11 @@ fn parse_function_block(
                     }
                     FUNC_CODE_INST_LOAD => {
                         // [code, ptr_val, ty_idx, align, volatile]
-                        let ptr = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                        let ptr = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let ty_idx = fields.get(2).copied().unwrap_or(0) as usize;
                         let load_ty = state.get_type(ty_idx)?;
                         let align_enc = fields.get(3).copied().unwrap_or(0);
@@ -1445,7 +1479,12 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             load_ty,
-                            InstrKind::Load { ty: load_ty, ptr, align, volatile },
+                            InstrKind::Load {
+                                ty: load_ty,
+                                ptr,
+                                align,
+                                volatile,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
@@ -1454,12 +1493,28 @@ fn parse_function_block(
                         // New: [code, ptr, val, align, volatile]
                         // Old: [code, val, ptr, align, volatile]
                         let (ptr, val) = if code == FUNC_CODE_INST_STORE {
-                            let p = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                            let v = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                            let p = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(1).copied().unwrap_or(0),
+                                state,
+                            )?;
+                            let v = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(2).copied().unwrap_or(0),
+                                state,
+                            )?;
                             (p, v)
                         } else {
-                            let v = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                            let p = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                            let v = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(1).copied().unwrap_or(0),
+                                state,
+                            )?;
+                            let p = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(2).copied().unwrap_or(0),
+                                state,
+                            )?;
                             (p, v)
                         };
                         let align_enc = fields.get(3).copied().unwrap_or(0);
@@ -1475,18 +1530,29 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             state.ctx.void_ty,
-                            InstrKind::Store { val, ptr, align, volatile },
+                            InstrKind::Store {
+                                val,
+                                ptr,
+                                align,
+                                volatile,
+                            },
                         );
                         // Store has no value result.
                         instr_count += 1;
                     }
-                    FUNC_CODE_INST_GEP | FUNC_CODE_INST_GEP_OLD | FUNC_CODE_INST_INBOUNDS_GEP_OLD => {
+                    FUNC_CODE_INST_GEP
+                    | FUNC_CODE_INST_GEP_OLD
+                    | FUNC_CODE_INST_INBOUNDS_GEP_OLD => {
                         let (inbounds, base_ty, ptr, indices) = if code == FUNC_CODE_INST_GEP {
                             // New: [code, inbounds, ty_idx, ptr, (ty, idx)...]
                             let ib = fields.get(1).copied().unwrap_or(0) != 0;
                             let ty_idx = fields.get(2).copied().unwrap_or(0) as usize;
                             let base = state.get_type(ty_idx)?;
-                            let p = decode_relative_vref(cur_val_id, fields.get(3).copied().unwrap_or(0), state)?;
+                            let p = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(3).copied().unwrap_or(0),
+                                state,
+                            )?;
                             let mut idxs = Vec::new();
                             let mut i = 4;
                             while i < fields.len() {
@@ -1501,7 +1567,11 @@ fn parse_function_block(
                         } else {
                             // Old: [code, (ty, val)...] with inbounds from code.
                             let ib = code == FUNC_CODE_INST_INBOUNDS_GEP_OLD;
-                            let p = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                            let p = decode_relative_vref(
+                                cur_val_id,
+                                fields.get(1).copied().unwrap_or(0),
+                                state,
+                            )?;
                             let base = type_of_vref(&p, &func, state);
                             let mut idxs = Vec::new();
                             let mut i = 2;
@@ -1518,15 +1588,28 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             ptr_ty,
-                            InstrKind::GetElementPtr { inbounds, base_ty, ptr, indices },
+                            InstrKind::GetElementPtr {
+                                inbounds,
+                                base_ty,
+                                ptr,
+                                indices,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
                     }
                     FUNC_CODE_INST_CMP2 | FUNC_CODE_INST_CMP => {
                         // [code, lhs, rhs, predicate]
-                        let lhs = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                        let rhs = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                        let lhs = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
+                        let rhs = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(2).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let pred = fields.get(3).copied().unwrap_or(0);
                         let i1_ty = state.ctx.i1_ty;
                         let kind = cmp_kind(pred, lhs, rhs);
@@ -1543,9 +1626,21 @@ fn parse_function_block(
                     }
                     FUNC_CODE_INST_SELECT | FUNC_CODE_INST_VSELECT => {
                         // [code, cond, true_val, false_val]
-                        let cond = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                        let then_val = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
-                        let else_val = decode_relative_vref(cur_val_id, fields.get(3).copied().unwrap_or(0), state)?;
+                        let cond = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
+                        let then_val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(2).copied().unwrap_or(0),
+                            state,
+                        )?;
+                        let else_val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(3).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let res_ty = type_of_vref(&then_val, &func, state);
                         let iid = emit_instr(
                             &mut func,
@@ -1553,7 +1648,11 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             res_ty,
-                            InstrKind::Select { cond, then_val, else_val },
+                            InstrKind::Select {
+                                cond,
+                                then_val,
+                                else_val,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
@@ -1591,7 +1690,12 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             ret_ty,
-                            InstrKind::Call { tail, callee_ty, callee, args: call_args },
+                            InstrKind::Call {
+                                tail,
+                                callee_ty,
+                                callee,
+                                args: call_args,
+                            },
                         );
                         // Only push if non-void result.
                         let ret_td = state.ctx.get_type(ret_ty).clone();
@@ -1604,7 +1708,11 @@ fn parse_function_block(
                         // [code, ty_idx, cond, default_dest, (case_val, case_dest)...]
                         let ty_idx = fields.get(1).copied().unwrap_or(0) as usize;
                         let _ty = state.get_type(ty_idx)?;
-                        let cond = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                        let cond = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(2).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let default = BlockId(fields.get(3).copied().unwrap_or(0) as u32);
                         let mut cases = Vec::new();
                         let mut i = 4;
@@ -1620,7 +1728,11 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             state.ctx.void_ty,
-                            InstrKind::Switch { val: cond, default, cases },
+                            InstrKind::Switch {
+                                val: cond,
+                                default,
+                                cases,
+                            },
                         );
                         if cur_block_idx < basic_blocks.len() {
                             basic_blocks[cur_block_idx].terminator = Some(iid);
@@ -1630,19 +1742,40 @@ fn parse_function_block(
                     }
                     FUNC_CODE_INST_UNOP => {
                         // [code, val, opcode, {flags}]
-                        let val = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                        let val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let opcode = fields.get(2).copied().unwrap_or(0);
                         let res_ty = type_of_vref(&val, &func, state);
                         let kind = match opcode {
-                            12 => InstrKind::FNeg { flags: FastMathFlags::default(), operand: val },
-                            _ => InstrKind::FNeg { flags: FastMathFlags::default(), operand: val },
+                            12 => InstrKind::FNeg {
+                                flags: FastMathFlags::default(),
+                                operand: val,
+                            },
+                            _ => InstrKind::FNeg {
+                                flags: FastMathFlags::default(),
+                                operand: val,
+                            },
                         };
-                        let iid = emit_instr(&mut func, &mut basic_blocks, cur_block_idx, None, res_ty, kind);
+                        let iid = emit_instr(
+                            &mut func,
+                            &mut basic_blocks,
+                            cur_block_idx,
+                            None,
+                            res_ty,
+                            kind,
+                        );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
                     }
                     FUNC_CODE_INST_FREEZE => {
-                        let val = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                        let val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let res_ty = type_of_vref(&val, &func, state);
                         let iid = emit_instr(
                             &mut func,
@@ -1656,7 +1789,11 @@ fn parse_function_block(
                         instr_count += 1;
                     }
                     FUNC_CODE_INST_EXTRACTVAL => {
-                        let agg = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
+                        let agg = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let indices: Vec<u32> = fields[2..].iter().map(|&x| x as u32).collect();
                         let agg_ty = type_of_vref(&agg, &func, state);
                         // Walk indices to find result type.
@@ -1667,14 +1804,25 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             res_ty,
-                            InstrKind::ExtractValue { aggregate: agg, indices },
+                            InstrKind::ExtractValue {
+                                aggregate: agg,
+                                indices,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
                     }
                     FUNC_CODE_INST_INSERTVAL => {
-                        let agg = decode_relative_vref(cur_val_id, fields.get(1).copied().unwrap_or(0), state)?;
-                        let val = decode_relative_vref(cur_val_id, fields.get(2).copied().unwrap_or(0), state)?;
+                        let agg = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(1).copied().unwrap_or(0),
+                            state,
+                        )?;
+                        let val = decode_relative_vref(
+                            cur_val_id,
+                            fields.get(2).copied().unwrap_or(0),
+                            state,
+                        )?;
                         let indices: Vec<u32> = fields[3..].iter().map(|&x| x as u32).collect();
                         let agg_ty = type_of_vref(&agg, &func, state);
                         let iid = emit_instr(
@@ -1683,7 +1831,11 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             agg_ty,
-                            InstrKind::InsertValue { aggregate: agg, val, indices },
+                            InstrKind::InsertValue {
+                                aggregate: agg,
+                                val,
+                                indices,
+                            },
                         );
                         state.value_table.push(ValueRef::Instruction(iid));
                         instr_count += 1;
@@ -1703,12 +1855,13 @@ fn parse_function_block(
                             cur_block_idx,
                             None,
                             state.ctx.void_ty,
-                            InstrKind::Fence { ordering: llvm_ir::MemOrdering::SeqCst },
+                            InstrKind::Fence {
+                                ordering: llvm_ir::MemOrdering::SeqCst,
+                            },
                         );
                         instr_count += 1;
                     }
-                    FUNC_CODE_INST_DEBUG_LOC
-                    | FUNC_CODE_INST_OPERAND_BUNDLE => {
+                    FUNC_CODE_INST_DEBUG_LOC | FUNC_CODE_INST_OPERAND_BUNDLE => {
                         // Skip debug/operand bundle records.
                     }
                     _ => {
@@ -1742,9 +1895,12 @@ fn decode_relative_vref(
     if encoded == 0 {
         return Err(BitcodeError::ParseError("zero value reference".into()));
     }
-    let abs = cur_val_id
-        .checked_sub(encoded as usize)
-        .ok_or_else(|| BitcodeError::ParseError(format!("value ref underflow: cur={} enc={}", cur_val_id, encoded)))?;
+    let abs = cur_val_id.checked_sub(encoded as usize).ok_or_else(|| {
+        BitcodeError::ParseError(format!(
+            "value ref underflow: cur={} enc={}",
+            cur_val_id, encoded
+        ))
+    })?;
     state.value_table.get(abs).copied().ok_or_else(|| {
         BitcodeError::ParseError(format!(
             "value abs {} out of range (table size {})",
@@ -1793,9 +1949,7 @@ fn extractvalue_type(ctx: &Context, mut ty: TypeId, indices: &[u32]) -> TypeId {
     for &idx in indices {
         let td = ctx.get_type(ty).clone();
         ty = match td {
-            TypeData::Struct(ref st) => {
-                st.fields.get(idx as usize).copied().unwrap_or(ty)
-            }
+            TypeData::Struct(ref st) => st.fields.get(idx as usize).copied().unwrap_or(ty),
             TypeData::Array { element, .. } => element,
             _ => ty,
         };
@@ -1839,25 +1993,65 @@ fn binop_kind(
     let fmf = FastMathFlags::default();
 
     Ok(match opcode {
-        0 => InstrKind::Add { flags: iaf, lhs, rhs },
-        1 => InstrKind::Sub { flags: iaf, lhs, rhs },
-        2 => InstrKind::Mul { flags: iaf, lhs, rhs },
+        0 => InstrKind::Add {
+            flags: iaf,
+            lhs,
+            rhs,
+        },
+        1 => InstrKind::Sub {
+            flags: iaf,
+            lhs,
+            rhs,
+        },
+        2 => InstrKind::Mul {
+            flags: iaf,
+            lhs,
+            rhs,
+        },
         4 => InstrKind::UDiv { exact, lhs, rhs },
         5 => InstrKind::SDiv { exact, lhs, rhs },
         6 => InstrKind::URem { lhs, rhs },
         7 => InstrKind::SRem { lhs, rhs },
-        10 => InstrKind::Shl { flags: iaf, lhs, rhs },
+        10 => InstrKind::Shl {
+            flags: iaf,
+            lhs,
+            rhs,
+        },
         11 => InstrKind::LShr { exact, lhs, rhs },
         12 => InstrKind::AShr { exact, lhs, rhs },
         13 => InstrKind::And { lhs, rhs },
         14 => InstrKind::Or { lhs, rhs },
         15 => InstrKind::Xor { lhs, rhs },
-        17 => InstrKind::FAdd { flags: fmf, lhs, rhs },
-        18 => InstrKind::FSub { flags: fmf, lhs, rhs },
-        19 => InstrKind::FMul { flags: fmf, lhs, rhs },
-        20 => InstrKind::FDiv { flags: fmf, lhs, rhs },
-        21 => InstrKind::FRem { flags: fmf, lhs, rhs },
-        _ => InstrKind::Add { flags: iaf, lhs, rhs },
+        17 => InstrKind::FAdd {
+            flags: fmf,
+            lhs,
+            rhs,
+        },
+        18 => InstrKind::FSub {
+            flags: fmf,
+            lhs,
+            rhs,
+        },
+        19 => InstrKind::FMul {
+            flags: fmf,
+            lhs,
+            rhs,
+        },
+        20 => InstrKind::FDiv {
+            flags: fmf,
+            lhs,
+            rhs,
+        },
+        21 => InstrKind::FRem {
+            flags: fmf,
+            lhs,
+            rhs,
+        },
+        _ => InstrKind::Add {
+            flags: iaf,
+            lhs,
+            rhs,
+        },
     })
 }
 
@@ -1921,7 +2115,7 @@ fn cmp_kind(pred: u64, lhs: ValueRef, rhs: ValueRef) -> InstrKind {
         }
     } else {
         let ip = match pred {
-            32 => IntPredicate::Eq,  // shouldn't happen
+            32 => IntPredicate::Eq, // shouldn't happen
             0 => IntPredicate::Eq,
             1 => IntPredicate::Ne,
             2 => IntPredicate::Ugt,
@@ -1957,7 +2151,11 @@ mod tests {
 
     impl BsWriter {
         fn new() -> Self {
-            BsWriter { buf: Vec::new(), pending: 0, pending_bits: 0 }
+            BsWriter {
+                buf: Vec::new(),
+                pending: 0,
+                pending_bits: 0,
+            }
         }
 
         fn write_bits(&mut self, val: u64, n: usize) {
@@ -2156,8 +2354,8 @@ mod tests {
 
         // Enter MODULE_BLOCK (id=8), new abbrev_len=3.
         w.write_bits(1, 2); // ENTER_SUBBLOCK
-        w.write_vbr(8, 8);  // block_id
-        w.write_vbr(3, 4);  // new abbrev_len
+        w.write_vbr(8, 8); // block_id
+        w.write_vbr(3, 4); // new abbrev_len
         w.align_32();
         // Placeholder for block length (in 32-bit words).
         let block_start_byte = w.buf.len();
@@ -2165,9 +2363,9 @@ mod tests {
 
         // MODULE_CODE_VERSION = 1, version = 2.
         w.write_bits(3, 3); // UNABBREV_RECORD in abbrev_len=3
-        w.write_vbr(1, 6);  // code = MODULE_CODE_VERSION
-        w.write_vbr(1, 6);  // num_ops = 1
-        w.write_vbr(2, 6);  // version = 2
+        w.write_vbr(1, 6); // code = MODULE_CODE_VERSION
+        w.write_vbr(1, 6); // num_ops = 1
+        w.write_vbr(2, 6); // version = 2
 
         // END_BLOCK.
         w.write_bits(0, 3); // END_BLOCK at abbrev_len=3
@@ -2199,12 +2397,13 @@ mod tests {
     fn test_type_table_void_and_integer() {
         // Construct a minimal .bc with a type block containing void + i32.
         // Then verify we can parse it without error.
-        let bc = build_type_table_bc(&[
-            (TYPE_CODE_VOID, vec![]),
-            (TYPE_CODE_INTEGER, vec![32]),
-        ]);
+        let bc = build_type_table_bc(&[(TYPE_CODE_VOID, vec![]), (TYPE_CODE_INTEGER, vec![32])]);
         let result = read_llvm_bc(&bc);
-        assert!(result.is_ok(), "type table parse failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "type table parse failed: {:?}",
+            result.err()
+        );
         let (ctx, _module) = result.unwrap();
         // void_ty and i32_ty are always built in; just check ctx has types.
         assert!(ctx.num_types() > 0);
@@ -2222,14 +2421,19 @@ mod tests {
         let abbrev_module = 3usize;
 
         // Enter MODULE_BLOCK.
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(abbrev_module as u64, 4); w.align_32();
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(abbrev_module as u64, 4);
+        w.align_32();
         let mod_len_offset = w.buf.len();
         w.buf.extend_from_slice(&[0u8; 4]);
 
         {
             // Enter TYPE_BLOCK (id=17), abbrev_len=4.
             w.write_bits(1, abbrev_module as u64 as usize); // ENTER_SUBBLOCK
-            w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
+            w.write_vbr(17, 8);
+            w.write_vbr(4u64, 4);
+            w.align_32();
             let type_len_offset = w.buf.len();
             w.buf.extend_from_slice(&[0u8; 4]);
 
@@ -2237,20 +2441,25 @@ mod tests {
             let n = type_records.len() as u64;
             w.write_bits(3, 4); // UNABBREV_RECORD at abbrev_len=4
             w.write_vbr(TYPE_CODE_NUMENTRY, 6);
-            w.write_vbr(1, 6); w.write_vbr(n, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(n, 6);
 
             for (code, fields) in type_records {
                 w.write_bits(3, 4);
                 w.write_vbr(*code, 6);
                 w.write_vbr(fields.len() as u64, 6);
-                for &f in fields { w.write_vbr(f, 6); }
+                for &f in fields {
+                    w.write_vbr(f, 6);
+                }
             }
 
             // END TYPE_BLOCK.
-            w.write_bits(0, 4); w.align_32();
+            w.write_bits(0, 4);
+            w.align_32();
             let type_end = w.buf.len();
             let type_words = (type_end - type_len_offset - 4) / 4;
-            w.buf[type_len_offset..type_len_offset+4].copy_from_slice(&(type_words as u32).to_le_bytes());
+            w.buf[type_len_offset..type_len_offset + 4]
+                .copy_from_slice(&(type_words as u32).to_le_bytes());
         }
 
         // END MODULE_BLOCK.
@@ -2258,7 +2467,8 @@ mod tests {
         w.align_32();
         let mod_end = w.buf.len();
         let mod_words = (mod_end - mod_len_offset - 4) / 4;
-        w.buf[mod_len_offset..mod_len_offset+4].copy_from_slice(&(mod_words as u32).to_le_bytes());
+        w.buf[mod_len_offset..mod_len_offset + 4]
+            .copy_from_slice(&(mod_words as u32).to_le_bytes());
 
         w.finish()
     }
@@ -2295,11 +2505,11 @@ mod tests {
     #[test]
     fn test_char6_lowercase() {
         use crate::bitstream::*; // for char6 helper
-        // 0..25 = a..z
-        // We verify by going through the bitstream reader reading 6-bit codes.
-        // Construct a byte stream with Char6 abbrev.
-        // Instead, test via the reader low-level. We'll just verify the logic
-        // by checking the VBR-decoded chars are sensible.
+                                 // 0..25 = a..z
+                                 // We verify by going through the bitstream reader reading 6-bit codes.
+                                 // Construct a byte stream with Char6 abbrev.
+                                 // Instead, test via the reader low-level. We'll just verify the logic
+                                 // by checking the VBR-decoded chars are sensible.
         let data: &[u8] = &[0b00000000]; // code 0 = 'a'
         let mut bs = BitStreamReader::new(data);
         assert_eq!(bs.read_bits(6).unwrap(), 0); // code 0 → 'a'
@@ -2326,29 +2536,48 @@ mod tests {
         let al = 3usize; // module abbrev_len
 
         // Enter MODULE_BLOCK.
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(al as u64, 4); w.align_32();
-        let mod_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(al as u64, 4);
+        w.align_32();
+        let mod_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
 
         // TYPE_BLOCK: [void=slot0, i32=slot1, fn(i32)->void=slot2]
-        w.write_bits(1, al); w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
-        let ty_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(17, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let ty_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
             // NUMENTRY 3
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_NUMENTRY, 6); w.write_vbr(1, 6); w.write_vbr(3, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_NUMENTRY, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(3, 6);
             // void
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_VOID, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_VOID, 6);
+            w.write_vbr(0, 6);
             // i32
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_INTEGER, 6); w.write_vbr(1, 6); w.write_vbr(32, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_INTEGER, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(32, 6);
             // fn(i32) -> void: FUNCTION vararg=0, ret=0(void), params=[1(i32)]
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_FUNCTION, 6); w.write_vbr(3, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_FUNCTION, 6);
+            w.write_vbr(3, 6);
             w.write_vbr(0, 6); // vararg
             w.write_vbr(0, 6); // ret = slot 0 (void)
             w.write_vbr(1, 6); // param = slot 1 (i32)
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let ty_end = w.buf.len();
         let ty_words = (ty_end - ty_off - 4) / 4;
-        w.buf[ty_off..ty_off+4].copy_from_slice(&(ty_words as u32).to_le_bytes());
+        w.buf[ty_off..ty_off + 4].copy_from_slice(&(ty_words as u32).to_le_bytes());
 
         // MODULE_CODE_FUNCTION record: ty=2, cc=0, is_decl=1, linkage=0
         w.write_bits(3, al);
@@ -2360,10 +2589,11 @@ mod tests {
         w.write_vbr(0, 6); // linkage = External
 
         // END MODULE.
-        w.write_bits(0, al); w.align_32();
+        w.write_bits(0, al);
+        w.align_32();
         let mod_end = w.buf.len();
         let mod_words = (mod_end - mod_off - 4) / 4;
-        w.buf[mod_off..mod_off+4].copy_from_slice(&(mod_words as u32).to_le_bytes());
+        w.buf[mod_off..mod_off + 4].copy_from_slice(&(mod_words as u32).to_le_bytes());
 
         with_magic(w.finish())
     }
@@ -2384,20 +2614,38 @@ mod tests {
         let al = 3usize;
 
         // Enter MODULE_BLOCK.
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(al as u64, 4); w.align_32();
-        let mod_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(al as u64, 4);
+        w.align_32();
+        let mod_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
 
         // TYPE_BLOCK: void(0), i32(1)
-        w.write_bits(1, al); w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
-        let ty_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(17, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let ty_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_NUMENTRY, 6); w.write_vbr(1, 6); w.write_vbr(2, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_VOID, 6); w.write_vbr(0, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_INTEGER, 6); w.write_vbr(1, 6); w.write_vbr(32, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_NUMENTRY, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(2, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_VOID, 6);
+            w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_INTEGER, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(32, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let ty_end = w.buf.len();
-        w.buf[ty_off..ty_off+4].copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[ty_off..ty_off + 4]
+            .copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
 
         // MODULE_CODE_GLOBALVAR: ty=1(i32), is_const=0, init_id=0 (none), linkage=0, align=0, section=0
         w.write_bits(3, al);
@@ -2411,9 +2659,11 @@ mod tests {
         w.write_vbr(0, 6); // section
 
         // END MODULE.
-        w.write_bits(0, al); w.align_32();
+        w.write_bits(0, al);
+        w.align_32();
         let mod_end = w.buf.len();
-        w.buf[mod_off..mod_off+4].copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[mod_off..mod_off + 4]
+            .copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
 
         with_magic(w.finish())
     }
@@ -2435,23 +2685,40 @@ mod tests {
         let al = 3usize;
 
         // Enter MODULE_BLOCK.
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(al as u64, 4); w.align_32();
-        let mod_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(al as u64, 4);
+        w.align_32();
+        let mod_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
 
         // TYPE_BLOCK: void(0), fn()->void(1)
-        w.write_bits(1, al); w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
-        let ty_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(17, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let ty_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_NUMENTRY, 6); w.write_vbr(1, 6); w.write_vbr(2, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_VOID, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_NUMENTRY, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(2, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_VOID, 6);
+            w.write_vbr(0, 6);
             // fn()->void: FUNCTION, vararg=0, ret=0
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_FUNCTION, 6); w.write_vbr(2, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_FUNCTION, 6);
+            w.write_vbr(2, 6);
             w.write_vbr(0, 6); // vararg
             w.write_vbr(0, 6); // ret = void (slot 0)
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let ty_end = w.buf.len();
-        w.buf[ty_off..ty_off+4].copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[ty_off..ty_off + 4]
+            .copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
 
         // MODULE_CODE_FUNCTION: ty=1, cc=0, is_decl=0, linkage=0
         w.write_bits(3, al);
@@ -2463,22 +2730,35 @@ mod tests {
         w.write_vbr(0, 6); // linkage
 
         // FUNCTION_BLOCK.
-        w.write_bits(1, al); w.write_vbr(12, 8); w.write_vbr(4u64, 4); w.align_32();
-        let fn_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(12, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let fn_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
             // DECLAREBLOCKS: 1 block.
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6); w.write_vbr(1, 6); w.write_vbr(1, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(1, 6);
             // INST_RET with no value.
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_INST_RET, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_INST_RET, 6);
+            w.write_vbr(0, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let fn_end = w.buf.len();
-        w.buf[fn_off..fn_off+4].copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[fn_off..fn_off + 4]
+            .copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
 
         // END MODULE.
-        w.write_bits(0, al); w.align_32();
+        w.write_bits(0, al);
+        w.align_32();
         let mod_end = w.buf.len();
-        w.buf[mod_off..mod_off+4].copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[mod_off..mod_off + 4]
+            .copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
 
         with_magic(w.finish())
     }
@@ -2502,43 +2782,83 @@ mod tests {
         let mut w = BsWriter::new();
         let al = 3usize;
 
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(al as u64, 4); w.align_32();
-        let mod_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(al as u64, 4);
+        w.align_32();
+        let mod_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
 
         // Types: void(0), fn()->void(1)
-        w.write_bits(1, al); w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
-        let ty_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(17, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let ty_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_NUMENTRY, 6); w.write_vbr(1, 6); w.write_vbr(2, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_VOID, 6); w.write_vbr(0, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_FUNCTION, 6); w.write_vbr(2, 6); w.write_vbr(0, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_NUMENTRY, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(2, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_VOID, 6);
+            w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_FUNCTION, 6);
+            w.write_vbr(2, 6);
+            w.write_vbr(0, 6);
+            w.write_vbr(0, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let ty_end = w.buf.len();
-        w.buf[ty_off..ty_off+4].copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[ty_off..ty_off + 4]
+            .copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
 
         // Function declaration.
-        w.write_bits(3, al); w.write_vbr(MODULE_CODE_FUNCTION, 6); w.write_vbr(4, 6);
-        w.write_vbr(1, 6); w.write_vbr(0, 6); w.write_vbr(0, 6); w.write_vbr(0, 6);
+        w.write_bits(3, al);
+        w.write_vbr(MODULE_CODE_FUNCTION, 6);
+        w.write_vbr(4, 6);
+        w.write_vbr(1, 6);
+        w.write_vbr(0, 6);
+        w.write_vbr(0, 6);
+        w.write_vbr(0, 6);
 
         // Function body.
-        w.write_bits(1, al); w.write_vbr(12, 8); w.write_vbr(4u64, 4); w.align_32();
-        let fn_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(12, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let fn_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
             // DECLAREBLOCKS: 2
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6); w.write_vbr(1, 6); w.write_vbr(2, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(2, 6);
             // Block 0: INST_BR dest=1 (unconditional)
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_INST_BR, 6); w.write_vbr(1, 6); w.write_vbr(1, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_INST_BR, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(1, 6);
             // Block 1: INST_RET (no value)
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_INST_RET, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_INST_RET, 6);
+            w.write_vbr(0, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let fn_end = w.buf.len();
-        w.buf[fn_off..fn_off+4].copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[fn_off..fn_off + 4]
+            .copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
 
-        w.write_bits(0, al); w.align_32();
+        w.write_bits(0, al);
+        w.align_32();
         let mod_end = w.buf.len();
-        w.buf[mod_off..mod_off+4].copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[mod_off..mod_off + 4]
+            .copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
 
         with_magic(w.finish())
     }
@@ -2549,7 +2869,11 @@ mod tests {
     fn test_parse_alloca_load_store() {
         let bc = build_alloca_load_store_bc();
         let result = read_llvm_bc(&bc);
-        assert!(result.is_ok(), "alloca/load/store parse failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "alloca/load/store parse failed: {:?}",
+            result.err()
+        );
         let (_ctx, module) = result.unwrap();
         assert_eq!(module.functions.len(), 1);
         // Function should have instructions.
@@ -2561,52 +2885,96 @@ mod tests {
         let mut w = BsWriter::new();
         let al = 3usize;
 
-        w.write_bits(1, 2); w.write_vbr(8, 8); w.write_vbr(al as u64, 4); w.align_32();
-        let mod_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, 2);
+        w.write_vbr(8, 8);
+        w.write_vbr(al as u64, 4);
+        w.align_32();
+        let mod_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
 
         // Types: void(0), i32(1), ptr(2), fn(i32)->void(3)
-        w.write_bits(1, al); w.write_vbr(17, 8); w.write_vbr(4u64, 4); w.align_32();
-        let ty_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(17, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let ty_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_NUMENTRY, 6); w.write_vbr(1, 6); w.write_vbr(4, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_VOID, 6); w.write_vbr(0, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_INTEGER, 6); w.write_vbr(1, 6); w.write_vbr(32, 6);
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_OPAQUE_POINTER, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_NUMENTRY, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(4, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_VOID, 6);
+            w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_INTEGER, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(32, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_OPAQUE_POINTER, 6);
+            w.write_vbr(0, 6);
             // fn(i32)->void
-            w.write_bits(3, 4); w.write_vbr(TYPE_CODE_FUNCTION, 6); w.write_vbr(3, 6);
-            w.write_vbr(0, 6); w.write_vbr(0, 6); w.write_vbr(1, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(TYPE_CODE_FUNCTION, 6);
+            w.write_vbr(3, 6);
+            w.write_vbr(0, 6);
+            w.write_vbr(0, 6);
+            w.write_vbr(1, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let ty_end = w.buf.len();
-        w.buf[ty_off..ty_off+4].copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[ty_off..ty_off + 4]
+            .copy_from_slice(&(((ty_end - ty_off - 4) / 4) as u32).to_le_bytes());
 
         // Function decl.
-        w.write_bits(3, al); w.write_vbr(MODULE_CODE_FUNCTION, 6); w.write_vbr(4, 6);
-        w.write_vbr(3, 6); w.write_vbr(0, 6); w.write_vbr(0, 6); w.write_vbr(0, 6);
+        w.write_bits(3, al);
+        w.write_vbr(MODULE_CODE_FUNCTION, 6);
+        w.write_vbr(4, 6);
+        w.write_vbr(3, 6);
+        w.write_vbr(0, 6);
+        w.write_vbr(0, 6);
+        w.write_vbr(0, 6);
 
         // Function body.
-        w.write_bits(1, al); w.write_vbr(12, 8); w.write_vbr(4u64, 4); w.align_32();
-        let fn_off = w.buf.len(); w.buf.extend_from_slice(&[0u8; 4]);
+        w.write_bits(1, al);
+        w.write_vbr(12, 8);
+        w.write_vbr(4u64, 4);
+        w.align_32();
+        let fn_off = w.buf.len();
+        w.buf.extend_from_slice(&[0u8; 4]);
         {
             // DECLAREBLOCKS: 1
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6); w.write_vbr(1, 6); w.write_vbr(1, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_DECLAREBLOCKS, 6);
+            w.write_vbr(1, 6);
+            w.write_vbr(1, 6);
             // ALLOCA i32 (inst_ty=1=i32, op_ty=1=i32, size=1, align=0)
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_INST_ALLOCA, 6); w.write_vbr(4, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_INST_ALLOCA, 6);
+            w.write_vbr(4, 6);
             w.write_vbr(1, 6); // inst_ty = i32
             w.write_vbr(1, 6); // op_ty = i32
             w.write_vbr(1, 6); // size
             w.write_vbr(0, 6); // align_encoded
 
             // RET void
-            w.write_bits(3, 4); w.write_vbr(FUNC_CODE_INST_RET, 6); w.write_vbr(0, 6);
+            w.write_bits(3, 4);
+            w.write_vbr(FUNC_CODE_INST_RET, 6);
+            w.write_vbr(0, 6);
         }
-        w.write_bits(0, 4); w.align_32();
+        w.write_bits(0, 4);
+        w.align_32();
         let fn_end = w.buf.len();
-        w.buf[fn_off..fn_off+4].copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[fn_off..fn_off + 4]
+            .copy_from_slice(&(((fn_end - fn_off - 4) / 4) as u32).to_le_bytes());
 
-        w.write_bits(0, al); w.align_32();
+        w.write_bits(0, al);
+        w.align_32();
         let mod_end = w.buf.len();
-        w.buf[mod_off..mod_off+4].copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
+        w.buf[mod_off..mod_off + 4]
+            .copy_from_slice(&(((mod_end - mod_off - 4) / 4) as u32).to_le_bytes());
 
         with_magic(w.finish())
     }
@@ -2625,7 +2993,11 @@ mod tests {
             (TYPE_CODE_INTEGER, vec![64]),
         ]);
         let result = read_llvm_bc(&bc);
-        assert!(result.is_ok(), "float/double type parse failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "float/double type parse failed: {:?}",
+            result.err()
+        );
     }
 
     // ── 15. Opaque pointer type ───────────────────────────────────────────────
@@ -2637,6 +3009,10 @@ mod tests {
             (TYPE_CODE_OPAQUE_POINTER, vec![0]),
         ]);
         let result = read_llvm_bc(&bc);
-        assert!(result.is_ok(), "opaque ptr type parse failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "opaque ptr type parse failed: {:?}",
+            result.err()
+        );
     }
 }

--- a/src/llvm-bitcode/src/reader.rs
+++ b/src/llvm-bitcode/src/reader.rs
@@ -5,8 +5,8 @@ use llvm_ir::value::Argument;
 use llvm_ir::{
     ArgId, BasicBlock, BlockId, ConstId, ConstantData, Context, FastMathFlags, FloatKind,
     FloatPredicate, Function, GlobalId, GlobalVariable, InstrId, InstrKind, Instruction,
-    IntArithFlags, IntPredicate, Linkage, MemOrdering, Module, RmwOp, TailCallKind,
-    TypeData, TypeId, ValueRef,
+    IntArithFlags, IntPredicate, Linkage, MemOrdering, Module, RmwOp, TailCallKind, TypeData,
+    TypeId, ValueRef,
 };
 
 /// Magic bytes for the LRIR format.
@@ -1289,17 +1289,27 @@ fn decode_instr(
                 handlers.push(BlockId(r.u32()?));
             }
             let default = decode_opt_u32(r)?.map(BlockId);
-            InstrKind::CatchSwitch { parent, handlers, default }
+            InstrKind::CatchSwitch {
+                parent,
+                handlers,
+                default,
+            }
         }
         instr_tag::CATCHRET => {
             let catch_pad = decode_vref(r)?;
             let successor = BlockId(r.u32()?);
-            InstrKind::CatchRet { catch_pad, successor }
+            InstrKind::CatchRet {
+                catch_pad,
+                successor,
+            }
         }
         instr_tag::CLEANUPRET => {
             let cleanup_pad = decode_vref(r)?;
             let unwind_dest = decode_opt_u32(r)?.map(BlockId);
-            InstrKind::CleanupRet { cleanup_pad, unwind_dest }
+            InstrKind::CleanupRet {
+                cleanup_pad,
+                unwind_dest,
+            }
         }
         other => return Err(BitcodeError::UnsupportedRecord(other)),
     };

--- a/src/llvm-bitcode/src/writer.rs
+++ b/src/llvm-bitcode/src/writer.rs
@@ -1112,7 +1112,10 @@ fn encode_instr(w: &mut Writer, instr: &Instruction) {
             }
             encode_opt_u32(w, default.map(|b| b.0));
         }
-        CatchRet { catch_pad, successor } => {
+        CatchRet {
+            catch_pad,
+            successor,
+        } => {
             w.u32(instr_tag::CATCHRET);
             encode_vref(w, catch_pad);
             w.u32(successor.0);

--- a/src/llvm-codegen/src/cfi.rs
+++ b/src/llvm-codegen/src/cfi.rs
@@ -55,7 +55,10 @@ impl CfiInstr {
                 v.extend(encode_uleb128(*offset as u64));
                 v
             }
-            CfiInstr::Offset { reg, factored_offset } => {
+            CfiInstr::Offset {
+                reg,
+                factored_offset,
+            } => {
                 // DW_CFA_offset: high 2 bits = 0b10, low 6 bits = reg
                 let mut v = vec![0x80 | (reg & 0x3f)];
                 v.extend(encode_uleb128(*factored_offset as u64));
@@ -133,7 +136,13 @@ impl CfiWriter {
         // DW_CFA_def_cfa(RSP=7, 8): at function entry CFA = RSP+8
         body.extend(CfiInstr::DefCfa { reg: 7, offset: 8 }.encode());
         // DW_CFA_offset(RIP=16, 1): return address saved at CFA-8 (factored offset 8/8=1)
-        body.extend(CfiInstr::Offset { reg: 16, factored_offset: 1 }.encode());
+        body.extend(
+            CfiInstr::Offset {
+                reg: 16,
+                factored_offset: 1,
+            }
+            .encode(),
+        );
 
         // Pad to 8-byte boundary (length field + body must be 8-byte aligned).
         // The total record = 4 (length) + body.len(); pad body so total is multiple of 8.
@@ -254,7 +263,10 @@ pub fn x86_fp_prologue_cfi() -> Vec<CfiInstr> {
         CfiInstr::AdvanceLoc(1),
         CfiInstr::DefCfaOffset(16),
         // RBP was saved at CFA-16 (factored: 16/8 = 2).
-        CfiInstr::Offset { reg: 6, factored_offset: 2 },
+        CfiInstr::Offset {
+            reg: 6,
+            factored_offset: 2,
+        },
         // After "mov rbp, rsp" (3 bytes), CFA register switches to RBP.
         CfiInstr::AdvanceLoc(3),
         CfiInstr::DefCfaRegister(6),
@@ -311,7 +323,11 @@ mod tests {
     fn cfi_offset_reg6_factor2() {
         // DW_CFA_offset(reg=6, factored_offset=2): 0x80 | 6 = 0x86, then ULEB128(2)=0x02
         assert_eq!(
-            CfiInstr::Offset { reg: 6, factored_offset: 2 }.encode(),
+            CfiInstr::Offset {
+                reg: 6,
+                factored_offset: 2
+            }
+            .encode(),
             vec![0x86, 0x02]
         );
     }
@@ -320,7 +336,11 @@ mod tests {
     fn cfi_offset_rip_factor1() {
         // DW_CFA_offset(reg=16, factored_offset=1): 0x80 | 16 = 0x90, ULEB128(1)=0x01
         assert_eq!(
-            CfiInstr::Offset { reg: 16, factored_offset: 1 }.encode(),
+            CfiInstr::Offset {
+                reg: 16,
+                factored_offset: 1
+            }
+            .encode(),
             vec![0x90, 0x01]
         );
     }
@@ -397,7 +417,10 @@ mod tests {
         let cie_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
         // The CIE record occupies 4 (length field) + cie_len bytes.
         let cie_total = 4 + cie_len;
-        assert!(bytes.len() > cie_total, "output must contain more than the CIE");
+        assert!(
+            bytes.len() > cie_total,
+            "output must contain more than the CIE"
+        );
 
         // The FDE starts at cie_total.
         let fde_off = cie_total;
@@ -456,14 +479,26 @@ mod tests {
         assert_eq!(instrs.len(), 5);
         assert_eq!(instrs[0], CfiInstr::AdvanceLoc(1));
         assert_eq!(instrs[1], CfiInstr::DefCfaOffset(16));
-        assert_eq!(instrs[2], CfiInstr::Offset { reg: 6, factored_offset: 2 });
+        assert_eq!(
+            instrs[2],
+            CfiInstr::Offset {
+                reg: 6,
+                factored_offset: 2
+            }
+        );
         assert_eq!(instrs[3], CfiInstr::AdvanceLoc(3));
         assert_eq!(instrs[4], CfiInstr::DefCfaRegister(6));
 
         // Verify the encoded bytes include def_cfa_offset and def_cfa_register opcodes.
         let encoded: Vec<u8> = instrs.iter().flat_map(|i| i.encode()).collect();
-        assert!(encoded.contains(&0x0e), "must contain DW_CFA_def_cfa_offset");
-        assert!(encoded.contains(&0x0d), "must contain DW_CFA_def_cfa_register");
+        assert!(
+            encoded.contains(&0x0e),
+            "must contain DW_CFA_def_cfa_offset"
+        );
+        assert!(
+            encoded.contains(&0x0d),
+            "must contain DW_CFA_def_cfa_register"
+        );
     }
 
     #[test]

--- a/src/llvm-codegen/src/dwarf_vars.rs
+++ b/src/llvm-codegen/src/dwarf_vars.rs
@@ -93,7 +93,7 @@ pub fn build_variable_die(
     // DW_AT_name as DW_FORM_string (null-terminated)
     die.extend_from_slice(name.as_bytes());
     die.push(0u8); // null terminator
-    // DW_AT_type as DW_FORM_ref4
+                   // DW_AT_type as DW_FORM_ref4
     die.extend_from_slice(&type_die_offset.to_le_bytes());
     // DW_AT_location as DW_FORM_exprloc (ULEB128 length + expr)
     let expr = encode_location(loc);

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -176,7 +176,8 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
             });
         }
         ObjectFormat::Coff => {
-            let (xdata, pdata) = build_coff_unwind_tables(size, mf.frame_size, &mf.used_callee_saved);
+            let (xdata, pdata) =
+                build_coff_unwind_tables(size, mf.frame_size, &mf.used_callee_saved);
             sections.push(Section {
                 name: ".xdata".into(),
                 data: xdata,
@@ -276,18 +277,21 @@ pub fn emit_object(mf: &MachineFunction, emitter: &mut dyn Emitter) -> ObjectFil
     for sec in &mut sections {
         for reloc in &mut sec.relocs {
             if let Some(ref ext) = reloc.external_name.clone() {
-                let idx = symbols.iter().position(|s| &s.name == ext).unwrap_or_else(|| {
-                    let i = symbols.len();
-                    symbols.push(Symbol {
-                        name: ext.clone(),
-                        section: 0,
-                        offset: 0,
-                        size: 0,
-                        global: true,
-                        undefined: true,
+                let idx = symbols
+                    .iter()
+                    .position(|s| &s.name == ext)
+                    .unwrap_or_else(|| {
+                        let i = symbols.len();
+                        symbols.push(Symbol {
+                            name: ext.clone(),
+                            section: 0,
+                            offset: 0,
+                            size: 0,
+                            global: true,
+                            undefined: true,
+                        });
+                        i
                     });
-                    i
-                });
                 reloc.symbol = idx;
             }
         }
@@ -341,9 +345,13 @@ fn serialize_elf(obj: &ObjectFile) -> Vec<u8> {
         }
     };
     let sec_align = |name: &str| -> u64 {
-        if name == ".text" || name == "__text" { 16 }
-        else if name == ".data" || name.starts_with(".rodata") { 8 }
-        else { 1 }
+        if name == ".text" || name == "__text" {
+            16
+        } else if name == ".data" || name.starts_with(".rodata") {
+            8
+        } else {
+            1
+        }
     };
 
     // Identify sections with relocs — we'll emit a .rela.<name> for each.
@@ -607,11 +615,11 @@ fn build_debug_line(source_file: &str, rows: &[DebugLineRow]) -> Vec<u8> {
     let file = source_file.rsplit('/').next().unwrap_or(source_file);
 
     let mut header_body = vec![
-        1u8, // minimum_instruction_length
-        1,   // default_is_stmt
+        1u8,          // minimum_instruction_length
+        1,            // default_is_stmt
         (-5i8) as u8, // line_base
-        14,  // line_range
-        13,  // opcode_base
+        14,           // line_range
+        13,           // opcode_base
     ];
     header_body.extend_from_slice(&[0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1]); // std opcode lengths
     header_body.push(0); // include_directories terminator
@@ -868,7 +876,10 @@ fn build_eh_frame(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -
         // After "push rbp" (1 byte): CFA = RSP+16, RBP saved at CFA-16.
         prologue_cfi.push(CfiInstr::AdvanceLoc(1));
         prologue_cfi.push(CfiInstr::DefCfaOffset(16));
-        prologue_cfi.push(CfiInstr::Offset { reg: 6, factored_offset: 2 });
+        prologue_cfi.push(CfiInstr::Offset {
+            reg: 6,
+            factored_offset: 2,
+        });
 
         // After "mov rbp, rsp" (3 bytes): CFA register = RBP.
         prologue_cfi.push(CfiInstr::AdvanceLoc(3));
@@ -884,20 +895,23 @@ fn build_eh_frame(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -
             // Our PReg: 0=RAX,1=RCX,2=RDX,3=RBX,4=RSP,5=RBP,6=RSI,7=RDI,8=R8..15=R15
             // DWARF:    RAX=0,RDX=1,RCX=2,RBX=3,RSI=4,RDI=5,RBP=6,RSP=7,R8-R15=8-15
             let dwarf_reg: u8 = match pr.0 {
-                0 => 0,  // RAX
-                1 => 2,  // RCX → DWARF 2
-                2 => 1,  // RDX → DWARF 1
-                3 => 3,  // RBX → DWARF 3
-                4 => 7,  // RSP → DWARF 7
-                5 => 6,  // RBP → DWARF 6
-                6 => 4,  // RSI → DWARF 4
-                7 => 5,  // RDI → DWARF 5
-                n => n,  // R8-R15 → DWARF 8-15 (same number)
+                0 => 0, // RAX
+                1 => 2, // RCX → DWARF 2
+                2 => 1, // RDX → DWARF 1
+                3 => 3, // RBX → DWARF 3
+                4 => 7, // RSP → DWARF 7
+                5 => 6, // RBP → DWARF 6
+                6 => 4, // RSI → DWARF 4
+                7 => 5, // RDI → DWARF 5
+                n => n, // R8-R15 → DWARF 8-15 (same number)
             };
             if reg <= 0x3f {
                 prologue_cfi.push(CfiInstr::AdvanceLoc(push_len));
                 let factored = 3u32 + idx as u32; // CFA-((3+idx)*8): after RA+RBP slots
-                prologue_cfi.push(CfiInstr::Offset { reg: dwarf_reg, factored_offset: factored });
+                prologue_cfi.push(CfiInstr::Offset {
+                    reg: dwarf_reg,
+                    factored_offset: factored,
+                });
             }
         }
     }
@@ -906,7 +920,11 @@ fn build_eh_frame(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -
     cfi.assemble()
 }
 
-fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -> (Vec<u8>, Vec<u8>) {
+fn build_coff_unwind_tables(
+    text_size: u64,
+    frame_size: u32,
+    used_callee_saved: &[PReg],
+) -> (Vec<u8>, Vec<u8>) {
     // Build UNWIND_INFO from prologue facts.
     //
     // Normal prologue byte layout (alloc ≤ 4096):
@@ -928,7 +946,11 @@ fn build_coff_unwind_tables(text_size: u64, frame_size: u32, used_callee_saved: 
     let has_frame = frame_size > 0 || !used_callee_saved.is_empty();
 
     // Round frame allocation up to 16-byte boundary.
-    let alloc_size: u32 = if frame_size == 0 { 0 } else { (frame_size + 15) & !15 };
+    let alloc_size: u32 = if frame_size == 0 {
+        0
+    } else {
+        (frame_size + 15) & !15
+    };
 
     // Instruction bytes consumed by callee-saved pushes (1 byte for rax-rdi, 2 for r8-r15).
     let callee_push_instr_bytes: u32 = used_callee_saved
@@ -1287,14 +1309,14 @@ fn write_coff_name_field(buf: &mut Vec<u8>, name: &str, strtab_off: u32) {
 
 fn coff_section_characteristics(name: &str) -> u32 {
     match name {
-        ".text" => 0x60000020,  // CNT_CODE | MEM_EXECUTE | MEM_READ
+        ".text" => 0x60000020, // CNT_CODE | MEM_EXECUTE | MEM_READ
         // .pdata/.xdata require explicit alignment so the SEH unwinder can
         // locate entries at load time; lld-link rejects missing alignment flags.
         ".pdata" => 0x40300040, // CNT_INITIALIZED_DATA | MEM_READ | ALIGN_4BYTES
         ".xdata" => 0x40400040, // CNT_INITIALIZED_DATA | MEM_READ | ALIGN_8BYTES
         ".rdata" => 0x40000040, // CNT_INITIALIZED_DATA | MEM_READ
         n if n.starts_with(".debug") => 0x42000040, // CNT_INITIALIZED_DATA | MEM_READ | MEM_DISCARDABLE
-        _ => 0x40000040, // CNT_INITIALIZED_DATA | MEM_READ
+        _ => 0x40000040,                            // CNT_INITIALIZED_DATA | MEM_READ
     }
 }
 
@@ -1355,7 +1377,7 @@ fn build_codeview_debug_s(
     sym_payload.push(0); // flags
     sym_payload.extend_from_slice(name_bytes);
     sym_payload.push(0); // null terminator
-    // S_END (0x0006) — closes the GPROC32 block
+                         // S_END (0x0006) — closes the GPROC32 block
     w16(&mut sym_payload, 2); // reclen
     w16(&mut sym_payload, 0x0006); // S_END
 
@@ -1414,7 +1436,7 @@ fn build_codeview_debug_s(
     w16(&mut lines_payload, 1); // iSeg (.text = section 1)
     w16(&mut lines_payload, 0); // flags (no columns)
     w32(&mut lines_payload, text_size as u32); // cbCon
-    // File block
+                                               // File block
     w32(&mut lines_payload, 0); // fileid (offset 0 in FILECHKSMS)
     w32(&mut lines_payload, nlines);
     w32(&mut lines_payload, cb_file_info);
@@ -1766,9 +1788,15 @@ mod tests {
             .clone();
 
         // Expect def_cfa_offset opcode (0x0e) in FDE program when frame facts exist.
-        assert!(eh.contains(&0x0e), "expected DW_CFA_def_cfa_offset in frame-aware FDE");
+        assert!(
+            eh.contains(&0x0e),
+            "expected DW_CFA_def_cfa_offset in frame-aware FDE"
+        );
         // Expect def_cfa_register opcode (0x0d) when frame pointer model is active.
-        assert!(eh.contains(&0x0d), "expected DW_CFA_def_cfa_register in frame-aware FDE");
+        assert!(
+            eh.contains(&0x0d),
+            "expected DW_CFA_def_cfa_register in frame-aware FDE"
+        );
     }
 
     #[test]
@@ -1815,12 +1843,25 @@ mod tests {
 
         // FDE starts at aligned boundary after first record.
         let fde_off = (4 + cie_len + 7) & !7;
-        let fde_len = u32::from_le_bytes([eh[fde_off], eh[fde_off + 1], eh[fde_off + 2], eh[fde_off + 3]]) as usize;
-        assert!(fde_len >= 12, "FDE should contain init loc + range + aug len");
+        let fde_len = u32::from_le_bytes([
+            eh[fde_off],
+            eh[fde_off + 1],
+            eh[fde_off + 2],
+            eh[fde_off + 3],
+        ]) as usize;
+        assert!(
+            fde_len >= 12,
+            "FDE should contain init loc + range + aug len"
+        );
 
         // FDE payload: [CIE ptr][init loc][range][aug-len]
         let range_off = fde_off + 4 + 4 + 4;
-        let range = u32::from_le_bytes([eh[range_off], eh[range_off + 1], eh[range_off + 2], eh[range_off + 3]]);
+        let range = u32::from_le_bytes([
+            eh[range_off],
+            eh[range_off + 1],
+            eh[range_off + 2],
+            eh[range_off + 3],
+        ]);
         assert_eq!(range, 3, "FDE range should match text size");
 
         // .eh_frame terminator record exists.
@@ -1862,9 +1903,15 @@ mod tests {
             .expect(".xdata section")
             .data
             .clone();
-        assert!(xdata.len() >= 8, "unwind info should include at least one code slot");
+        assert!(
+            xdata.len() >= 8,
+            "unwind info should include at least one code slot"
+        );
         assert_eq!(xdata[0] & 0x7, 1, "UNWIND_INFO version 1");
-        assert!(xdata[2] >= 1, "count_of_codes should be non-zero when frame facts exist");
+        assert!(
+            xdata[2] >= 1,
+            "count_of_codes should be non-zero when frame facts exist"
+        );
         assert_eq!(xdata[3] & 0x0f, 5, "frame register should be RBP");
     }
 
@@ -1919,7 +1966,10 @@ mod tests {
 
         assert_eq!(begin, 0);
         assert_eq!(end, 2, "runtime function end should match text size");
-        assert_eq!(unwind_info_rva, 0, "points at section-local xdata start in this object model");
+        assert_eq!(
+            unwind_info_rva, 0,
+            "points at section-local xdata start in this object model"
+        );
     }
 
     #[test]
@@ -1978,17 +2028,29 @@ mod tests {
         struct NopCoff;
         impl Emitter for NopCoff {
             fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
-                Section { name: ".text".into(), data: vec![0xC3], relocs: vec![], debug_rows: vec![] }
+                Section {
+                    name: ".text".into(),
+                    data: vec![0xC3],
+                    relocs: vec![],
+                    debug_rows: vec![],
+                }
             }
-            fn object_format(&self) -> ObjectFormat { ObjectFormat::Coff }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Coff
+            }
         }
         let mut mf = MachineFunction::new("pdata_test".into());
-        mf.blocks.push(MachineBlock { label: "entry".into(), instrs: vec![] });
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
         mf.frame_size = 8;
         let bytes = emit_object(&mf, &mut NopCoff).to_bytes();
-        let chars = coff_section_chars(&bytes, b".pdata")
-            .expect(".pdata section not found");
-        assert_eq!(chars, 0x40300040, ".pdata must have ALIGN_4BYTES (0x40300040)");
+        let chars = coff_section_chars(&bytes, b".pdata").expect(".pdata section not found");
+        assert_eq!(
+            chars, 0x40300040,
+            ".pdata must have ALIGN_4BYTES (0x40300040)"
+        );
     }
 
     #[test]
@@ -1999,17 +2061,29 @@ mod tests {
         struct NopCoff;
         impl Emitter for NopCoff {
             fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
-                Section { name: ".text".into(), data: vec![0xC3], relocs: vec![], debug_rows: vec![] }
+                Section {
+                    name: ".text".into(),
+                    data: vec![0xC3],
+                    relocs: vec![],
+                    debug_rows: vec![],
+                }
             }
-            fn object_format(&self) -> ObjectFormat { ObjectFormat::Coff }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Coff
+            }
         }
         let mut mf = MachineFunction::new("xdata_test".into());
-        mf.blocks.push(MachineBlock { label: "entry".into(), instrs: vec![] });
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
         mf.frame_size = 8;
         let bytes = emit_object(&mf, &mut NopCoff).to_bytes();
-        let chars = coff_section_chars(&bytes, b".xdata")
-            .expect(".xdata section not found");
-        assert_eq!(chars, 0x40400040, ".xdata must have ALIGN_8BYTES (0x40400040)");
+        let chars = coff_section_chars(&bytes, b".xdata").expect(".xdata section not found");
+        assert_eq!(
+            chars, 0x40400040,
+            ".xdata must have ALIGN_8BYTES (0x40400040)"
+        );
     }
 
     #[test]
@@ -2020,15 +2094,30 @@ mod tests {
             format: ObjectFormat::Coff,
             elf_machine: 0,
             coff_machine: 0x8664,
-            sections: vec![Section { name: ".text".into(), data: vec![0xC3], relocs: vec![], debug_rows: vec![] }],
-            symbols: vec![Symbol { name: "fn".into(), section: 0, offset: 0, size: 1, global: true, undefined: false }],
+            sections: vec![Section {
+                name: ".text".into(),
+                data: vec![0xC3],
+                relocs: vec![],
+                debug_rows: vec![],
+            }],
+            symbols: vec![Symbol {
+                name: "fn".into(),
+                section: 0,
+                offset: 0,
+                size: 1,
+                global: true,
+                undefined: false,
+            }],
         };
         let bytes = obj.to_bytes();
         let symtab_ptr = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]) as usize;
         // IMAGE_SYMBOL layout: Name(8) + Value(4) + SectionNumber(2) + Type(2) + ...
         // Type field starts at offset 14 within each 18-byte symbol record.
         let type_field = u16::from_le_bytes([bytes[symtab_ptr + 14], bytes[symtab_ptr + 15]]);
-        assert_eq!(type_field, 0x0020, "external function symbols must have Type = 0x0020");
+        assert_eq!(
+            type_field, 0x0020,
+            "external function symbols must have Type = 0x0020"
+        );
     }
 
     #[test]
@@ -2039,22 +2128,48 @@ mod tests {
         struct NopCoff;
         impl Emitter for NopCoff {
             fn emit_function(&mut self, _mf: &MachineFunction) -> Section {
-                Section { name: ".text".into(), data: vec![0xC3], relocs: vec![], debug_rows: vec![] }
+                Section {
+                    name: ".text".into(),
+                    data: vec![0xC3],
+                    relocs: vec![],
+                    debug_rows: vec![],
+                }
             }
-            fn object_format(&self) -> ObjectFormat { ObjectFormat::Coff }
+            fn object_format(&self) -> ObjectFormat {
+                ObjectFormat::Coff
+            }
         }
         let mut mf = MachineFunction::new("large_frame".into());
-        mf.blocks.push(MachineBlock { label: "entry".into(), instrs: vec![] });
+        mf.blocks.push(MachineBlock {
+            label: "entry".into(),
+            instrs: vec![],
+        });
         mf.frame_size = 256;
         let obj = emit_object(&mf, &mut NopCoff);
-        let xdata = obj.sections.iter().find(|s| s.name == ".xdata")
-            .expect(".xdata section").data.clone();
+        let xdata = obj
+            .sections
+            .iter()
+            .find(|s| s.name == ".xdata")
+            .expect(".xdata section")
+            .data
+            .clone();
         // CountOfCodes = xdata[2]. ALLOC_LARGE uses 2 slots, PUSH_NONVOL for RBP = 1 → total = 3.
-        assert_eq!(xdata[2], 3, "ALLOC_LARGE(2 slots) + PUSH_NONVOL(1 slot) = 3 total");
+        assert_eq!(
+            xdata[2], 3,
+            "ALLOC_LARGE(2 slots) + PUSH_NONVOL(1 slot) = 3 total"
+        );
         // Header is 4 bytes; first code slot at offset 4.
         // First code must be UWOP_ALLOC_LARGE (op=1, info=0) → byte[5] low nibble = 1.
-        assert_eq!(xdata[5] & 0x0f, 1, "first unwind op must be UWOP_ALLOC_LARGE (1)");
-        assert_eq!(xdata[5] >> 4, 0, "UWOP_ALLOC_LARGE info must be 0 for sizes ≤ 512 KiB");
+        assert_eq!(
+            xdata[5] & 0x0f,
+            1,
+            "first unwind op must be UWOP_ALLOC_LARGE (1)"
+        );
+        assert_eq!(
+            xdata[5] >> 4,
+            0,
+            "UWOP_ALLOC_LARGE info must be 0 for sizes ≤ 512 KiB"
+        );
         // Slots 1 encodes alloc_size/8 = 256/8 = 32.
         let operand = u16::from_le_bytes([xdata[6], xdata[7]]);
         assert_eq!(operand, 32, "ALLOC_LARGE operand must be alloc_size/8 = 32");
@@ -2064,8 +2179,7 @@ mod tests {
 // ── Global-variable data section emission ─────────────────────────────────
 
 use llvm_ir::{
-    context::ConstId,
-    ConstExprOp, ConstantData, Context, FloatKind, Linkage, Module, TypeData,
+    context::ConstId, ConstExprOp, ConstantData, Context, FloatKind, Linkage, Module, TypeData,
 };
 use std::collections::HashMap;
 
@@ -2157,8 +2271,7 @@ fn gep_byte_offset(ctx: &Context, base_ty: llvm_ir::context::TypeId, indices: &[
                 TypeData::Struct(st) => {
                     let fi = idx as usize;
                     let flds: Vec<_> = st.fields.clone();
-                    offset +=
-                        struct_field_byte_offset(ctx, &flds, fi, st.packed) as i64;
+                    offset += struct_field_byte_offset(ctx, &flds, fi, st.packed) as i64;
                     if fi < flds.len() {
                         cur_ty = flds[fi];
                     }
@@ -2198,7 +2311,8 @@ fn eval_const_bytes(
             let byte_count = (match ctx.get_type(ty) {
                 TypeData::Integer(b) => *b,
                 _ => 64,
-            } as u64).div_ceil(8);
+            } as u64)
+                .div_ceil(8);
             for i in 0..byte_count {
                 out.push((val >> (i * 8)) as u8);
             }
@@ -2240,9 +2354,17 @@ fn eval_const_bytes(
             let struct_start = out.len();
             for (i, fld_cid) in fields.iter().enumerate() {
                 let fty = field_tys.get(i).copied().unwrap_or(ctx.i8_ty);
-                let al = if is_packed { 1 } else { align_of_ty(ctx, fty) as usize };
+                let al = if is_packed {
+                    1
+                } else {
+                    align_of_ty(ctx, fty) as usize
+                };
                 let local_pos = out.len() - struct_start;
-                let pad = if al > 0 { (al - local_pos % al) % al } else { 0 };
+                let pad = if al > 0 {
+                    (al - local_pos % al) % al
+                } else {
+                    0
+                };
                 out.extend(std::iter::repeat_n(0u8, pad));
                 eval_const_bytes(ctx, *fld_cid, sec_base, global_sym_map, relocs, out);
             }
@@ -2266,8 +2388,10 @@ fn eval_const_bytes(
                     }
                 }
                 ConstExprOp::GetElementPtr { base_ty, .. } => {
-                    let indices: Vec<i64> =
-                        operands[1..].iter().map(|&c| const_as_i64(ctx, c)).collect();
+                    let indices: Vec<i64> = operands[1..]
+                        .iter()
+                        .map(|&c| const_as_i64(ctx, c))
+                        .collect();
                     let addend = gep_byte_offset(ctx, base_ty, &indices);
                     match ctx.get_const(operands[0]).clone() {
                         ConstantData::GlobalRef { name, .. } => {
@@ -2275,7 +2399,12 @@ fn eval_const_bytes(
                         }
                         _ => {
                             eval_const_bytes(
-                                ctx, operands[0], sec_base, global_sym_map, relocs, out,
+                                ctx,
+                                operands[0],
+                                sec_base,
+                                global_sym_map,
+                                relocs,
+                                out,
                             );
                         }
                     }
@@ -2300,7 +2429,9 @@ fn eval_const_bytes(
                     };
                     let byte_count = (int_bits as usize).div_ceil(8);
                     if let Some(&base_cid) = operands.first() {
-                        if let ConstantData::GlobalRef { name, .. } = ctx.get_const(base_cid).clone() {
+                        if let ConstantData::GlobalRef { name, .. } =
+                            ctx.get_const(base_cid).clone()
+                        {
                             push_ptr_reloc(sec_base, &name, 0, global_sym_map, relocs, out);
                             // push_ptr_reloc always emits 8 bytes; truncate if int is narrower
                             if byte_count < 8 {
@@ -2322,11 +2453,19 @@ fn eval_const_bytes(
                     if let Some(&src_cid) = operands.first() {
                         let mut src_buf = Vec::new();
                         eval_const_bytes(
-                            ctx, src_cid, sec_base, global_sym_map, relocs, &mut src_buf,
+                            ctx,
+                            src_cid,
+                            sec_base,
+                            global_sym_map,
+                            relocs,
+                            &mut src_buf,
                         );
                         let sign_extend = op == ConstExprOp::SExt;
                         let fill = if sign_extend {
-                            src_buf.last().map(|&b| if b & 0x80 != 0 { 0xFF } else { 0 }).unwrap_or(0)
+                            src_buf
+                                .last()
+                                .map(|&b| if b & 0x80 != 0 { 0xFF } else { 0 })
+                                .unwrap_or(0)
                         } else {
                             0
                         };
@@ -2437,7 +2576,11 @@ pub fn emit_globals(
         // Natural alignment: min of sizeof(ty), 16.
         let sz = sizeof_ty(ctx, gv.ty) as usize;
         let al = (sz as u64).clamp(1, 16) as usize;
-        let pad = if al > 0 { (al - sec.data.len() % al) % al } else { 0 };
+        let pad = if al > 0 {
+            (al - sec.data.len() % al) % al
+        } else {
+            0
+        };
         sec.data.extend(std::iter::repeat_n(0u8, pad));
 
         let global_offset = sec.data.len() as u64;

--- a/src/llvm-codegen/src/intrinsics.rs
+++ b/src/llvm-codegen/src/intrinsics.rs
@@ -177,7 +177,10 @@ mod tests {
         let mut mf = empty_mf();
         let handled = lower_intrinsic("llvm.assume", &[], &mut mf, 0);
         assert!(handled);
-        assert!(mf.blocks[0].instrs.is_empty(), "assume should emit no instructions");
+        assert!(
+            mf.blocks[0].instrs.is_empty(),
+            "assume should emit no instructions"
+        );
     }
 
     #[test]
@@ -272,7 +275,10 @@ mod tests {
         let mut mf = empty_mf();
         let handled = lower_intrinsic("llvm.unknown_xyz_42", &[], &mut mf, 0);
         assert!(!handled, "unknown intrinsics must return false");
-        assert!(mf.blocks[0].instrs.is_empty(), "no instructions emitted for unknown");
+        assert!(
+            mf.blocks[0].instrs.is_empty(),
+            "no instructions emitted for unknown"
+        );
     }
 
     #[test]

--- a/src/llvm-codegen/src/lib.rs
+++ b/src/llvm-codegen/src/lib.rs
@@ -6,6 +6,8 @@ pub mod cfi;
 pub mod dwarf_vars;
 /// Public API for `emit`.
 pub mod emit;
+/// LLVM intrinsic recognition and lowering.
+pub mod intrinsics;
 /// Public API for `isel`.
 pub mod isel;
 /// Public API for `legalize`.
@@ -14,8 +16,6 @@ pub mod legalize;
 pub mod regalloc;
 /// Public API for `regalloc_gc`.
 pub mod regalloc_gc;
-/// LLVM intrinsic recognition and lowering.
-pub mod intrinsics;
 /// Public API for `schedule`.
 pub mod schedule;
 
@@ -25,26 +25,28 @@ pub use assembler::{
     McAssembler, McAssemblyReport,
 };
 /// Public API for `re-export`.
+pub use cfi::{x86_fp_prologue_cfi, CfiInstr, CfiWriter};
+/// Public API for `re-export`.
+pub use dwarf_vars::{
+    build_variable_die, encode_breg6, encode_location, encode_reg, encode_sleb128, encode_uleb128,
+    VarLocation, X86_DWARF_REG,
+};
+/// Public API for `re-export`.
 pub use emit::{
     emit_globals, emit_object, sizeof_ty, Emitter, ObjectFile, ObjectFormat, Reloc, RelocKind,
     Section, Symbol,
 };
+/// Public API for `intrinsics` re-exports.
+pub use intrinsics::{is_llvm_intrinsic, lower_intrinsic};
 /// Public API for `re-export`.
-pub use isel::{IselBackend, MInstr, MOpcode, MOperand, MachineBlock, MachineFunction, PReg, RegClass, VReg};
-/// Public API for `re-export`.
-pub use cfi::{x86_fp_prologue_cfi, CfiInstr, CfiWriter};
-/// Public API for `re-export`.
-pub use dwarf_vars::{
-    build_variable_die, encode_breg6, encode_location, encode_reg, encode_sleb128,
-    encode_uleb128, VarLocation, X86_DWARF_REG,
+pub use isel::{
+    IselBackend, MInstr, MOpcode, MOperand, MachineBlock, MachineFunction, PReg, RegClass, VReg,
 };
 /// Public API for `re-export`.
 pub use regalloc::{
     allocate_registers, apply_allocation, compute_live_intervals, graph_color,
     insert_spill_reloads, linear_scan, RegAllocStrategy,
 };
-/// Public API for `intrinsics` re-exports.
-pub use intrinsics::{is_llvm_intrinsic, lower_intrinsic};
 /// Public API for `schedule` re-exports.
 pub use schedule::{
     apply_schedule, build_dep_dag, compute_critical_paths, list_schedule, x86_latency, DepEdge,

--- a/src/llvm-codegen/src/lsda.rs
+++ b/src/llvm-codegen/src/lsda.rs
@@ -157,7 +157,9 @@ pub struct XdataBuilder {
 impl XdataBuilder {
     /// Create a new, empty `XdataBuilder`.
     pub fn new() -> Self {
-        Self { ip_to_state: Vec::new() }
+        Self {
+            ip_to_state: Vec::new(),
+        }
     }
 
     /// Record an IP-to-state transition at `ip_offset` bytes from function start.
@@ -327,16 +329,31 @@ mod tests {
         assert_eq!(bytes[0], 0xff); // @LPStart = omit
         assert_eq!(bytes[1], 0xff); // @TType   = omit
         assert_eq!(bytes[2], 0x01); // CallSite encoding = uleb128
-        // Must have more bytes beyond the 3-byte header.
+                                    // Must have more bytes beyond the 3-byte header.
         assert!(bytes.len() > 4);
     }
 
     #[test]
     fn lsda_multiple_call_sites() {
         let mut lsda = LsdaBuilder::new();
-        lsda.add_call_site(CallSiteRecord { call_start: 0, call_len: 5, landing_pad: 30, action: 0 });
-        lsda.add_call_site(CallSiteRecord { call_start: 10, call_len: 5, landing_pad: 50, action: 0 });
-        lsda.add_call_site(CallSiteRecord { call_start: 20, call_len: 5, landing_pad: 0, action: 0 });
+        lsda.add_call_site(CallSiteRecord {
+            call_start: 0,
+            call_len: 5,
+            landing_pad: 30,
+            action: 0,
+        });
+        lsda.add_call_site(CallSiteRecord {
+            call_start: 10,
+            call_len: 5,
+            landing_pad: 50,
+            action: 0,
+        });
+        lsda.add_call_site(CallSiteRecord {
+            call_start: 20,
+            call_len: 5,
+            landing_pad: 0,
+            action: 0,
+        });
         let bytes = lsda.build();
         // At least 3 call-site records beyond the header.
         assert!(bytes.len() > 10);

--- a/src/llvm-codegen/src/regalloc.rs
+++ b/src/llvm-codegen/src/regalloc.rs
@@ -226,7 +226,9 @@ pub fn allocate_registers(
 ) -> RegAllocResult {
     // Fast path: no float VRegs present (common until FP backends land).
     // Avoids the partition + second linear-scan call entirely.
-    let has_float = intervals.iter().any(|iv| iv.vreg.class() == crate::isel::RegClass::Float);
+    let has_float = intervals
+        .iter()
+        .any(|iv| iv.vreg.class() == crate::isel::RegClass::Float);
     if !has_float {
         return match strategy {
             RegAllocStrategy::LinearScan => linear_scan(intervals, int_pregs),
@@ -235,8 +237,10 @@ pub fn allocate_registers(
     }
 
     // Partition live intervals by register class.
-    let (int_intervals, fp_intervals): (Vec<_>, Vec<_>) =
-        intervals.iter().cloned().partition(|iv| iv.vreg.class() == crate::isel::RegClass::Int);
+    let (int_intervals, fp_intervals): (Vec<_>, Vec<_>) = intervals
+        .iter()
+        .cloned()
+        .partition(|iv| iv.vreg.class() == crate::isel::RegClass::Int);
 
     let int_result = match strategy {
         RegAllocStrategy::LinearScan => linear_scan(&int_intervals, int_pregs),
@@ -327,9 +331,8 @@ pub fn linear_scan(intervals: &[LiveInterval], allocatable: &[PReg]) -> RegAlloc
             result.vreg_to_preg.insert(interval.vreg, pr);
             // Insert in sorted position to maintain the end-sorted invariant without
             // a full O(n log n) sort on every push.
-            let pos = active.partition_point(|&(e, vr, _)| {
-                (e, vr.0) <= (interval.end, interval.vreg.0)
-            });
+            let pos =
+                active.partition_point(|&(e, vr, _)| (e, vr.0) <= (interval.end, interval.vreg.0));
             active.insert(pos, (interval.end, interval.vreg, pr));
         }
     }
@@ -396,7 +399,11 @@ pub fn insert_spill_reloads(
                             (load_op, mf.fresh_vreg())
                         };
                         // Insert LOAD before this instruction.
-                        new_instrs.push(MInstr::new(chosen_load).with_dst(fresh).with_imm(slot as i64));
+                        new_instrs.push(
+                            MInstr::new(chosen_load)
+                                .with_dst(fresh)
+                                .with_imm(slot as i64),
+                        );
                         *op = MOperand::VReg(fresh);
                     }
                 }
@@ -423,7 +430,11 @@ pub fn insert_spill_reloads(
             new_instrs.push(instr);
 
             if let Some((fresh, slot, chosen_store)) = store_after {
-                new_instrs.push(MInstr::new(chosen_store).with_imm(slot as i64).with_vreg(fresh));
+                new_instrs.push(
+                    MInstr::new(chosen_store)
+                        .with_imm(slot as i64)
+                        .with_vreg(fresh),
+                );
             }
         }
 
@@ -554,7 +565,6 @@ mod tests {
             end,
         }
     }
-
 
     #[test]
     fn compute_intervals_returns_deterministic_order_for_equal_starts() {
@@ -890,11 +900,27 @@ mod tests {
         let int_pool = vec![PReg(0), PReg(1)];
         let fp_pool: Vec<PReg> = vec![];
         let intervals = vec![
-            LiveInterval { vreg: VReg::new_int(0), start: 0, end: 4 },
-            LiveInterval { vreg: VReg::new_int(1), start: 1, end: 5 },
+            LiveInterval {
+                vreg: VReg::new_int(0),
+                start: 0,
+                end: 4,
+            },
+            LiveInterval {
+                vreg: VReg::new_int(1),
+                start: 1,
+                end: 5,
+            },
         ];
-        let result = allocate_registers(&intervals, &int_pool, &fp_pool, RegAllocStrategy::LinearScan);
-        assert!(result.spilled.is_empty(), "no spills expected with 2 regs for 2 int VRegs");
+        let result = allocate_registers(
+            &intervals,
+            &int_pool,
+            &fp_pool,
+            RegAllocStrategy::LinearScan,
+        );
+        assert!(
+            result.spilled.is_empty(),
+            "no spills expected with 2 regs for 2 int VRegs"
+        );
         // Both assignments must be in the int pool.
         for (vr, pr) in &result.vreg_to_preg {
             assert!(
@@ -911,11 +937,27 @@ mod tests {
         let int_pool = vec![PReg(0), PReg(1)];
         let fp_pool = vec![PReg(16), PReg(17)]; // simulate XMM0/XMM1
         let intervals = vec![
-            LiveInterval { vreg: VReg::new_float(0), start: 0, end: 4 },
-            LiveInterval { vreg: VReg::new_float(1), start: 1, end: 5 },
+            LiveInterval {
+                vreg: VReg::new_float(0),
+                start: 0,
+                end: 4,
+            },
+            LiveInterval {
+                vreg: VReg::new_float(1),
+                start: 1,
+                end: 5,
+            },
         ];
-        let result = allocate_registers(&intervals, &int_pool, &fp_pool, RegAllocStrategy::LinearScan);
-        assert!(result.spilled.is_empty(), "no spills: 2 FP regs for 2 float VRegs");
+        let result = allocate_registers(
+            &intervals,
+            &int_pool,
+            &fp_pool,
+            RegAllocStrategy::LinearScan,
+        );
+        assert!(
+            result.spilled.is_empty(),
+            "no spills: 2 FP regs for 2 float VRegs"
+        );
         for (vr, pr) in &result.vreg_to_preg {
             assert!(
                 fp_pool.contains(pr),
@@ -934,13 +976,37 @@ mod tests {
         let int_pool = vec![PReg(0), PReg(1)];
         let fp_pool = vec![PReg(16), PReg(17)];
         let intervals = vec![
-            LiveInterval { vreg: VReg::new_int(0),   start: 0, end: 6 },
-            LiveInterval { vreg: VReg::new_int(1),   start: 1, end: 7 },
-            LiveInterval { vreg: VReg::new_float(2), start: 2, end: 8 },
-            LiveInterval { vreg: VReg::new_float(3), start: 3, end: 9 },
+            LiveInterval {
+                vreg: VReg::new_int(0),
+                start: 0,
+                end: 6,
+            },
+            LiveInterval {
+                vreg: VReg::new_int(1),
+                start: 1,
+                end: 7,
+            },
+            LiveInterval {
+                vreg: VReg::new_float(2),
+                start: 2,
+                end: 8,
+            },
+            LiveInterval {
+                vreg: VReg::new_float(3),
+                start: 3,
+                end: 9,
+            },
         ];
-        let result = allocate_registers(&intervals, &int_pool, &fp_pool, RegAllocStrategy::LinearScan);
-        assert!(result.spilled.is_empty(), "no spills: 2+2 regs for 2+2 VRegs");
+        let result = allocate_registers(
+            &intervals,
+            &int_pool,
+            &fp_pool,
+            RegAllocStrategy::LinearScan,
+        );
+        assert!(
+            result.spilled.is_empty(),
+            "no spills: 2+2 regs for 2+2 VRegs"
+        );
         assert_eq!(result.vreg_to_preg.len(), 4, "all 4 VRegs must be assigned");
 
         for (vr, pr) in &result.vreg_to_preg {

--- a/src/llvm-codegen/src/schedule.rs
+++ b/src/llvm-codegen/src/schedule.rs
@@ -138,7 +138,10 @@ fn is_terminator(opcode: MOpcode) -> bool {
 /// Returns `true` if an instruction has a `Block` operand (targets a basic block),
 /// which is the target-independent signal for a branch instruction.
 fn has_block_operand(instr: &MInstr) -> bool {
-    instr.operands.iter().any(|op| matches!(op, MOperand::Block(_)))
+    instr
+        .operands
+        .iter()
+        .any(|op| matches!(op, MOperand::Block(_)))
 }
 
 // ── dependency DAG construction ────────────────────────────────────────────
@@ -151,10 +154,7 @@ fn has_block_operand(instr: &MInstr) -> bool {
 /// The `latency_fn` callback is called with the *producing* instruction's
 /// opcode to obtain the RAW latency for that edge.  WAR and WAW edges and
 /// conservative memory/control edges all use a latency of 1.
-pub fn build_dep_dag(
-    instrs: &[MInstr],
-    latency_fn: &dyn Fn(MOpcode) -> u32,
-) -> Vec<Vec<DepEdge>> {
+pub fn build_dep_dag(instrs: &[MInstr], latency_fn: &dyn Fn(MOpcode) -> u32) -> Vec<Vec<DepEdge>> {
     let n = instrs.len();
     let mut succ: Vec<Vec<DepEdge>> = vec![Vec::new(); n];
 
@@ -185,14 +185,22 @@ pub fn build_dep_dag(
             // WAW: both write the same register.
             let waw = wr[i].iter().any(|w| wr[j].contains(w));
             if waw {
-                succ[i].push(DepEdge { to: j, kind: DepKind::Waw, latency: 1 });
+                succ[i].push(DepEdge {
+                    to: j,
+                    kind: DepKind::Waw,
+                    latency: 1,
+                });
                 continue;
             }
 
             // WAR: i reads something that j writes.
             let war = rd[i].iter().any(|r| wr[j].contains(r));
             if war {
-                succ[i].push(DepEdge { to: j, kind: DepKind::War, latency: 1 });
+                succ[i].push(DepEdge {
+                    to: j,
+                    kind: DepKind::War,
+                    latency: 1,
+                });
                 // Still fall through to check Mem/Ctrl — they're orthogonal.
                 // But we skip adding another reg dep for the same pair.
                 continue;
@@ -200,13 +208,21 @@ pub fn build_dep_dag(
 
             // Mem: conservative — any two memory ops in order have a dependency.
             if is_mem[i] && is_mem[j] {
-                succ[i].push(DepEdge { to: j, kind: DepKind::Mem, latency: 1 });
+                succ[i].push(DepEdge {
+                    to: j,
+                    kind: DepKind::Mem,
+                    latency: 1,
+                });
                 continue;
             }
 
             // Ctrl: every prior instruction must precede a terminator.
             if is_ctrl[j] {
-                succ[i].push(DepEdge { to: j, kind: DepKind::Ctrl, latency: 1 });
+                succ[i].push(DepEdge {
+                    to: j,
+                    kind: DepKind::Ctrl,
+                    latency: 1,
+                });
             }
         }
     }
@@ -302,7 +318,11 @@ pub fn list_schedule(
 
     // Safety: if the DAG is acyclic (it always is by construction) every node
     // will have been scheduled.
-    debug_assert_eq!(order.len(), n, "list_schedule: not all instructions were scheduled");
+    debug_assert_eq!(
+        order.len(),
+        n,
+        "list_schedule: not all instructions were scheduled"
+    );
     order
 }
 
@@ -312,7 +332,11 @@ pub fn list_schedule(
 ///
 /// `order` must be a permutation of `0..block.instrs.len()`.
 pub fn apply_schedule(block: &mut MachineBlock, order: &[usize]) {
-    debug_assert_eq!(order.len(), block.instrs.len(), "order length must match instrs length");
+    debug_assert_eq!(
+        order.len(),
+        block.instrs.len(),
+        "order length must match instrs length"
+    );
     let old = std::mem::take(&mut block.instrs);
     block.instrs = order.iter().map(|&i| old[i].clone()).collect();
 }
@@ -440,7 +464,9 @@ mod tests {
     use crate::isel::{MInstr, MOpcode, MachineBlock, PReg, VReg};
 
     // A simple constant latency function for testing (every op = 1 cycle).
-    fn unit_latency(_: MOpcode) -> u32 { 1 }
+    fn unit_latency(_: MOpcode) -> u32 {
+        1
+    }
 
     // ── test 1: RAW dependency ─────────────────────────────────────────────
 
@@ -478,7 +504,7 @@ mod tests {
         // Instead: encode both as VReg reads/writes to share the key space.
         let v1 = VReg(100);
         let a2 = MInstr::new(MOpcode(0x00)).with_vreg(v1); // reads v1
-        let b2 = MInstr::new(MOpcode(0x00)).with_dst(v1);  // writes v1 → no operand read → WAR
+        let b2 = MInstr::new(MOpcode(0x00)).with_dst(v1); // writes v1 → no operand read → WAR
 
         // Actually WAR: a reads v1, b writes v1; since a has no dst we need
         // to check: writes(a2) is empty (no dst), reads(a2) = {v1}.
@@ -540,7 +566,7 @@ mod tests {
         // Three instructions: a, b, term (a branch that uses Block operand).
         let a = MInstr::new(MOpcode(0x10)); // ADD_RR (no deps)
         let b = MInstr::new(MOpcode(0x12)); // SUB_RR (no deps)
-        // Terminator: JMP (0x50) with a Block operand.
+                                            // Terminator: JMP (0x50) with a Block operand.
         let term = MInstr::new(MOpcode(0x50)).with_block(0);
 
         let instrs = vec![a, b, term];
@@ -598,7 +624,9 @@ mod tests {
 
         assert_eq!(order.len(), 3);
         // Find positions in the schedule.
-        let pos: Vec<usize> = (0..3).map(|i| order.iter().position(|&x| x == i).unwrap()).collect();
+        let pos: Vec<usize> = (0..3)
+            .map(|i| order.iter().position(|&x| x == i).unwrap())
+            .collect();
         assert!(pos[0] < pos[1], "A must come before B");
         assert!(pos[1] < pos[2], "B must come before C");
     }
@@ -625,13 +653,21 @@ mod tests {
 
         // a (index 1) has successors b→c, so CP should be ≥ 2.
         // d (index 0) has no successors, so CP = 0.
-        assert!(cp[1] >= 2, "chain head should have critical path >= 2, got {}", cp[1]);
+        assert!(
+            cp[1] >= 2,
+            "chain head should have critical path >= 2, got {}",
+            cp[1]
+        );
         assert_eq!(cp[0], 0, "independent instruction d should have CP = 0");
 
         let order = list_schedule(&instrs, &dag, &unit_latency);
         let pos_a = order.iter().position(|&x| x == 1).unwrap();
         let pos_d = order.iter().position(|&x| x == 0).unwrap();
-        assert!(pos_a < pos_d, "chain head 'a' (CP={}) should be scheduled before 'd' (CP=0)", cp[1]);
+        assert!(
+            pos_a < pos_d,
+            "chain head 'a' (CP={}) should be scheduled before 'd' (CP=0)",
+            cp[1]
+        );
     }
 
     // ── test 9: apply_schedule reorders block ──────────────────────────────

--- a/src/llvm-codegen/tests/codeview_coff.rs
+++ b/src/llvm-codegen/tests/codeview_coff.rs
@@ -37,7 +37,14 @@ fn emits_codeview_debug_s_for_coff_when_dbg_metadata_present() {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let mut emitter = X86Emitter::new(ObjectFormat::Coff);
@@ -84,7 +91,14 @@ fn build_coff_cv_obj() -> (Vec<u8>, Vec<u8>) {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let mut emitter = X86Emitter::new(ObjectFormat::Coff);
@@ -109,7 +123,10 @@ fn debug_s_contains_s_gproc32_record() {
 
     // Scan for S_GPROC32 record type bytes [0x10, 0x11] (little-endian 0x1110).
     let has_gproc32 = cv.windows(2).any(|w| w == [0x10, 0x11]);
-    assert!(has_gproc32, ".debug$S must contain S_GPROC32 (0x1110) record");
+    assert!(
+        has_gproc32,
+        ".debug$S must contain S_GPROC32 (0x1110) record"
+    );
 }
 
 #[test]
@@ -138,7 +155,10 @@ fn debug_s_contains_debug_s_lines_subsection() {
     let has_lines = cv
         .windows(4)
         .any(|w| u32::from_le_bytes(w.try_into().unwrap()) == 0xF2);
-    assert!(has_lines, ".debug$S must contain DEBUG_S_LINES (0xF2) subsection");
+    assert!(
+        has_lines,
+        ".debug$S must contain DEBUG_S_LINES (0xF2) subsection"
+    );
 }
 
 #[test]
@@ -148,7 +168,10 @@ fn debug_s_contains_filechksms_subsection() {
     let has_chksm = cv
         .windows(4)
         .any(|w| u32::from_le_bytes(w.try_into().unwrap()) == 0xF4);
-    assert!(has_chksm, ".debug$S must contain DEBUG_S_FILECHKSMS (0xF4) subsection");
+    assert!(
+        has_chksm,
+        ".debug$S must contain DEBUG_S_FILECHKSMS (0xF4) subsection"
+    );
 }
 
 #[test]
@@ -158,5 +181,8 @@ fn debug_s_contains_stringtable_subsection() {
     let has_strtab = cv
         .windows(4)
         .any(|w| u32::from_le_bytes(w.try_into().unwrap()) == 0xF3);
-    assert!(has_strtab, ".debug$S must contain DEBUG_S_STRINGTABLE (0xF3) subsection");
+    assert!(
+        has_strtab,
+        ".debug$S must contain DEBUG_S_STRINGTABLE (0xF3) subsection"
+    );
 }

--- a/src/llvm-codegen/tests/dwarf_line.rs
+++ b/src/llvm-codegen/tests/dwarf_line.rs
@@ -84,7 +84,14 @@ fn emit_dbg_elf_obj_from_ir(src: &str, out: &Path) -> ObjectFile {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = X86Emitter::new(ObjectFormat::Elf);
     let obj = emit_object(&mf, &mut emitter);
@@ -121,7 +128,14 @@ fn emit_dbg_elf_obj_from_ir(src: &str, out: &Path) -> ObjectFile {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP, LDR_FP, STR_FP);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        LDR_FP,
+        STR_FP,
+        LDR_FP,
+        STR_FP,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = AArch64Emitter::new(ObjectFormat::Elf);
     let obj = emit_object(&mf, &mut emitter);
@@ -173,7 +187,10 @@ fn emits_debug_line_when_dbg_metadata_present() {
             .expect("run llvm-dwarfdump");
         assert!(out.status.success());
         let text = String::from_utf8_lossy(&out.stdout);
-        assert!(text.contains("dbg_test.c") || text.contains("line"), "dwarfdump output: {text}");
+        assert!(
+            text.contains("dbg_test.c") || text.contains("line"),
+            "dwarfdump output: {text}"
+        );
 
         let info = Command::new(&tool)
             .arg("--debug-info")
@@ -213,7 +230,10 @@ fn debug_rows_preserve_line_transitions_across_blocks() {
         .iter()
         .find(|s| s.name == ".text" || s.name == "__text")
         .expect("text section");
-    assert!(!text.debug_rows.is_empty(), "expected instruction debug rows");
+    assert!(
+        !text.debug_rows.is_empty(),
+        "expected instruction debug rows"
+    );
     let mut lines: Vec<u32> = text.debug_rows.iter().map(|r| r.line).collect();
     lines.sort_unstable();
     lines.dedup();

--- a/src/llvm-codegen/tests/global_emit.rs
+++ b/src/llvm-codegen/tests/global_emit.rs
@@ -180,7 +180,7 @@ fn emit_globals_gep_constexpr_reloc_with_addend() {
     .unwrap();
     let (secs, syms) = emit_globals(&ctx, &module, elf()).unwrap();
     assert_eq!(secs.len(), 1); // both constant → .rodata
-    // @p3 → 8 zero bytes + reloc with addend = 3 * sizeof(i32) = 12
+                               // @p3 → 8 zero bytes + reloc with addend = 3 * sizeof(i32) = 12
     let p3_sym = syms.iter().find(|s| s.name == "p3").unwrap();
     let reloc = secs[0]
         .relocs

--- a/src/llvm-codegen/tests/golden_codegen.rs
+++ b/src/llvm-codegen/tests/golden_codegen.rs
@@ -128,7 +128,6 @@ entry:
 !12 = !DILocation(line: 42, column: 7, scope: !1)
 "#,
     },
-
 ];
 
 fn stable_hash_hex(data: &[u8]) -> String {
@@ -177,7 +176,14 @@ fn emit_case(case: GoldenCase) -> Vec<u8> {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let mut emitter = X86Emitter::new(ObjectFormat::Elf);

--- a/src/llvm-codegen/tests/linker_compat.rs
+++ b/src/llvm-codegen/tests/linker_compat.rs
@@ -80,7 +80,14 @@ fn emit_host_obj_x86(
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = X86Emitter::new(obj_format);
     let obj = emit_object(&mf, &mut emitter);
@@ -110,7 +117,14 @@ fn emit_host_obj_aarch64(
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    llvm_codegen::regalloc::insert_spill_reloads(&mut mf, &mut result, LDR_FP, STR_FP, LDR_FP, STR_FP);
+    llvm_codegen::regalloc::insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        LDR_FP,
+        STR_FP,
+        LDR_FP,
+        STR_FP,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = AArch64Emitter::new(obj_format);
     let obj = emit_object(&mf, &mut emitter);
@@ -314,7 +328,9 @@ fn coff_object_main_symbol_visible() {
 fn tool_presence_report_is_accessible() {
     // Lightweight smoke to keep path used in CI logs if desired.
     let mut tools = Vec::<(&str, bool)>::new();
-    for t in ["cc", "ld", "lld", "lld-link", "readelf", "nm", "llvm-nm", "objdump", "otool"] {
+    for t in [
+        "cc", "ld", "lld", "lld-link", "readelf", "nm", "llvm-nm", "objdump", "otool",
+    ] {
         tools.push((t, have_tool(t)));
     }
     assert!(!tools.is_empty());

--- a/src/llvm-codegen/tests/lsda.rs
+++ b/src/llvm-codegen/tests/lsda.rs
@@ -204,8 +204,11 @@ fn lsda_cs_table_length_field_correct() {
     let (cs_table_len, advance) = decode_uleb128(&bytes[3..]);
     let table_start = 3 + advance;
     let table_end = bytes.len();
-    assert_eq!(cs_table_len as usize, table_end - table_start,
-        "cs_table_length field must match actual call-site table byte count");
+    assert_eq!(
+        cs_table_len as usize,
+        table_end - table_start,
+        "cs_table_length field must match actual call-site table byte count"
+    );
 }
 
 // ── XdataBuilder tests ────────────────────────────────────────────────────

--- a/src/llvm-codegen/tests/pgo_instrprof.rs
+++ b/src/llvm-codegen/tests/pgo_instrprof.rs
@@ -6,37 +6,76 @@
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
-use llvm_ir::{InstrprofIntrinsic};
+use llvm_ir::InstrprofIntrinsic;
 use llvm_ir_parser::parser::parse;
-use llvm_target_x86::{instructions::{MOV_LOAD_MR, MOV_STORE_RM, NOP, CALL_R}, X86Backend, X86Emitter};
+use llvm_target_x86::{
+    instructions::{CALL_R, MOV_LOAD_MR, MOV_STORE_RM, NOP},
+    X86Backend, X86Emitter,
+};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 fn compile_x86(src: &str) -> Vec<llvm_codegen::isel::MInstr> {
     let (ctx, module) = parse(src).expect("parse failed");
-    let func = module.functions.iter().find(|f| f.name == "main" && !f.is_declaration)
+    let func = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main" && !f.is_declaration)
         .expect("no @main definition");
     let mut backend = X86Backend::default();
     let mut mf = backend.lower_function(&ctx, &module, func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, &mf.allocatable_fp_pregs, RegAllocStrategy::LinearScan);
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        &mf.allocatable_fp_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
-    mf.blocks.iter().flat_map(|b| b.instrs.iter().cloned()).collect()
+    mf.blocks
+        .iter()
+        .flat_map(|b| b.instrs.iter().cloned())
+        .collect()
 }
 
 fn compile_x86_object(src: &str) -> Vec<u8> {
     let (ctx, module) = parse(src).expect("parse failed");
-    let func = module.functions.iter().find(|f| f.name == "main" && !f.is_declaration)
+    let func = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main" && !f.is_declaration)
         .expect("no @main definition");
     let mut backend = X86Backend::default();
     let mut mf = backend.lower_function(&ctx, &module, func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, &mf.allocatable_fp_pregs, RegAllocStrategy::LinearScan);
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        &mf.allocatable_fp_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = X86Emitter::new(ObjectFormat::Elf);
     emit_object(&mf, &mut emitter).to_bytes()
@@ -62,7 +101,10 @@ fn instrprof_from_name_recognizes_value_profile() {
 
 #[test]
 fn instrprof_from_name_returns_none_for_unknown() {
-    assert_eq!(InstrprofIntrinsic::from_name("llvm.instrprof.unknown"), None);
+    assert_eq!(
+        InstrprofIntrinsic::from_name("llvm.instrprof.unknown"),
+        None
+    );
     assert_eq!(InstrprofIntrinsic::from_name("llvm.lifetime.start"), None);
     assert_eq!(InstrprofIntrinsic::from_name("llvm.vp.add.i32"), None);
     assert_eq!(InstrprofIntrinsic::from_name(""), None);
@@ -110,13 +152,19 @@ entry:
 fn instrprof_increment_compiles_without_error() {
     // Must not panic; object bytes must be non-empty.
     let bytes = compile_x86_object(INSTRPROF_INCREMENT_IR);
-    assert!(!bytes.is_empty(), "expected non-empty object for instrprof.increment");
+    assert!(
+        !bytes.is_empty(),
+        "expected non-empty object for instrprof.increment"
+    );
 }
 
 #[test]
 fn instrprof_value_profile_compiles_without_error() {
     let bytes = compile_x86_object(INSTRPROF_VALUE_PROFILE_IR);
-    assert!(!bytes.is_empty(), "expected non-empty object for instrprof.value.profile");
+    assert!(
+        !bytes.is_empty(),
+        "expected non-empty object for instrprof.value.profile"
+    );
 }
 
 #[test]
@@ -125,7 +173,10 @@ fn instrprof_increment_emits_nop_not_call() {
     let instrs = compile_x86(INSTRPROF_INCREMENT_IR);
     let has_nop = instrs.iter().any(|mi| mi.opcode == NOP);
     let has_call_to_instrprof = instrs.iter().any(|mi| mi.opcode == CALL_R);
-    assert!(has_nop, "expected at least one NOP from instrprof.increment lowering");
+    assert!(
+        has_nop,
+        "expected at least one NOP from instrprof.increment lowering"
+    );
     // We allow call_r for other calls but confirm instrprof didn't sneak through as a real call.
     // Since @main has no other calls, any CALL_R would be the intrinsic leaking through.
     assert!(

--- a/src/llvm-codegen/tests/thinlto.rs
+++ b/src/llvm-codegen/tests/thinlto.rs
@@ -71,7 +71,10 @@ fn embed_bitcode_adds_llvmcmd_section() {
     let mut obj = elf_obj();
     embed_bitcode(&mut obj, &ctx, &module, "--opt-level=2").unwrap();
     let cmd = obj.sections.iter().find(|s| s.name == ".llvmcmd").unwrap();
-    assert_eq!(cmd.data, b"--opt-level=2", ".llvmcmd must contain the cmdline string");
+    assert_eq!(
+        cmd.data, b"--opt-level=2",
+        ".llvmcmd must contain the cmdline string"
+    );
 }
 
 #[test]
@@ -89,7 +92,10 @@ fn embed_bitcode_empty_cmdline() {
     let mut obj = elf_obj();
     embed_bitcode(&mut obj, &ctx, &module, "").unwrap();
     let cmd = obj.sections.iter().find(|s| s.name == ".llvmcmd").unwrap();
-    assert_eq!(cmd.data, b"", ".llvmcmd with empty cmdline must be zero bytes");
+    assert_eq!(
+        cmd.data, b"",
+        ".llvmcmd with empty cmdline must be zero bytes"
+    );
 }
 
 #[test]
@@ -105,8 +111,15 @@ fn embed_bitcode_preserves_existing_sections() {
         debug_rows: Vec::new(),
     });
     embed_bitcode(&mut obj, &ctx, &module, "").unwrap();
-    assert_eq!(obj.sections[0].name, ".text", ".text must remain at index 0");
-    assert_eq!(obj.sections.len(), 3, "must have .text + .llvmbc + .llvmcmd");
+    assert_eq!(
+        obj.sections[0].name, ".text",
+        ".text must remain at index 0"
+    );
+    assert_eq!(
+        obj.sections.len(),
+        3,
+        "must have .text + .llvmbc + .llvmcmd"
+    );
 }
 
 // ── Mach-O tests ────────────────────────────────────────────────────────────
@@ -158,8 +171,7 @@ fn thinlto_roundtrip_module_name() {
     embed_bitcode(&mut obj, &ctx, &module, "").unwrap();
 
     let bc_sec = obj.sections.iter().find(|s| s.name == ".llvmbc").unwrap();
-    let (_, module2) = read_bitcode(&bc_sec.data)
-        .expect("embedded bitcode must be valid LRIR");
+    let (_, module2) = read_bitcode(&bc_sec.data).expect("embedded bitcode must be valid LRIR");
     assert_eq!(
         module2.name, "mymod",
         "module name must survive the embed/read round-trip"

--- a/src/llvm-codegen/tests/unwind_verify.rs
+++ b/src/llvm-codegen/tests/unwind_verify.rs
@@ -87,7 +87,11 @@ fn coff_unwind_tables_visible_to_llvm_readobj() {
     emit_obj(ObjectFormat::Coff, &obj_path);
 
     if let Some(readobj) = require_tool(
-        &["llvm-readobj", "llvm-readobj-19", "/usr/lib/llvm-19/bin/llvm-readobj"],
+        &[
+            "llvm-readobj",
+            "llvm-readobj-19",
+            "/usr/lib/llvm-19/bin/llvm-readobj",
+        ],
         "llvm-readobj",
     ) {
         let out = Command::new(&readobj)

--- a/src/llvm-ir-parser/examples/run_ir.rs
+++ b/src/llvm-ir-parser/examples/run_ir.rs
@@ -53,7 +53,14 @@ fn run_ours(ctx: &Context, module: &Module, label: &str) -> Result<i32, String> 
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let obj_format = host_object_format().ok_or_else(|| "unsupported host OS".to_string())?;

--- a/src/llvm-ir-parser/src/lexer.rs
+++ b/src/llvm-ir-parser/src/lexer.rs
@@ -11,11 +11,11 @@ use std::fmt;
 pub enum Keyword {
     // Directives
     /// `Source` variant.
-    Source,     // source_filename
+    Source, // source_filename
     /// `Target` variant.
-    Target,     // target
+    Target, // target
     /// `Triple` variant.
-    Triple,     // triple
+    Triple, // triple
     /// `Datalayout` variant.
     Datalayout, // datalayout
     /// `Define` variant.
@@ -312,7 +312,7 @@ pub enum Keyword {
     /// `Unwind` variant.
     Unwind,
     /// `X` variant.
-    X,      // "x" in vector / array size
+    X, // "x" in vector / array size
     /// `Vscale` variant.
     Vscale, // "vscale" before "x" in scalable vector
 }

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -286,7 +286,7 @@ impl<'src> Parser<'src> {
                         }
                         Token::LocalIdent(s) if s == "comdat" => {
                             self.lex.next()?; // consume `comdat`
-                            // Optional `($name)`.
+                                              // Optional `($name)`.
                             if matches!(self.lex.peek()?, Token::LParen) {
                                 self.skip_balanced_parens()?;
                             }
@@ -784,7 +784,8 @@ impl<'src> Parser<'src> {
         if !self.staged_phi_patches.is_empty() {
             let staged = std::mem::take(&mut self.staged_phi_patches);
             for (incoming_idx, local_name) in staged {
-                self.pending_phi_patches.push((iid, incoming_idx, local_name));
+                self.pending_phi_patches
+                    .push((iid, incoming_idx, local_name));
             }
         }
 
@@ -1002,18 +1003,17 @@ impl<'src> Parser<'src> {
                 // num_elements), the comma is already consumed so we must NOT
                 // go through parse_optional_align (which expects its own
                 // leading comma).
-                let (num_elements, comma_before_align_consumed) =
-                    if self.lex.eat(&Token::Comma) {
-                        match self.lex.peek()? {
-                            Token::Kw(Keyword::Align) => (None, true),
-                            _ => {
-                                let (ne, _) = self.parse_typed_value()?;
-                                (Some(ne), false)
-                            }
+                let (num_elements, comma_before_align_consumed) = if self.lex.eat(&Token::Comma) {
+                    match self.lex.peek()? {
+                        Token::Kw(Keyword::Align) => (None, true),
+                        _ => {
+                            let (ne, _) = self.parse_typed_value()?;
+                            (Some(ne), false)
                         }
-                    } else {
-                        (None, false)
-                    };
+                    }
+                } else {
+                    (None, false)
+                };
                 let align = if comma_before_align_consumed {
                     // Comma was already consumed; parse `align N` directly.
                     if self.lex.eat_kw(Keyword::Align) {
@@ -1686,15 +1686,26 @@ impl<'src> Parser<'src> {
                 self.lex.expect_kw(&Keyword::Unwind)?;
                 let default = self.parse_unwind_dest()?;
                 let ptr_ty = self.ctx.ptr_ty;
-                Ok((InstrKind::CatchSwitch { parent, handlers, default }, ptr_ty))
+                Ok((
+                    InstrKind::CatchSwitch {
+                        parent,
+                        handlers,
+                        default,
+                    },
+                    ptr_ty,
+                ))
             }
             Token::Kw(Keyword::Catchret) => {
                 // catchret from %tok to label %cont
                 self.lex.next()?;
                 // "from" keyword (optional for robustness)
                 match self.lex.peek()?.clone() {
-                    Token::Kw(Keyword::From) => { self.lex.next()?; }
-                    Token::LocalIdent(ref s) if s == "from" => { self.lex.next()?; }
+                    Token::Kw(Keyword::From) => {
+                        self.lex.next()?;
+                    }
+                    Token::LocalIdent(ref s) if s == "from" => {
+                        self.lex.next()?;
+                    }
                     _ => {}
                 }
                 let catch_pad = self.parse_value_untyped()?;
@@ -1703,22 +1714,38 @@ impl<'src> Parser<'src> {
                 let bname = self.lex.expect_local_ident()?;
                 let successor = self.get_or_create_block(&bname)?;
                 let ptr_ty = self.ctx.ptr_ty;
-                Ok((InstrKind::CatchRet { catch_pad, successor }, ptr_ty))
+                Ok((
+                    InstrKind::CatchRet {
+                        catch_pad,
+                        successor,
+                    },
+                    ptr_ty,
+                ))
             }
             Token::Kw(Keyword::Cleanupret) => {
                 // cleanupret from %tok unwind to caller  OR  unwind label %dest
                 self.lex.next()?;
                 // "from" keyword (optional for robustness)
                 match self.lex.peek()?.clone() {
-                    Token::Kw(Keyword::From) => { self.lex.next()?; }
-                    Token::LocalIdent(ref s) if s == "from" => { self.lex.next()?; }
+                    Token::Kw(Keyword::From) => {
+                        self.lex.next()?;
+                    }
+                    Token::LocalIdent(ref s) if s == "from" => {
+                        self.lex.next()?;
+                    }
                     _ => {}
                 }
                 let cleanup_pad = self.parse_value_untyped()?;
                 self.lex.expect_kw(&Keyword::Unwind)?;
                 let unwind_dest = self.parse_unwind_dest()?;
                 let ptr_ty = self.ctx.ptr_ty;
-                Ok((InstrKind::CleanupRet { cleanup_pad, unwind_dest }, ptr_ty))
+                Ok((
+                    InstrKind::CleanupRet {
+                        cleanup_pad,
+                        unwind_dest,
+                    },
+                    ptr_ty,
+                ))
             }
             _ => {
                 let t = self.lex.next()?;
@@ -1810,7 +1837,10 @@ impl<'src> Parser<'src> {
                 let vref = self.parse_value_untyped()?;
                 Ok(Some(vref))
             }
-            t => Err(self.err(format!("expected 'none' or local ident after 'within', got {:?}", t))),
+            t => Err(self.err(format!(
+                "expected 'none' or local ident after 'within', got {:?}",
+                t
+            ))),
         }
     }
 
@@ -1868,7 +1898,10 @@ impl<'src> Parser<'src> {
                 self.lex.next()?;
                 Ok(None)
             }
-            t => Err(self.err(format!("expected 'to caller' or 'label' after 'unwind', got {:?}", t))),
+            t => Err(self.err(format!(
+                "expected 'to caller' or 'label' after 'unwind', got {:?}",
+                t
+            ))),
         }
     }
 
@@ -1965,8 +1998,9 @@ impl<'src> Parser<'src> {
             // variant; until then they error out cleanly.
             Token::Kw(Keyword::Getelementptr) => self.parse_constexpr_gep_as_instr(),
             Token::Kw(Keyword::Bitcast) => {
-                self.parse_constexpr_cast_as_instr(Keyword::Bitcast, |val, to| {
-                    InstrKind::BitCast { val, to }
+                self.parse_constexpr_cast_as_instr(Keyword::Bitcast, |val, to| InstrKind::BitCast {
+                    val,
+                    to,
                 })
             }
             Token::Kw(Keyword::Inttoptr) => {
@@ -1979,24 +2013,26 @@ impl<'src> Parser<'src> {
                     InstrKind::PtrToInt { val, to }
                 })
             }
-            Token::Kw(Keyword::Addrspacecast) => {
-                self.parse_constexpr_cast_as_instr(Keyword::Addrspacecast, |val, to| {
+            Token::Kw(Keyword::Addrspacecast) => self
+                .parse_constexpr_cast_as_instr(Keyword::Addrspacecast, |val, to| {
                     InstrKind::AddrSpaceCast { val, to }
-                })
-            }
+                }),
             Token::Kw(Keyword::Trunc) => {
-                self.parse_constexpr_cast_as_instr(Keyword::Trunc, |val, to| {
-                    InstrKind::Trunc { val, to }
+                self.parse_constexpr_cast_as_instr(Keyword::Trunc, |val, to| InstrKind::Trunc {
+                    val,
+                    to,
                 })
             }
             Token::Kw(Keyword::Zext) => {
-                self.parse_constexpr_cast_as_instr(Keyword::Zext, |val, to| {
-                    InstrKind::ZExt { val, to }
+                self.parse_constexpr_cast_as_instr(Keyword::Zext, |val, to| InstrKind::ZExt {
+                    val,
+                    to,
                 })
             }
             Token::Kw(Keyword::Sext) => {
-                self.parse_constexpr_cast_as_instr(Keyword::Sext, |val, to| {
-                    InstrKind::SExt { val, to }
+                self.parse_constexpr_cast_as_instr(Keyword::Sext, |val, to| InstrKind::SExt {
+                    val,
+                    to,
                 })
             }
             _ => {
@@ -2025,11 +2061,7 @@ impl<'src> Parser<'src> {
 
     /// Parse `{ <ty> <v>, <ty> <v>, ... }` as an anonymous (or named) struct
     /// constant.  The result `TypeId` is the surrounding context's type.
-    fn parse_struct_constant(
-        &mut self,
-        ty: TypeId,
-        _packed: bool,
-    ) -> Result<ValueRef, ParseError> {
+    fn parse_struct_constant(&mut self, ty: TypeId, _packed: bool) -> Result<ValueRef, ParseError> {
         self.lex.expect(&Token::LBrace)?;
         let mut fields = Vec::new();
         if !matches!(self.lex.peek()?, Token::RBrace) {
@@ -2152,8 +2184,7 @@ impl<'src> Parser<'src> {
 
         if let (Some(fid), Some(bid)) = (self.current_func, self.current_block) {
             let kind = make_kind(val, dst_ty);
-            let iid =
-                self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
+            let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
             self.module.functions[fid].block_mut(bid).append_instr(iid);
             Ok(ValueRef::Instruction(iid))
         } else {
@@ -2166,9 +2197,7 @@ impl<'src> Parser<'src> {
                 Keyword::Zext => ConstExprOp::ZExt,
                 Keyword::Sext => ConstExprOp::SExt,
                 other => {
-                    return Err(
-                        self.err(format!("unsupported constexpr cast keyword: {:?}", other))
-                    )
+                    return Err(self.err(format!("unsupported constexpr cast keyword: {:?}", other)))
                 }
             };
             let operand_const = self.value_ref_to_const_id(val)?;
@@ -2280,7 +2309,10 @@ impl<'src> Parser<'src> {
         for (instr_id, incoming_idx, name) in patches {
             let vref = self.resolve_local(&name)?;
             let instr = self.module.functions[fid].instr_mut(instr_id);
-            if let InstrKind::Phi { ref mut incoming, .. } = instr.kind {
+            if let InstrKind::Phi {
+                ref mut incoming, ..
+            } = instr.kind
+            {
                 if let Some(entry) = incoming.get_mut(incoming_idx) {
                     entry.0 = vref;
                 }
@@ -2779,7 +2811,9 @@ impl<'src> Parser<'src> {
         //   !llvm.dbg.cu = !{!0}
         self.lex.expect(&Token::Bang)?;
         let lhs = match self.lex.peek()? {
-            Token::IntLit(_) | Token::UIntLit(_) => Some((Some(self.lex.expect_uint_lit()? as u32), None)),
+            Token::IntLit(_) | Token::UIntLit(_) => {
+                Some((Some(self.lex.expect_uint_lit()? as u32), None))
+            }
             Token::LocalIdent(_) => Some((None, Some(self.lex.expect_local_ident()?))),
             _ => {
                 self.skip_one_metadata_value()?;
@@ -2949,7 +2983,12 @@ impl<'src> Parser<'src> {
         }
         if matches!(
             cur,
-            Token::Comma | Token::Colon | Token::RParen | Token::RBracket | Token::RBrace | Token::RAngle
+            Token::Comma
+                | Token::Colon
+                | Token::RParen
+                | Token::RBracket
+                | Token::RBrace
+                | Token::RAngle
         ) {
             return false;
         }
@@ -3163,7 +3202,6 @@ impl<'src> Parser<'src> {
         let _ = self.parse_metadata_value_text()?;
         Ok(())
     }
-
 }
 
 // ---------------------------------------------------------------------------
@@ -3309,10 +3347,7 @@ entry:
         let loc = module.debug_location(12).expect("dilocation");
         assert_eq!(loc.line, 27);
         assert_eq!(loc.column, 3);
-        assert_eq!(
-            module.metadata_node(14),
-            Some("!{!\"int\",!15}")
-        );
+        assert_eq!(module.metadata_node(14), Some("!{!\"int\",!15}"));
     }
 
     #[test]
@@ -3334,9 +3369,20 @@ entry:
             module2.named_metadata,
             vec![("llvm.dbg.cu".to_string(), "!{!0}".to_string())]
         );
-        assert_eq!(module2.metadata_node(0).map(|s| s.contains("DICompileUnit")), Some(true));
-        assert_eq!(module2.metadata_node(1).map(|s| s.contains("DIFile")), Some(true));
-        assert_eq!(module2.metadata_node(12), Some("!DILocation(line:7,column:2,scope:!0)"));
+        assert_eq!(
+            module2
+                .metadata_node(0)
+                .map(|s| s.contains("DICompileUnit")),
+            Some(true)
+        );
+        assert_eq!(
+            module2.metadata_node(1).map(|s| s.contains("DIFile")),
+            Some(true)
+        );
+        assert_eq!(
+            module2.metadata_node(12),
+            Some("!DILocation(line:7,column:2,scope:!0)")
+        );
         let loc = module2.debug_location(12).expect("dilocation");
         assert_eq!(loc.line, 7);
         assert_eq!(loc.column, 2);

--- a/src/llvm-ir-parser/tests/catch_pads.rs
+++ b/src/llvm-ir-parser/tests/catch_pads.rs
@@ -50,9 +50,18 @@ entry:
 declare ptr @__gxx_personality_v0(...)
 "#;
     let printed = print_module(src);
-    assert!(printed.contains("cleanuppad"), "missing cleanuppad: {printed}");
-    assert!(printed.contains("cleanupret"), "missing cleanupret: {printed}");
-    assert!(printed.contains("within none"), "missing 'within none': {printed}");
+    assert!(
+        printed.contains("cleanuppad"),
+        "missing cleanuppad: {printed}"
+    );
+    assert!(
+        printed.contains("cleanupret"),
+        "missing cleanupret: {printed}"
+    );
+    assert!(
+        printed.contains("within none"),
+        "missing 'within none': {printed}"
+    );
 }
 
 /// Parse a `catchswitch` with two handlers.
@@ -88,7 +97,10 @@ declare ptr @__gxx_personality_v0(...)
         }
     }
     let out = Printer::new(&ctx).print_module(&module);
-    assert!(out.contains("catchswitch"), "missing catchswitch in printed output: {out}");
+    assert!(
+        out.contains("catchswitch"),
+        "missing catchswitch in printed output: {out}"
+    );
     // The test asserts no panic; handler count assertion above covers semantics.
     let _ = found;
 }
@@ -115,8 +127,14 @@ declare ptr @__gxx_personality_v0(...)
     for block in &f.blocks {
         if let Some(tid) = block.terminator {
             let term = f.instr(tid);
-            if let InstrKind::CatchSwitch { default, handlers, .. } = &term.kind {
-                assert!(default.is_none(), "expected None default for unwind-to-caller");
+            if let InstrKind::CatchSwitch {
+                default, handlers, ..
+            } = &term.kind
+            {
+                assert!(
+                    default.is_none(),
+                    "expected None default for unwind-to-caller"
+                );
                 assert_eq!(handlers.len(), 1);
             }
         }
@@ -146,7 +164,10 @@ declare ptr @__gxx_personality_v0(...)
         if let Some(tid) = block.terminator {
             let term = f.instr(tid);
             if let InstrKind::CleanupRet { unwind_dest, .. } = &term.kind {
-                assert!(unwind_dest.is_some(), "expected Some unwind_dest for 'unwind label'");
+                assert!(
+                    unwind_dest.is_some(),
+                    "expected Some unwind_dest for 'unwind label'"
+                );
             }
         }
     }
@@ -172,7 +193,10 @@ declare ptr @__gxx_personality_v0(...)
         if let Some(tid) = block.terminator {
             let term = f.instr(tid);
             if let InstrKind::CleanupRet { unwind_dest, .. } = &term.kind {
-                assert!(unwind_dest.is_none(), "expected None for 'unwind to caller'");
+                assert!(
+                    unwind_dest.is_none(),
+                    "expected None for 'unwind to caller'"
+                );
             }
         }
     }
@@ -203,12 +227,20 @@ declare ptr @__gxx_personality_v0(...)
             let instr = f.instr(iid);
             if let InstrKind::CatchPad { args, .. } = &instr.kind {
                 // Two args: [ptr null, i32 0]
-                assert_eq!(args.len(), 2, "expected 2 catchpad args, got {}", args.len());
+                assert_eq!(
+                    args.len(),
+                    2,
+                    "expected 2 catchpad args, got {}",
+                    args.len()
+                );
                 found_catchpad = true;
             }
         }
     }
-    assert!(found_catchpad, "no catchpad instruction found in parsed function");
+    assert!(
+        found_catchpad,
+        "no catchpad instruction found in parsed function"
+    );
 }
 
 /// Parse a realistic catchpad sequence (as clang would emit) without panicking.
@@ -246,9 +278,19 @@ declare ptr @__CxxFrameHandler3(...)
     let (ctx, module) = parse(src).expect("realistic clang SEH output failed to parse");
     // Verify basic structure: at least 4 blocks
     let f = &module.functions[0];
-    assert!(f.blocks.len() >= 4, "expected at least 4 blocks, got {}", f.blocks.len());
+    assert!(
+        f.blocks.len() >= 4,
+        "expected at least 4 blocks, got {}",
+        f.blocks.len()
+    );
     // Verify print round-trip doesn't panic
     let out = Printer::new(&ctx).print_module(&module);
-    assert!(out.contains("catchpad"), "missing catchpad in output: {out}");
-    assert!(out.contains("catchswitch"), "missing catchswitch in output: {out}");
+    assert!(
+        out.contains("catchpad"),
+        "missing catchpad in output: {out}"
+    );
+    assert!(
+        out.contains("catchswitch"),
+        "missing catchswitch in output: {out}"
+    );
 }

--- a/src/llvm-ir-parser/tests/differential.rs
+++ b/src/llvm-ir-parser/tests/differential.rs
@@ -14,7 +14,10 @@ use std::process::Command;
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads, RegAllocStrategy},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{printer::Printer, Context, Module};
@@ -579,8 +582,20 @@ fn compile_and_run_ours(ctx: &Context, module: &Module, label: &str) -> (Option<
 
     let mut mf = backend.lower_function(ctx, module, main_func);
     let intervals = compute_live_intervals(&mf);
-    let mut result = allocate_registers(&intervals, &mf.allocatable_pregs, &mf.allocatable_fp_pregs, RegAllocStrategy::LinearScan);
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    let mut result = allocate_registers(
+        &intervals,
+        &mf.allocatable_pregs,
+        &mf.allocatable_fp_pregs,
+        RegAllocStrategy::LinearScan,
+    );
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
     let mut emitter = X86Emitter::new(ObjectFormat::Elf);
     let obj = emit_object(&mf, &mut emitter);
@@ -648,8 +663,8 @@ fn run_semantic_test(label: &str, src: &str, expected_exit: i32) {
         None => return,
     };
 
-    let (mut ctx, mut module) = parse(src)
-        .unwrap_or_else(|e| panic!("our parser rejected '{label}': {e}"));
+    let (mut ctx, mut module) =
+        parse(src).unwrap_or_else(|e| panic!("our parser rejected '{label}': {e}"));
     let mut pm = PassManager::new();
     pm.add_function_pass(Mem2Reg);
     pm.run(&mut ctx, &mut module);
@@ -837,60 +852,165 @@ fn check_fixture_hash(name: &str, src: &str) {
 #[test]
 fn check_regression_hashes() {
     let fixtures: &[(&str, &str)] = &[
-        ("01_int_arith_flags", include_str!("fixtures/01_int_arith_flags.ll")),
+        (
+            "01_int_arith_flags",
+            include_str!("fixtures/01_int_arith_flags.ll"),
+        ),
         ("02_udiv_urem", include_str!("fixtures/02_udiv_urem.ll")),
-        ("03_sdiv_exact_srem", include_str!("fixtures/03_sdiv_exact_srem.ll")),
-        ("04_fp_arith_double", include_str!("fixtures/04_fp_arith_double.ll")),
-        ("05_fp_arith_float", include_str!("fixtures/05_fp_arith_float.ll")),
+        (
+            "03_sdiv_exact_srem",
+            include_str!("fixtures/03_sdiv_exact_srem.ll"),
+        ),
+        (
+            "04_fp_arith_double",
+            include_str!("fixtures/04_fp_arith_double.ll"),
+        ),
+        (
+            "05_fp_arith_float",
+            include_str!("fixtures/05_fp_arith_float.ll"),
+        ),
         ("06_fp_fastmath", include_str!("fixtures/06_fp_fastmath.ll")),
         ("07_fcmp", include_str!("fixtures/07_fcmp.ll")),
-        ("08_icmp_all_preds", include_str!("fixtures/08_icmp_all_preds.ll")),
-        ("09_trunc_zext_sext", include_str!("fixtures/09_trunc_zext_sext.ll")),
-        ("10_fptrunc_fpext", include_str!("fixtures/10_fptrunc_fpext.ll")),
-        ("11_fp_int_casts", include_str!("fixtures/11_fp_int_casts.ll")),
+        (
+            "08_icmp_all_preds",
+            include_str!("fixtures/08_icmp_all_preds.ll"),
+        ),
+        (
+            "09_trunc_zext_sext",
+            include_str!("fixtures/09_trunc_zext_sext.ll"),
+        ),
+        (
+            "10_fptrunc_fpext",
+            include_str!("fixtures/10_fptrunc_fpext.ll"),
+        ),
+        (
+            "11_fp_int_casts",
+            include_str!("fixtures/11_fp_int_casts.ll"),
+        ),
         ("12_ptr_casts", include_str!("fixtures/12_ptr_casts.ll")),
-        ("14_alloca_align", include_str!("fixtures/14_alloca_align.ll")),
-        ("15_load_store_align", include_str!("fixtures/15_load_store_align.ll")),
-        ("15b_volatile_mem", include_str!("fixtures/15b_volatile_mem.ll")),
-        ("16_gep_inbounds", include_str!("fixtures/16_gep_inbounds.ll")),
+        (
+            "14_alloca_align",
+            include_str!("fixtures/14_alloca_align.ll"),
+        ),
+        (
+            "15_load_store_align",
+            include_str!("fixtures/15_load_store_align.ll"),
+        ),
+        (
+            "15b_volatile_mem",
+            include_str!("fixtures/15b_volatile_mem.ll"),
+        ),
+        (
+            "16_gep_inbounds",
+            include_str!("fixtures/16_gep_inbounds.ll"),
+        ),
         ("17_gep_struct", include_str!("fixtures/17_gep_struct.ll")),
-        ("18_extractvalue", include_str!("fixtures/18_extractvalue.ll")),
+        (
+            "18_extractvalue",
+            include_str!("fixtures/18_extractvalue.ll"),
+        ),
         ("19_insertvalue", include_str!("fixtures/19_insertvalue.ll")),
-        ("20_extractelement", include_str!("fixtures/20_extractelement.ll")),
-        ("21_insertelement", include_str!("fixtures/21_insertelement.ll")),
-        ("22_shufflevector", include_str!("fixtures/22_shufflevector.ll")),
+        (
+            "20_extractelement",
+            include_str!("fixtures/20_extractelement.ll"),
+        ),
+        (
+            "21_insertelement",
+            include_str!("fixtures/21_insertelement.ll"),
+        ),
+        (
+            "22_shufflevector",
+            include_str!("fixtures/22_shufflevector.ll"),
+        ),
         ("23_unreachable", include_str!("fixtures/23_unreachable.ll")),
         ("24_switch_many", include_str!("fixtures/24_switch_many.ll")),
-        ("25_switch_default_only", include_str!("fixtures/25_switch_default_only.ll")),
+        (
+            "25_switch_default_only",
+            include_str!("fixtures/25_switch_default_only.ll"),
+        ),
         ("26_phi_loop", include_str!("fixtures/26_phi_loop.ll")),
-        ("27_phi_multiple", include_str!("fixtures/27_phi_multiple.ll")),
+        (
+            "27_phi_multiple",
+            include_str!("fixtures/27_phi_multiple.ll"),
+        ),
         ("28_tail_calls", include_str!("fixtures/28_tail_calls.ll")),
-        ("29_indirect_call", include_str!("fixtures/29_indirect_call.ll")),
-        ("30_variadic_call", include_str!("fixtures/30_variadic_call.ll")),
+        (
+            "29_indirect_call",
+            include_str!("fixtures/29_indirect_call.ll"),
+        ),
+        (
+            "30_variadic_call",
+            include_str!("fixtures/30_variadic_call.ll"),
+        ),
         ("31_array_type", include_str!("fixtures/31_array_type.ll")),
         ("32_struct_anon", include_str!("fixtures/32_struct_anon.ll")),
-        ("33_vector_arith", include_str!("fixtures/33_vector_arith.ll")),
-        ("34_named_struct_nested", include_str!("fixtures/34_named_struct_nested.ll")),
+        (
+            "33_vector_arith",
+            include_str!("fixtures/33_vector_arith.ll"),
+        ),
+        (
+            "34_named_struct_nested",
+            include_str!("fixtures/34_named_struct_nested.ll"),
+        ),
         ("35_const_undef", include_str!("fixtures/35_const_undef.ll")),
-        ("36_const_zeroinitializer", include_str!("fixtures/36_const_zeroinitializer.ll")),
+        (
+            "36_const_zeroinitializer",
+            include_str!("fixtures/36_const_zeroinitializer.ll"),
+        ),
         ("37_const_null", include_str!("fixtures/37_const_null.ll")),
-        ("38_const_float_hex", include_str!("fixtures/38_const_float_hex.ll")),
-        ("39_private_linkage", include_str!("fixtures/39_private_linkage.ll")),
-        ("40_internal_linkage", include_str!("fixtures/40_internal_linkage.ll")),
-        ("41_module_header", include_str!("fixtures/41_module_header.ll")),
-        ("42_multi_function", include_str!("fixtures/42_multi_function.ll")),
-        ("43_declare_void", include_str!("fixtures/43_declare_void.ll")),
-        ("44_declare_ptr_ret", include_str!("fixtures/44_declare_ptr_ret.ll")),
-        ("45_select_chain", include_str!("fixtures/45_select_chain.ll")),
+        (
+            "38_const_float_hex",
+            include_str!("fixtures/38_const_float_hex.ll"),
+        ),
+        (
+            "39_private_linkage",
+            include_str!("fixtures/39_private_linkage.ll"),
+        ),
+        (
+            "40_internal_linkage",
+            include_str!("fixtures/40_internal_linkage.ll"),
+        ),
+        (
+            "41_module_header",
+            include_str!("fixtures/41_module_header.ll"),
+        ),
+        (
+            "42_multi_function",
+            include_str!("fixtures/42_multi_function.ll"),
+        ),
+        (
+            "43_declare_void",
+            include_str!("fixtures/43_declare_void.ll"),
+        ),
+        (
+            "44_declare_ptr_ret",
+            include_str!("fixtures/44_declare_ptr_ret.ll"),
+        ),
+        (
+            "45_select_chain",
+            include_str!("fixtures/45_select_chain.ll"),
+        ),
         ("46_phi_diamond", include_str!("fixtures/46_phi_diamond.ll")),
-        ("47_alloca_array", include_str!("fixtures/47_alloca_array.ll")),
+        (
+            "47_alloca_array",
+            include_str!("fixtures/47_alloca_array.ll"),
+        ),
         ("48_fp_loop", include_str!("fixtures/48_fp_loop.ll")),
         ("49_all_icmp_br", include_str!("fixtures/49_all_icmp_br.ll")),
-        ("50_bitwise_shifts", include_str!("fixtures/50_bitwise_shifts.ll")),
+        (
+            "50_bitwise_shifts",
+            include_str!("fixtures/50_bitwise_shifts.ll"),
+        ),
         ("51_cast_chain", include_str!("fixtures/51_cast_chain.ll")),
-        ("53_fp_scalar_ops", include_str!("fixtures/53_fp_scalar_ops.ll")),
+        (
+            "53_fp_scalar_ops",
+            include_str!("fixtures/53_fp_scalar_ops.ll"),
+        ),
         ("54_fp_compare", include_str!("fixtures/54_fp_compare.ll")),
-        ("55_fp_conversions", include_str!("fixtures/55_fp_conversions.ll")),
+        (
+            "55_fp_conversions",
+            include_str!("fixtures/55_fp_conversions.ll"),
+        ),
     ];
 
     for (name, src) in fixtures {

--- a/src/llvm-ir-parser/tests/parse_basic.rs
+++ b/src/llvm-ir-parser/tests/parse_basic.rs
@@ -143,8 +143,7 @@ entry:
     let printed = Printer::new(&ctx).print_module(&module);
     assert!(printed.contains("fence seq_cst"), "{printed}");
     assert!(
-        printed
-            .contains("%cas = cmpxchg ptr %p, i32 %cmp, i32 %new acq_rel acquire"),
+        printed.contains("%cas = cmpxchg ptr %p, i32 %cmp, i32 %new acq_rel acquire"),
         "{printed}"
     );
     assert!(
@@ -274,7 +273,10 @@ entry:
 
     let hoisted = f.instr(bb.body[0]);
     assert!(
-        matches!(hoisted.kind, InstrKind::GetElementPtr { inbounds: true, .. }),
+        matches!(
+            hoisted.kind,
+            InstrKind::GetElementPtr { inbounds: true, .. }
+        ),
         "first instruction should be a hoisted inbounds GEP, got {:?}",
         hoisted.kind
     );
@@ -397,10 +399,7 @@ fn parse_constexpr_gep_in_global_initializer() {
         ConstantData::Expr { op, operands, .. } => {
             assert!(matches!(
                 op,
-                ConstExprOp::GetElementPtr {
-                    inbounds: true,
-                    ..
-                }
+                ConstExprOp::GetElementPtr { inbounds: true, .. }
             ));
             assert_eq!(operands.len(), 3, "base + 2 indices");
         }
@@ -408,8 +407,9 @@ fn parse_constexpr_gep_in_global_initializer() {
     }
     let printed = Printer::new(&ctx).print_module(&module);
     assert!(
-        printed
-            .contains("@p3 = constant ptr getelementptr inbounds ([4 x i32], ptr @base, i64 0, i64 3)"),
+        printed.contains(
+            "@p3 = constant ptr getelementptr inbounds ([4 x i32], ptr @base, i64 0, i64 3)"
+        ),
         "constexpr GEP did not print in canonical form:\n{printed}"
     );
 
@@ -447,7 +447,10 @@ fn parse_constexpr_casts_in_global_initializer() {
     ));
 
     let printed = Printer::new(&ctx).print_module(&module);
-    assert!(printed.contains("@bc = constant ptr bitcast (ptr @h to ptr)"), "{printed}");
+    assert!(
+        printed.contains("@bc = constant ptr bitcast (ptr @h to ptr)"),
+        "{printed}"
+    );
     assert!(
         printed.contains("@itp = constant ptr inttoptr (i64 4096 to ptr)"),
         "{printed}"
@@ -471,8 +474,15 @@ lpad:
 }
 "#;
     let (ctx, module) = parse(src).expect("parse failed");
-    let f = module.functions.iter().find(|f| f.name == "f").expect("function f");
-    match &f.instr(f.blocks[0].terminator.expect("entry terminator")).kind {
+    let f = module
+        .functions
+        .iter()
+        .find(|f| f.name == "f")
+        .expect("function f");
+    match &f
+        .instr(f.blocks[0].terminator.expect("entry terminator"))
+        .kind
+    {
         InstrKind::Invoke {
             normal_dest,
             unwind_dest,
@@ -488,7 +498,10 @@ lpad:
             cleanup, clauses, ..
         } => {
             assert!(*cleanup);
-            assert!(matches!(clauses.as_slice(), [LandingPadClause::Catch { .. }]));
+            assert!(matches!(
+                clauses.as_slice(),
+                [LandingPadClause::Catch { .. }]
+            ));
         }
         other => panic!("expected landingpad, got {other:?}"),
     }
@@ -705,7 +718,11 @@ exit:
     // Should have three blocks: entry, loop, exit.
     assert_eq!(f.blocks.len(), 3);
     // The loop block must contain the phi as its first body instruction.
-    let loop_block = f.blocks.iter().find(|b| b.name == "loop").expect("loop block");
+    let loop_block = f
+        .blocks
+        .iter()
+        .find(|b| b.name == "loop")
+        .expect("loop block");
     let phi_instr = f.instr(loop_block.body[0]);
     assert_eq!(phi_instr.kind.opcode(), "phi");
     // Verify both incoming entries were parsed (entry and loop back-edge).
@@ -750,10 +767,22 @@ exit:
 "#;
     let (_ctx, module) = parse(src).expect("adler32 multi-phi parse failed");
     let f = &module.functions[0];
-    assert_eq!(f.blocks.len(), 4, "expected entry, loop, body, exit — got {}", f.blocks.len());
-    let loop_block = f.blocks.iter().find(|b| b.name == "loop").expect("loop block");
+    assert_eq!(
+        f.blocks.len(),
+        4,
+        "expected entry, loop, body, exit — got {}",
+        f.blocks.len()
+    );
+    let loop_block = f
+        .blocks
+        .iter()
+        .find(|b| b.name == "loop")
+        .expect("loop block");
     // First three body instructions in loop are phi nodes.
-    assert!(loop_block.body.len() >= 3, "loop block should have at least 3 body instrs (3 phis)");
+    assert!(
+        loop_block.body.len() >= 3,
+        "loop block should have at least 3 body instrs (3 phis)"
+    );
     for idx in 0..3 {
         let instr = f.instr(loop_block.body[idx]);
         assert_eq!(

--- a/src/llvm-ir-parser/tests/smoke.rs
+++ b/src/llvm-ir-parser/tests/smoke.rs
@@ -137,7 +137,10 @@ fn run_binary(path: &Path, label: &str, which: &str) -> Option<std::process::Out
             Ok(None) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                eprintln!("[smoke/{label}] {which} timed out after {}s", timeout.as_secs());
+                eprintln!(
+                    "[smoke/{label}] {which} timed out after {}s",
+                    timeout.as_secs()
+                );
                 return None;
             }
             Err(e) => {
@@ -208,7 +211,14 @@ fn run_ours(ctx: &Context, module: &Module, label: &str) -> Option<RunResult> {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
     let obj_format = match host_object_format() {
         Some(f) => f,

--- a/src/llvm-ir/src/builder.rs
+++ b/src/llvm-ir/src/builder.rs
@@ -4,8 +4,8 @@ use crate::basic_block::BasicBlock;
 use crate::context::{BlockId, ConstId, Context, FunctionId, GlobalId, TypeId, ValueRef};
 use crate::function::Function;
 use crate::instruction::{
-    FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate, MemOrdering,
-    RmwOp, TailCallKind,
+    FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
+    MemOrdering, RmwOp, TailCallKind,
 };
 use crate::module::Module;
 use crate::value::{Argument, GlobalVariable, Linkage};
@@ -1100,7 +1100,11 @@ impl<'a> Builder<'a> {
         args: Vec<ValueRef>,
     ) -> ValueRef {
         let tok_ty = self.ctx.ptr_ty; // token type approximated as ptr
-        self.append_instr(Some(name.into()), tok_ty, InstrKind::CatchPad { catch_switch, args })
+        self.append_instr(
+            Some(name.into()),
+            tok_ty,
+            InstrKind::CatchPad { catch_switch, args },
+        )
     }
 
     /// Build a `cleanuppad within <parent> [args...]` instruction.
@@ -1113,7 +1117,11 @@ impl<'a> Builder<'a> {
         args: Vec<ValueRef>,
     ) -> ValueRef {
         let tok_ty = self.ctx.ptr_ty;
-        self.append_instr(Some(name.into()), tok_ty, InstrKind::CleanupPad { parent, args })
+        self.append_instr(
+            Some(name.into()),
+            tok_ty,
+            InstrKind::CleanupPad { parent, args },
+        )
     }
 
     /// Build a `catchswitch within <parent> [handlers...] unwind <dest>` terminator.
@@ -1127,7 +1135,11 @@ impl<'a> Builder<'a> {
         self.append_instr(
             None,
             tok_ty,
-            InstrKind::CatchSwitch { parent, handlers, default },
+            InstrKind::CatchSwitch {
+                parent,
+                handlers,
+                default,
+            },
         )
     }
 
@@ -1137,7 +1149,10 @@ impl<'a> Builder<'a> {
         self.append_instr(
             None,
             void_ty,
-            InstrKind::CatchRet { catch_pad, successor },
+            InstrKind::CatchRet {
+                catch_pad,
+                successor,
+            },
         )
     }
 
@@ -1151,7 +1166,10 @@ impl<'a> Builder<'a> {
         self.append_instr(
             None,
             void_ty,
-            InstrKind::CleanupRet { cleanup_pad, unwind_dest },
+            InstrKind::CleanupRet {
+                cleanup_pad,
+                unwind_dest,
+            },
         )
     }
 

--- a/src/llvm-ir/src/function.rs
+++ b/src/llvm-ir/src/function.rs
@@ -153,7 +153,12 @@ impl Function {
     }
 
     /// Public API for `add_instr_metadata`.
-    pub fn add_instr_metadata(&mut self, id: InstrId, key: impl Into<String>, value: impl Into<String>) {
+    pub fn add_instr_metadata(
+        &mut self,
+        id: InstrId,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) {
         self.instr_metadata
             .entry(id)
             .or_default()

--- a/src/llvm-ir/src/instruction.rs
+++ b/src/llvm-ir/src/instruction.rs
@@ -399,32 +399,17 @@ pub enum InstrKind {
         rhs: ValueRef,
     },
     /// `URem` variant.
-    URem {
-        lhs: ValueRef,
-        rhs: ValueRef,
-    },
+    URem { lhs: ValueRef, rhs: ValueRef },
     /// `SRem` variant.
-    SRem {
-        lhs: ValueRef,
-        rhs: ValueRef,
-    },
+    SRem { lhs: ValueRef, rhs: ValueRef },
 
     // --- Bitwise ---
     /// `And` variant.
-    And {
-        lhs: ValueRef,
-        rhs: ValueRef,
-    },
+    And { lhs: ValueRef, rhs: ValueRef },
     /// `Or` variant.
-    Or {
-        lhs: ValueRef,
-        rhs: ValueRef,
-    },
+    Or { lhs: ValueRef, rhs: ValueRef },
     /// `Xor` variant.
-    Xor {
-        lhs: ValueRef,
-        rhs: ValueRef,
-    },
+    Xor { lhs: ValueRef, rhs: ValueRef },
     /// `Shl` variant.
     Shl {
         flags: IntArithFlags,
@@ -527,74 +512,33 @@ pub enum InstrKind {
 
     // --- Casts ---
     /// `Trunc` variant.
-    Trunc {
-        val: ValueRef,
-        to: TypeId,
-    },
+    Trunc { val: ValueRef, to: TypeId },
     /// `ZExt` variant.
-    ZExt {
-        val: ValueRef,
-        to: TypeId,
-    },
+    ZExt { val: ValueRef, to: TypeId },
     /// `SExt` variant.
-    SExt {
-        val: ValueRef,
-        to: TypeId,
-    },
+    SExt { val: ValueRef, to: TypeId },
     /// `FPTrunc` variant.
-    FPTrunc {
-        val: ValueRef,
-        to: TypeId,
-    },
+    FPTrunc { val: ValueRef, to: TypeId },
     /// `FPExt` variant.
-    FPExt {
-        val: ValueRef,
-        to: TypeId,
-    },
+    FPExt { val: ValueRef, to: TypeId },
     /// `FPToUI` variant.
-    FPToUI {
-        val: ValueRef,
-        to: TypeId,
-    },
+    FPToUI { val: ValueRef, to: TypeId },
     /// `FPToSI` variant.
-    FPToSI {
-        val: ValueRef,
-        to: TypeId,
-    },
+    FPToSI { val: ValueRef, to: TypeId },
     /// `UIToFP` variant.
-    UIToFP {
-        val: ValueRef,
-        to: TypeId,
-    },
+    UIToFP { val: ValueRef, to: TypeId },
     /// `SIToFP` variant.
-    SIToFP {
-        val: ValueRef,
-        to: TypeId,
-    },
+    SIToFP { val: ValueRef, to: TypeId },
     /// `PtrToInt` variant.
-    PtrToInt {
-        val: ValueRef,
-        to: TypeId,
-    },
+    PtrToInt { val: ValueRef, to: TypeId },
     /// `IntToPtr` variant.
-    IntToPtr {
-        val: ValueRef,
-        to: TypeId,
-    },
+    IntToPtr { val: ValueRef, to: TypeId },
     /// `BitCast` variant.
-    BitCast {
-        val: ValueRef,
-        to: TypeId,
-    },
+    BitCast { val: ValueRef, to: TypeId },
     /// `AddrSpaceCast` variant.
-    AddrSpaceCast {
-        val: ValueRef,
-        to: TypeId,
-    },
+    AddrSpaceCast { val: ValueRef, to: TypeId },
     /// `Freeze` variant.
-    Freeze {
-        val: ValueRef,
-    },
+    Freeze { val: ValueRef },
 
     // --- Misc ---
     /// `Select` variant.
@@ -620,10 +564,7 @@ pub enum InstrKind {
         indices: Vec<u32>,
     },
     /// `ExtractElement` variant.
-    ExtractElement {
-        vec: ValueRef,
-        idx: ValueRef,
-    },
+    ExtractElement { vec: ValueRef, idx: ValueRef },
     /// `InsertElement` variant.
     InsertElement {
         vec: ValueRef,
@@ -717,13 +658,9 @@ pub enum InstrKind {
 
     // --- Terminators ---
     /// `Ret` variant.
-    Ret {
-        val: Option<ValueRef>,
-    },
+    Ret { val: Option<ValueRef> },
     /// `Br` variant.
-    Br {
-        dest: BlockId,
-    },
+    Br { dest: BlockId },
     /// `CondBr` variant.
     CondBr {
         cond: ValueRef,
@@ -1045,9 +982,7 @@ impl InstrKind {
                 v
             }
             InstrKind::CatchRet { successor, .. } => vec![*successor],
-            InstrKind::CleanupRet { unwind_dest, .. } => {
-                unwind_dest.iter().copied().collect()
-            }
+            InstrKind::CleanupRet { unwind_dest, .. } => unwind_dest.iter().copied().collect(),
             // Non-terminators and exit terminators (Ret, Unreachable, Resume) have no
             // successors.  Listed explicitly so the compiler enforces that every
             // future variant is consciously placed in one arm or the other.
@@ -1151,12 +1086,24 @@ mod tests {
     use crate::context::{BlockId, ConstId, Context, InstrId};
 
     // ── tiny helpers ────────────────────────────────────────────────────────
-    fn c0() -> ValueRef { ValueRef::Constant(ConstId(0)) }
-    fn c1() -> ValueRef { ValueRef::Constant(ConstId(1)) }
-    fn c2() -> ValueRef { ValueRef::Constant(ConstId(2)) }
-    fn v0() -> ValueRef { ValueRef::Instruction(InstrId(0)) }
-    fn b0() -> BlockId  { BlockId(0) }
-    fn b1() -> BlockId  { BlockId(1) }
+    fn c0() -> ValueRef {
+        ValueRef::Constant(ConstId(0))
+    }
+    fn c1() -> ValueRef {
+        ValueRef::Constant(ConstId(1))
+    }
+    fn c2() -> ValueRef {
+        ValueRef::Constant(ConstId(2))
+    }
+    fn v0() -> ValueRef {
+        ValueRef::Instruction(InstrId(0))
+    }
+    fn b0() -> BlockId {
+        BlockId(0)
+    }
+    fn b1() -> BlockId {
+        BlockId(1)
+    }
 
     // ── existing tests ───────────────────────────────────────────────────────
 
@@ -1184,43 +1131,69 @@ mod tests {
 
     #[test]
     fn operands_add() {
-        let k = InstrKind::Add { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::Add {
+            flags: IntArithFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_sub() {
-        let k = InstrKind::Sub { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::Sub {
+            flags: IntArithFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_mul() {
-        let k = InstrKind::Mul { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::Mul {
+            flags: IntArithFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_udiv() {
-        let k = InstrKind::UDiv { exact: false, lhs: c0(), rhs: c1() };
+        let k = InstrKind::UDiv {
+            exact: false,
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_sdiv() {
-        let k = InstrKind::SDiv { exact: true, lhs: c0(), rhs: c1() };
+        let k = InstrKind::SDiv {
+            exact: true,
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_urem() {
-        let k = InstrKind::URem { lhs: c0(), rhs: c1() };
+        let k = InstrKind::URem {
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_srem() {
-        let k = InstrKind::SRem { lhs: c0(), rhs: c1() };
+        let k = InstrKind::SRem {
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
@@ -1228,70 +1201,134 @@ mod tests {
 
     #[test]
     fn operands_and() {
-        assert_eq!(InstrKind::And { lhs: c0(), rhs: c1() }.operands(), vec![c0(), c1()]);
+        assert_eq!(
+            InstrKind::And {
+                lhs: c0(),
+                rhs: c1()
+            }
+            .operands(),
+            vec![c0(), c1()]
+        );
     }
 
     #[test]
     fn operands_or() {
-        assert_eq!(InstrKind::Or { lhs: c0(), rhs: c1() }.operands(), vec![c0(), c1()]);
+        assert_eq!(
+            InstrKind::Or {
+                lhs: c0(),
+                rhs: c1()
+            }
+            .operands(),
+            vec![c0(), c1()]
+        );
     }
 
     #[test]
     fn operands_xor() {
-        assert_eq!(InstrKind::Xor { lhs: c0(), rhs: c1() }.operands(), vec![c0(), c1()]);
+        assert_eq!(
+            InstrKind::Xor {
+                lhs: c0(),
+                rhs: c1()
+            }
+            .operands(),
+            vec![c0(), c1()]
+        );
     }
 
     #[test]
     fn operands_shl() {
-        let k = InstrKind::Shl { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::Shl {
+            flags: IntArithFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_lshr() {
-        assert_eq!(InstrKind::LShr { exact: false, lhs: c0(), rhs: c1() }.operands(), vec![c0(), c1()]);
+        assert_eq!(
+            InstrKind::LShr {
+                exact: false,
+                lhs: c0(),
+                rhs: c1()
+            }
+            .operands(),
+            vec![c0(), c1()]
+        );
     }
 
     #[test]
     fn operands_ashr() {
-        assert_eq!(InstrKind::AShr { exact: false, lhs: c0(), rhs: c1() }.operands(), vec![c0(), c1()]);
+        assert_eq!(
+            InstrKind::AShr {
+                exact: false,
+                lhs: c0(),
+                rhs: c1()
+            }
+            .operands(),
+            vec![c0(), c1()]
+        );
     }
 
     // ── operands() — FP arithmetic (6 variants) ───────────────────────────────
 
     #[test]
     fn operands_fadd() {
-        let k = InstrKind::FAdd { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::FAdd {
+            flags: FastMathFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_fsub() {
-        let k = InstrKind::FSub { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::FSub {
+            flags: FastMathFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_fmul() {
-        let k = InstrKind::FMul { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::FMul {
+            flags: FastMathFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_fdiv() {
-        let k = InstrKind::FDiv { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::FDiv {
+            flags: FastMathFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_frem() {
-        let k = InstrKind::FRem { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() };
+        let k = InstrKind::FRem {
+            flags: FastMathFlags::default(),
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_fneg() {
-        let k = InstrKind::FNeg { flags: FastMathFlags::default(), operand: c0() };
+        let k = InstrKind::FNeg {
+            flags: FastMathFlags::default(),
+            operand: c0(),
+        };
         assert_eq!(k.operands(), vec![c0()]);
     }
 
@@ -1299,7 +1336,11 @@ mod tests {
 
     #[test]
     fn operands_icmp() {
-        let k = InstrKind::ICmp { pred: IntPredicate::Eq, lhs: c0(), rhs: c1() };
+        let k = InstrKind::ICmp {
+            pred: IntPredicate::Eq,
+            lhs: c0(),
+            rhs: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
@@ -1319,27 +1360,45 @@ mod tests {
     #[test]
     fn operands_alloca_no_count() {
         let ctx = Context::new();
-        let k = InstrKind::Alloca { alloc_ty: ctx.i32_ty, num_elements: None, align: None };
+        let k = InstrKind::Alloca {
+            alloc_ty: ctx.i32_ty,
+            num_elements: None,
+            align: None,
+        };
         assert_eq!(k.operands(), vec![]);
     }
 
     #[test]
     fn operands_alloca_with_count() {
         let ctx = Context::new();
-        let k = InstrKind::Alloca { alloc_ty: ctx.i32_ty, num_elements: Some(c0()), align: None };
+        let k = InstrKind::Alloca {
+            alloc_ty: ctx.i32_ty,
+            num_elements: Some(c0()),
+            align: None,
+        };
         assert_eq!(k.operands(), vec![c0()]);
     }
 
     #[test]
     fn operands_load() {
         let ctx = Context::new();
-        let k = InstrKind::Load { ty: ctx.i32_ty, ptr: c0(), align: None, volatile: false };
+        let k = InstrKind::Load {
+            ty: ctx.i32_ty,
+            ptr: c0(),
+            align: None,
+            volatile: false,
+        };
         assert_eq!(k.operands(), vec![c0()]);
     }
 
     #[test]
     fn operands_store() {
-        let k = InstrKind::Store { val: c0(), ptr: c1(), align: None, volatile: false };
+        let k = InstrKind::Store {
+            val: c0(),
+            ptr: c1(),
+            align: None,
+            volatile: false,
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
@@ -1372,100 +1431,198 @@ mod tests {
     #[test]
     fn operands_trunc() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::Trunc { val: c0(), to: ctx.i8_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::Trunc {
+                val: c0(),
+                to: ctx.i8_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_zext() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::ZExt { val: c0(), to: ctx.i64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::ZExt {
+                val: c0(),
+                to: ctx.i64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_sext() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::SExt { val: c0(), to: ctx.i64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::SExt {
+                val: c0(),
+                to: ctx.i64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_fptrunc() {
         let ctx = Context::new();
         let f32_ty = ctx.f32_ty;
-        assert_eq!(InstrKind::FPTrunc { val: c0(), to: f32_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::FPTrunc {
+                val: c0(),
+                to: f32_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_fpext() {
         let ctx = Context::new();
         let f64_ty = ctx.f64_ty;
-        assert_eq!(InstrKind::FPExt { val: c0(), to: f64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::FPExt {
+                val: c0(),
+                to: f64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_fptoui() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::FPToUI { val: c0(), to: ctx.i64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::FPToUI {
+                val: c0(),
+                to: ctx.i64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_fptosi() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::FPToSI { val: c0(), to: ctx.i64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::FPToSI {
+                val: c0(),
+                to: ctx.i64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_uitofp() {
         let ctx = Context::new();
         let f64_ty = ctx.f64_ty;
-        assert_eq!(InstrKind::UIToFP { val: c0(), to: f64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::UIToFP {
+                val: c0(),
+                to: f64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_sitofp() {
         let ctx = Context::new();
         let f64_ty = ctx.f64_ty;
-        assert_eq!(InstrKind::SIToFP { val: c0(), to: f64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::SIToFP {
+                val: c0(),
+                to: f64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_ptrtoint() {
         let ctx = Context::new();
-        assert_eq!(InstrKind::PtrToInt { val: c0(), to: ctx.i64_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::PtrToInt {
+                val: c0(),
+                to: ctx.i64_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_inttoptr() {
         let ctx = Context::new();
         let ptr_ty = ctx.ptr_ty;
-        assert_eq!(InstrKind::IntToPtr { val: c0(), to: ptr_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::IntToPtr {
+                val: c0(),
+                to: ptr_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_bitcast() {
         let ctx = Context::new();
         let ptr_ty = ctx.ptr_ty;
-        assert_eq!(InstrKind::BitCast { val: c0(), to: ptr_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::BitCast {
+                val: c0(),
+                to: ptr_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     #[test]
     fn operands_addrspacecast() {
         let ctx = Context::new();
         let ptr_ty = ctx.ptr_ty;
-        assert_eq!(InstrKind::AddrSpaceCast { val: c0(), to: ptr_ty }.operands(), vec![c0()]);
+        assert_eq!(
+            InstrKind::AddrSpaceCast {
+                val: c0(),
+                to: ptr_ty
+            }
+            .operands(),
+            vec![c0()]
+        );
     }
 
     // ── operands() — misc (7 variants) ───────────────────────────────────────
 
     #[test]
     fn operands_select() {
-        let k = InstrKind::Select { cond: c0(), then_val: c1(), else_val: v0() };
+        let k = InstrKind::Select {
+            cond: c0(),
+            then_val: c1(),
+            else_val: v0(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1(), v0()]);
     }
 
     #[test]
     fn operands_phi_empty() {
         let ctx = Context::new();
-        let k = InstrKind::Phi { ty: ctx.i32_ty, incoming: vec![] };
+        let k = InstrKind::Phi {
+            ty: ctx.i32_ty,
+            incoming: vec![],
+        };
         assert_eq!(k.operands(), vec![]);
     }
 
@@ -1482,32 +1639,50 @@ mod tests {
 
     #[test]
     fn operands_extractvalue() {
-        let k = InstrKind::ExtractValue { aggregate: c0(), indices: vec![0, 1] };
+        let k = InstrKind::ExtractValue {
+            aggregate: c0(),
+            indices: vec![0, 1],
+        };
         assert_eq!(k.operands(), vec![c0()]);
     }
 
     #[test]
     fn operands_insertvalue() {
-        let k = InstrKind::InsertValue { aggregate: c0(), val: c1(), indices: vec![0] };
+        let k = InstrKind::InsertValue {
+            aggregate: c0(),
+            val: c1(),
+            indices: vec![0],
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_extractelement() {
-        let k = InstrKind::ExtractElement { vec: c0(), idx: c1() };
+        let k = InstrKind::ExtractElement {
+            vec: c0(),
+            idx: c1(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
     #[test]
     fn operands_insertelement() {
-        let k = InstrKind::InsertElement { vec: c0(), val: c1(), idx: v0() };
+        let k = InstrKind::InsertElement {
+            vec: c0(),
+            val: c1(),
+            idx: v0(),
+        };
         assert_eq!(k.operands(), vec![c0(), c1(), v0()]);
     }
 
     #[test]
     fn operands_shufflevector() {
         // mask is Vec<i32> (integer literals, not ValueRefs) — v1 and v2 only.
-        let k = InstrKind::ShuffleVector { v1: c0(), v2: c1(), mask: vec![0, 1, 0, 1] };
+        let k = InstrKind::ShuffleVector {
+            v1: c0(),
+            v2: c1(),
+            mask: vec![0, 1, 0, 1],
+        };
         assert_eq!(k.operands(), vec![c0(), c1()]);
     }
 
@@ -1560,7 +1735,11 @@ mod tests {
 
     #[test]
     fn operands_condbr() {
-        let k = InstrKind::CondBr { cond: c0(), then_dest: b0(), else_dest: b1() };
+        let k = InstrKind::CondBr {
+            cond: c0(),
+            then_dest: b0(),
+            else_dest: b1(),
+        };
         // Only the condition is a value operand; block targets are not.
         assert_eq!(k.operands(), vec![c0()]);
     }
@@ -1590,7 +1769,11 @@ mod tests {
 
     #[test]
     fn successors_condbr() {
-        let k = InstrKind::CondBr { cond: c0(), then_dest: b0(), else_dest: b1() };
+        let k = InstrKind::CondBr {
+            cond: c0(),
+            then_dest: b0(),
+            else_dest: b1(),
+        };
         assert_eq!(k.successors(), vec![b0(), b1()]);
     }
 
@@ -1606,7 +1789,11 @@ mod tests {
 
     #[test]
     fn successors_switch_no_cases() {
-        let k = InstrKind::Switch { val: c0(), default: b1(), cases: vec![] };
+        let k = InstrKind::Switch {
+            val: c0(),
+            default: b1(),
+            cases: vec![],
+        };
         assert_eq!(k.successors(), vec![b1()]);
     }
 
@@ -1633,52 +1820,219 @@ mod tests {
         let callee_ty = ctx.mk_fn_type(ctx.void_ty, vec![], false);
         // One representative from each group of non-terminators.
         let cases: &[InstrKind] = &[
-            InstrKind::Add { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::Sub { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::Mul { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::UDiv { exact: false, lhs: c0(), rhs: c1() },
-            InstrKind::SDiv { exact: false, lhs: c0(), rhs: c1() },
-            InstrKind::URem { lhs: c0(), rhs: c1() },
-            InstrKind::SRem { lhs: c0(), rhs: c1() },
-            InstrKind::And { lhs: c0(), rhs: c1() },
-            InstrKind::Or  { lhs: c0(), rhs: c1() },
-            InstrKind::Xor { lhs: c0(), rhs: c1() },
-            InstrKind::Shl { flags: IntArithFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::LShr { exact: false, lhs: c0(), rhs: c1() },
-            InstrKind::AShr { exact: false, lhs: c0(), rhs: c1() },
-            InstrKind::FAdd { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::FSub { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::FMul { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::FDiv { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::FRem { flags: FastMathFlags::default(), lhs: c0(), rhs: c1() },
-            InstrKind::FNeg { flags: FastMathFlags::default(), operand: c0() },
-            InstrKind::ICmp { pred: IntPredicate::Eq, lhs: c0(), rhs: c1() },
-            InstrKind::FCmp { flags: FastMathFlags::default(), pred: FloatPredicate::Oeq, lhs: c0(), rhs: c1() },
-            InstrKind::Alloca { alloc_ty: ctx.i32_ty, num_elements: None, align: None },
-            InstrKind::Load  { ty: ctx.i32_ty, ptr: c0(), align: None, volatile: false },
-            InstrKind::Store { val: c0(), ptr: c1(), align: None, volatile: false },
-            InstrKind::GetElementPtr { inbounds: false, base_ty: ctx.i32_ty, ptr: c0(), indices: vec![] },
-            InstrKind::Trunc { val: c0(), to: ctx.i8_ty },
-            InstrKind::ZExt  { val: c0(), to: ctx.i64_ty },
-            InstrKind::SExt  { val: c0(), to: ctx.i64_ty },
-            InstrKind::FPTrunc { val: c0(), to: ctx.f32_ty },
-            InstrKind::FPExt   { val: c0(), to: ctx.f64_ty },
-            InstrKind::FPToUI  { val: c0(), to: ctx.i64_ty },
-            InstrKind::FPToSI  { val: c0(), to: ctx.i64_ty },
-            InstrKind::UIToFP  { val: c0(), to: ctx.f64_ty },
-            InstrKind::SIToFP  { val: c0(), to: ctx.f64_ty },
-            InstrKind::PtrToInt { val: c0(), to: ctx.i64_ty },
-            InstrKind::IntToPtr { val: c0(), to: ctx.ptr_ty },
-            InstrKind::BitCast  { val: c0(), to: ctx.ptr_ty },
-            InstrKind::AddrSpaceCast { val: c0(), to: ctx.ptr_ty },
-            InstrKind::Select { cond: c0(), then_val: c1(), else_val: v0() },
-            InstrKind::Phi { ty: ctx.i32_ty, incoming: vec![] },
-            InstrKind::ExtractValue { aggregate: c0(), indices: vec![0] },
-            InstrKind::InsertValue  { aggregate: c0(), val: c1(), indices: vec![0] },
-            InstrKind::ExtractElement { vec: c0(), idx: c1() },
-            InstrKind::InsertElement  { vec: c0(), val: c1(), idx: v0() },
-            InstrKind::ShuffleVector  { v1: c0(), v2: c1(), mask: vec![0, 1] },
-            InstrKind::Call { tail: TailCallKind::None, callee_ty, callee: c0(), args: vec![] },
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Sub {
+                flags: IntArithFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Mul {
+                flags: IntArithFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::UDiv {
+                exact: false,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::SDiv {
+                exact: false,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::URem {
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::SRem {
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::And {
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Or {
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Xor {
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Shl {
+                flags: IntArithFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::LShr {
+                exact: false,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::AShr {
+                exact: false,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FAdd {
+                flags: FastMathFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FSub {
+                flags: FastMathFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FMul {
+                flags: FastMathFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FDiv {
+                flags: FastMathFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FRem {
+                flags: FastMathFlags::default(),
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FNeg {
+                flags: FastMathFlags::default(),
+                operand: c0(),
+            },
+            InstrKind::ICmp {
+                pred: IntPredicate::Eq,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::FCmp {
+                flags: FastMathFlags::default(),
+                pred: FloatPredicate::Oeq,
+                lhs: c0(),
+                rhs: c1(),
+            },
+            InstrKind::Alloca {
+                alloc_ty: ctx.i32_ty,
+                num_elements: None,
+                align: None,
+            },
+            InstrKind::Load {
+                ty: ctx.i32_ty,
+                ptr: c0(),
+                align: None,
+                volatile: false,
+            },
+            InstrKind::Store {
+                val: c0(),
+                ptr: c1(),
+                align: None,
+                volatile: false,
+            },
+            InstrKind::GetElementPtr {
+                inbounds: false,
+                base_ty: ctx.i32_ty,
+                ptr: c0(),
+                indices: vec![],
+            },
+            InstrKind::Trunc {
+                val: c0(),
+                to: ctx.i8_ty,
+            },
+            InstrKind::ZExt {
+                val: c0(),
+                to: ctx.i64_ty,
+            },
+            InstrKind::SExt {
+                val: c0(),
+                to: ctx.i64_ty,
+            },
+            InstrKind::FPTrunc {
+                val: c0(),
+                to: ctx.f32_ty,
+            },
+            InstrKind::FPExt {
+                val: c0(),
+                to: ctx.f64_ty,
+            },
+            InstrKind::FPToUI {
+                val: c0(),
+                to: ctx.i64_ty,
+            },
+            InstrKind::FPToSI {
+                val: c0(),
+                to: ctx.i64_ty,
+            },
+            InstrKind::UIToFP {
+                val: c0(),
+                to: ctx.f64_ty,
+            },
+            InstrKind::SIToFP {
+                val: c0(),
+                to: ctx.f64_ty,
+            },
+            InstrKind::PtrToInt {
+                val: c0(),
+                to: ctx.i64_ty,
+            },
+            InstrKind::IntToPtr {
+                val: c0(),
+                to: ctx.ptr_ty,
+            },
+            InstrKind::BitCast {
+                val: c0(),
+                to: ctx.ptr_ty,
+            },
+            InstrKind::AddrSpaceCast {
+                val: c0(),
+                to: ctx.ptr_ty,
+            },
+            InstrKind::Select {
+                cond: c0(),
+                then_val: c1(),
+                else_val: v0(),
+            },
+            InstrKind::Phi {
+                ty: ctx.i32_ty,
+                incoming: vec![],
+            },
+            InstrKind::ExtractValue {
+                aggregate: c0(),
+                indices: vec![0],
+            },
+            InstrKind::InsertValue {
+                aggregate: c0(),
+                val: c1(),
+                indices: vec![0],
+            },
+            InstrKind::ExtractElement {
+                vec: c0(),
+                idx: c1(),
+            },
+            InstrKind::InsertElement {
+                vec: c0(),
+                val: c1(),
+                idx: v0(),
+            },
+            InstrKind::ShuffleVector {
+                v1: c0(),
+                v2: c1(),
+                mask: vec![0, 1],
+            },
+            InstrKind::Call {
+                tail: TailCallKind::None,
+                callee_ty,
+                callee: c0(),
+                args: vec![],
+            },
         ];
         for k in cases {
             assert_eq!(k.successors(), vec![], "{:?} should have no successors", k);
@@ -1689,7 +2043,9 @@ mod tests {
 
     #[test]
     fn operands_fence_has_no_value_operands() {
-        let k = InstrKind::Fence { ordering: MemOrdering::SeqCst };
+        let k = InstrKind::Fence {
+            ordering: MemOrdering::SeqCst,
+        };
         assert_eq!(k.operands(), vec![]);
     }
 
@@ -1723,7 +2079,9 @@ mod tests {
 
     #[test]
     fn successors_atomics_are_empty() {
-        let fence = InstrKind::Fence { ordering: MemOrdering::SeqCst };
+        let fence = InstrKind::Fence {
+            ordering: MemOrdering::SeqCst,
+        };
         let cas = InstrKind::CmpXchg {
             ptr: c0(),
             cmp: c1(),
@@ -1750,7 +2108,9 @@ mod tests {
 
     #[test]
     fn opcode_names_atomics() {
-        let fence = InstrKind::Fence { ordering: MemOrdering::SeqCst };
+        let fence = InstrKind::Fence {
+            ordering: MemOrdering::SeqCst,
+        };
         let cas = InstrKind::CmpXchg {
             ptr: c0(),
             cmp: c1(),

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -41,12 +41,12 @@ pub mod instruction;
 pub mod module;
 /// Public API for `printer`.
 pub mod printer;
+/// IR minimizer (delta debugging style).
+pub mod reduce;
 /// Public API for `types`.
 pub mod types;
 /// Public API for `value`.
 pub mod value;
-/// IR minimizer (delta debugging style).
-pub mod reduce;
 
 // Re-export key types at crate root for ergonomic use.
 /// Public API for `re-export`.
@@ -61,16 +61,16 @@ pub use context::{
 pub use function::Function;
 /// Public API for `re-export`.
 pub use instruction::{
-    ExactFlag, FastMathFlags, FloatPredicate, InstrKind, Instruction, IntArithFlags, IntPredicate,
-    InstrprofIntrinsic, LandingPadClause, MemOrdering, RmwOp, TailCallKind, VpIntrinsic,
+    ExactFlag, FastMathFlags, FloatPredicate, InstrKind, InstrprofIntrinsic, Instruction,
+    IntArithFlags, IntPredicate, LandingPadClause, MemOrdering, RmwOp, TailCallKind, VpIntrinsic,
 };
 /// Public API for `re-export`.
 pub use module::{DebugLocation, Module};
 /// Public API for `re-export`.
 pub use printer::Printer;
 /// Public API for `re-export`.
+pub use reduce::{ContainsPredicate, Predicate, Reducer};
+/// Public API for `re-export`.
 pub use types::{FloatKind, FunctionType, StructType, TypeData};
 /// Public API for `re-export`.
 pub use value::{Argument, ConstExprOp, ConstantData, GlobalVariable, Linkage};
-/// Public API for `re-export`.
-pub use reduce::{ContainsPredicate, Predicate, Reducer};

--- a/src/llvm-ir/src/reduce.rs
+++ b/src/llvm-ir/src/reduce.rs
@@ -22,7 +22,7 @@
 use crate::basic_block::BasicBlock;
 use crate::context::{BlockId, ConstId, InstrId, TypeId, ValueRef};
 use crate::function::Function;
-use crate::instruction::{Instruction, InstrKind};
+use crate::instruction::{InstrKind, Instruction};
 use crate::module::Module;
 use crate::printer::Printer;
 use crate::Context;
@@ -88,12 +88,7 @@ impl Reducer {
     /// still satisfies `pred`.
     ///
     /// Returns the reduced `(Context, Module)`.
-    pub fn reduce(
-        &self,
-        ctx: Context,
-        module: Module,
-        pred: &dyn Predicate,
-    ) -> (Context, Module) {
+    pub fn reduce(&self, ctx: Context, module: Module, pred: &dyn Predicate) -> (Context, Module) {
         // Verify that the predicate holds on the original input.
         if !pred.test(&ctx, &module) {
             // Predicate does not hold; return as-is.
@@ -141,11 +136,7 @@ impl Reducer {
 
 /// Try to remove each non-entry, non-main function.  A function is kept if
 /// removing it causes the predicate to return `false`.
-fn reduce_functions(
-    ctx: Context,
-    module: Module,
-    pred: &dyn Predicate,
-) -> (bool, Context, Module) {
+fn reduce_functions(ctx: Context, module: Module, pred: &dyn Predicate) -> (bool, Context, Module) {
     // Collect indices to try removing (in reverse so indices stay valid if we
     // rebuild from scratch each time).
     let n = module.functions.len();
@@ -185,7 +176,11 @@ fn reduce_functions(
 }
 
 /// Clone the module but skip function at index `skip_idx`.
-fn clone_module_without_function(ctx: &Context, module: &Module, skip_idx: usize) -> (Context, Module) {
+fn clone_module_without_function(
+    ctx: &Context,
+    module: &Module,
+    skip_idx: usize,
+) -> (Context, Module) {
     let new_ctx = ctx.clone();
     let mut new_module = module_header_clone(module);
 
@@ -207,11 +202,7 @@ fn clone_module_without_function(ctx: &Context, module: &Module, skip_idx: usize
 /// means replacing it with an unconditional branch to the entry block for any
 /// predecessor that referred to it, and removing all phi incoming edges that
 /// reference the block.  The block's body is simply dropped.
-fn reduce_blocks(
-    ctx: Context,
-    module: Module,
-    pred: &dyn Predicate,
-) -> (bool, Context, Module) {
+fn reduce_blocks(ctx: Context, module: Module, pred: &dyn Predicate) -> (bool, Context, Module) {
     let mut changed = false;
     let mut ctx = ctx;
     let mut module = module;
@@ -229,8 +220,7 @@ fn reduce_blocks(
         while bi > 1 {
             bi -= 1;
             // Try removing block bi from function fi.
-            let (trial_ctx, trial_module) =
-                clone_module_without_block(&ctx, &module, fi, bi);
+            let (trial_ctx, trial_module) = clone_module_without_block(&ctx, &module, fi, bi);
             if pred.test(&trial_ctx, &trial_module) {
                 ctx = trial_ctx;
                 module = trial_module;
@@ -285,7 +275,8 @@ fn clone_module_without_block(
         // Re-allocate instructions with adjusted block/value refs.
         // We need to remap InstrIds because some instructions in the removed
         // block will be gone.  Collect which InstrIds are kept.
-        let mut kept_instr_ids: std::collections::HashSet<InstrId> = std::collections::HashSet::new();
+        let mut kept_instr_ids: std::collections::HashSet<InstrId> =
+            std::collections::HashSet::new();
         for (bi, bb) in func.blocks.iter().enumerate() {
             if bi == skip_bid {
                 continue;
@@ -634,12 +625,7 @@ fn module_header_clone(module: &Module) -> Module {
 /// Clone the signature (name, type, args, linkage flags) of a function
 /// without blocks or instructions.
 fn function_signature_clone(func: &Function) -> Function {
-    let mut new_func = Function::new(
-        func.name.clone(),
-        func.ty,
-        func.args.clone(),
-        func.linkage,
-    );
+    let mut new_func = Function::new(func.name.clone(), func.ty, func.args.clone(), func.linkage);
     new_func.is_declaration = func.is_declaration;
     new_func
 }
@@ -671,7 +657,10 @@ fn remap_instr_kind(
         }
     };
     let remap_bid = |b: BlockId| -> BlockId {
-        bid_map.get(b.0 as usize).and_then(|opt| *opt).unwrap_or(fallback_bid)
+        bid_map
+            .get(b.0 as usize)
+            .and_then(|opt| *opt)
+            .unwrap_or(fallback_bid)
     };
 
     match kind {
@@ -701,7 +690,11 @@ fn remap_instr_kind(
             then_dest: remap_bid(*then_dest),
             else_dest: remap_bid(*else_dest),
         },
-        InstrKind::Switch { val, default, cases } => InstrKind::Switch {
+        InstrKind::Switch {
+            val,
+            default,
+            cases,
+        } => InstrKind::Switch {
             val: remap_vref(*val),
             default: remap_bid(*default),
             cases: cases
@@ -737,70 +730,211 @@ where
 {
     use InstrKind::*;
     match kind {
-        Add { flags, lhs, rhs } => Add { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        Sub { flags, lhs, rhs } => Sub { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        Mul { flags, lhs, rhs } => Mul { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        UDiv { exact, lhs, rhs } => UDiv { exact: *exact, lhs: f(*lhs), rhs: f(*rhs) },
-        SDiv { exact, lhs, rhs } => SDiv { exact: *exact, lhs: f(*lhs), rhs: f(*rhs) },
-        URem { lhs, rhs } => URem { lhs: f(*lhs), rhs: f(*rhs) },
-        SRem { lhs, rhs } => SRem { lhs: f(*lhs), rhs: f(*rhs) },
-        And { lhs, rhs } => And { lhs: f(*lhs), rhs: f(*rhs) },
-        Or { lhs, rhs } => Or { lhs: f(*lhs), rhs: f(*rhs) },
-        Xor { lhs, rhs } => Xor { lhs: f(*lhs), rhs: f(*rhs) },
-        Shl { flags, lhs, rhs } => Shl { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        LShr { exact, lhs, rhs } => LShr { exact: *exact, lhs: f(*lhs), rhs: f(*rhs) },
-        AShr { exact, lhs, rhs } => AShr { exact: *exact, lhs: f(*lhs), rhs: f(*rhs) },
-        FAdd { flags, lhs, rhs } => FAdd { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        FSub { flags, lhs, rhs } => FSub { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        FMul { flags, lhs, rhs } => FMul { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        FDiv { flags, lhs, rhs } => FDiv { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        FRem { flags, lhs, rhs } => FRem { flags: *flags, lhs: f(*lhs), rhs: f(*rhs) },
-        FNeg { flags, operand } => FNeg { flags: *flags, operand: f(*operand) },
-        ICmp { pred, lhs, rhs } => ICmp { pred: *pred, lhs: f(*lhs), rhs: f(*rhs) },
-        FCmp { flags, pred, lhs, rhs } => FCmp {
+        Add { flags, lhs, rhs } => Add {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        Sub { flags, lhs, rhs } => Sub {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        Mul { flags, lhs, rhs } => Mul {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        UDiv { exact, lhs, rhs } => UDiv {
+            exact: *exact,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        SDiv { exact, lhs, rhs } => SDiv {
+            exact: *exact,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        URem { lhs, rhs } => URem {
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        SRem { lhs, rhs } => SRem {
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        And { lhs, rhs } => And {
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        Or { lhs, rhs } => Or {
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        Xor { lhs, rhs } => Xor {
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        Shl { flags, lhs, rhs } => Shl {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        LShr { exact, lhs, rhs } => LShr {
+            exact: *exact,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        AShr { exact, lhs, rhs } => AShr {
+            exact: *exact,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FAdd { flags, lhs, rhs } => FAdd {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FSub { flags, lhs, rhs } => FSub {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FMul { flags, lhs, rhs } => FMul {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FDiv { flags, lhs, rhs } => FDiv {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FRem { flags, lhs, rhs } => FRem {
+            flags: *flags,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FNeg { flags, operand } => FNeg {
+            flags: *flags,
+            operand: f(*operand),
+        },
+        ICmp { pred, lhs, rhs } => ICmp {
+            pred: *pred,
+            lhs: f(*lhs),
+            rhs: f(*rhs),
+        },
+        FCmp {
+            flags,
+            pred,
+            lhs,
+            rhs,
+        } => FCmp {
             flags: *flags,
             pred: *pred,
             lhs: f(*lhs),
             rhs: f(*rhs),
         },
-        Alloca { alloc_ty, num_elements, align } => Alloca {
+        Alloca {
+            alloc_ty,
+            num_elements,
+            align,
+        } => Alloca {
             alloc_ty: *alloc_ty,
             num_elements: num_elements.map(|v| f(v)),
             align: *align,
         },
-        Load { ty, ptr, align, volatile } => Load {
+        Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => Load {
             ty: *ty,
             ptr: f(*ptr),
             align: *align,
             volatile: *volatile,
         },
-        Store { val, ptr, align, volatile } => Store {
+        Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => Store {
             val: f(*val),
             ptr: f(*ptr),
             align: *align,
             volatile: *volatile,
         },
-        GetElementPtr { inbounds, base_ty, ptr, indices } => GetElementPtr {
+        GetElementPtr {
+            inbounds,
+            base_ty,
+            ptr,
+            indices,
+        } => GetElementPtr {
             inbounds: *inbounds,
             base_ty: *base_ty,
             ptr: f(*ptr),
             indices: indices.iter().map(|&i| f(i)).collect(),
         },
-        Trunc { val, to } => Trunc { val: f(*val), to: *to },
-        ZExt { val, to } => ZExt { val: f(*val), to: *to },
-        SExt { val, to } => SExt { val: f(*val), to: *to },
-        FPTrunc { val, to } => FPTrunc { val: f(*val), to: *to },
-        FPExt { val, to } => FPExt { val: f(*val), to: *to },
-        FPToUI { val, to } => FPToUI { val: f(*val), to: *to },
-        FPToSI { val, to } => FPToSI { val: f(*val), to: *to },
-        UIToFP { val, to } => UIToFP { val: f(*val), to: *to },
-        SIToFP { val, to } => SIToFP { val: f(*val), to: *to },
-        PtrToInt { val, to } => PtrToInt { val: f(*val), to: *to },
-        IntToPtr { val, to } => IntToPtr { val: f(*val), to: *to },
-        BitCast { val, to } => BitCast { val: f(*val), to: *to },
-        AddrSpaceCast { val, to } => AddrSpaceCast { val: f(*val), to: *to },
+        Trunc { val, to } => Trunc {
+            val: f(*val),
+            to: *to,
+        },
+        ZExt { val, to } => ZExt {
+            val: f(*val),
+            to: *to,
+        },
+        SExt { val, to } => SExt {
+            val: f(*val),
+            to: *to,
+        },
+        FPTrunc { val, to } => FPTrunc {
+            val: f(*val),
+            to: *to,
+        },
+        FPExt { val, to } => FPExt {
+            val: f(*val),
+            to: *to,
+        },
+        FPToUI { val, to } => FPToUI {
+            val: f(*val),
+            to: *to,
+        },
+        FPToSI { val, to } => FPToSI {
+            val: f(*val),
+            to: *to,
+        },
+        UIToFP { val, to } => UIToFP {
+            val: f(*val),
+            to: *to,
+        },
+        SIToFP { val, to } => SIToFP {
+            val: f(*val),
+            to: *to,
+        },
+        PtrToInt { val, to } => PtrToInt {
+            val: f(*val),
+            to: *to,
+        },
+        IntToPtr { val, to } => IntToPtr {
+            val: f(*val),
+            to: *to,
+        },
+        BitCast { val, to } => BitCast {
+            val: f(*val),
+            to: *to,
+        },
+        AddrSpaceCast { val, to } => AddrSpaceCast {
+            val: f(*val),
+            to: *to,
+        },
         Freeze { val } => Freeze { val: f(*val) },
-        Select { cond, then_val, else_val } => Select {
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => Select {
             cond: f(*cond),
             then_val: f(*then_val),
             else_val: f(*else_val),
@@ -809,7 +943,11 @@ where
             aggregate: f(*aggregate),
             indices: indices.clone(),
         },
-        InsertValue { aggregate, val, indices } => InsertValue {
+        InsertValue {
+            aggregate,
+            val,
+            indices,
+        } => InsertValue {
             aggregate: f(*aggregate),
             val: f(*val),
             indices: indices.clone(),
@@ -828,13 +966,23 @@ where
             v2: f(*v2),
             mask: mask.clone(),
         },
-        Call { tail, callee_ty, callee, args } => Call {
+        Call {
+            tail,
+            callee_ty,
+            callee,
+            args,
+        } => Call {
             tail: *tail,
             callee_ty: *callee_ty,
             callee: f(*callee),
             args: args.iter().map(|&a| f(a)).collect(),
         },
-        LandingPad { result_ty, personality_fn, cleanup, clauses } => LandingPad {
+        LandingPad {
+            result_ty,
+            personality_fn,
+            cleanup,
+            clauses,
+        } => LandingPad {
             result_ty: *result_ty,
             personality_fn: personality_fn.map(|v| f(v)),
             cleanup: *cleanup,
@@ -842,23 +990,45 @@ where
                 .iter()
                 .map(|c| match c {
                     crate::instruction::LandingPadClause::Catch { ty, value } => {
-                        crate::instruction::LandingPadClause::Catch { ty: *ty, value: f(*value) }
+                        crate::instruction::LandingPadClause::Catch {
+                            ty: *ty,
+                            value: f(*value),
+                        }
                     }
                     crate::instruction::LandingPadClause::Filter { ty, value } => {
-                        crate::instruction::LandingPadClause::Filter { ty: *ty, value: f(*value) }
+                        crate::instruction::LandingPadClause::Filter {
+                            ty: *ty,
+                            value: f(*value),
+                        }
                     }
                 })
                 .collect(),
         },
-        InlineAsm { asm_string, constraints, side_effect, align_stack, args } => InlineAsm {
+        InlineAsm {
+            asm_string,
+            constraints,
+            side_effect,
+            align_stack,
+            args,
+        } => InlineAsm {
             asm_string: asm_string.clone(),
             constraints: constraints.clone(),
             side_effect: *side_effect,
             align_stack: *align_stack,
             args: args.iter().map(|&a| f(a)).collect(),
         },
-        Fence { ordering } => Fence { ordering: *ordering },
-        CmpXchg { ptr, cmp, new_val, success_ord, fail_ord, weak, volatile } => CmpXchg {
+        Fence { ordering } => Fence {
+            ordering: *ordering,
+        },
+        CmpXchg {
+            ptr,
+            cmp,
+            new_val,
+            success_ord,
+            fail_ord,
+            weak,
+            volatile,
+        } => CmpXchg {
             ptr: f(*ptr),
             cmp: f(*cmp),
             new_val: f(*new_val),
@@ -867,26 +1037,48 @@ where
             weak: *weak,
             volatile: *volatile,
         },
-        AtomicRmw { op, ptr, val, ordering, volatile } => AtomicRmw {
+        AtomicRmw {
+            op,
+            ptr,
+            val,
+            ordering,
+            volatile,
+        } => AtomicRmw {
             op: *op,
             ptr: f(*ptr),
             val: f(*val),
             ordering: *ordering,
             volatile: *volatile,
         },
-        Ret { val } => Ret { val: val.map(|v| f(v)) },
+        Ret { val } => Ret {
+            val: val.map(|v| f(v)),
+        },
         Br { dest } => Br { dest: *dest },
-        CondBr { cond, then_dest, else_dest } => CondBr {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => CondBr {
             cond: f(*cond),
             then_dest: *then_dest,
             else_dest: *else_dest,
         },
-        Switch { val, default, cases } => Switch {
+        Switch {
+            val,
+            default,
+            cases,
+        } => Switch {
             val: f(*val),
             default: *default,
             cases: cases.iter().map(|(v, b)| (f(*v), *b)).collect(),
         },
-        Invoke { callee_ty, callee, args, normal_dest, unwind_dest } => Invoke {
+        Invoke {
+            callee_ty,
+            callee,
+            args,
+            normal_dest,
+            unwind_dest,
+        } => Invoke {
             callee_ty: *callee_ty,
             callee: f(*callee),
             args: args.iter().map(|&a| f(a)).collect(),
@@ -907,16 +1099,26 @@ where
             parent: parent.map(|v| f(v)),
             args: args.iter().map(|&a| f(a)).collect(),
         },
-        CatchSwitch { parent, handlers, default } => CatchSwitch {
+        CatchSwitch {
+            parent,
+            handlers,
+            default,
+        } => CatchSwitch {
             parent: parent.map(|v| f(v)),
             handlers: handlers.clone(),
             default: *default,
         },
-        CatchRet { catch_pad, successor } => CatchRet {
+        CatchRet {
+            catch_pad,
+            successor,
+        } => CatchRet {
             catch_pad: f(*catch_pad),
             successor: *successor,
         },
-        CleanupRet { cleanup_pad, unwind_dest } => CleanupRet {
+        CleanupRet {
+            cleanup_pad,
+            unwind_dest,
+        } => CleanupRet {
             cleanup_pad: f(*cleanup_pad),
             unwind_dest: *unwind_dest,
         },
@@ -969,8 +1171,16 @@ mod tests {
         // Function foo
         let foo_ty = ctx.mk_fn_type(ctx.i32_ty, vec![ctx.i32_ty, ctx.i32_ty], false);
         let foo_args = vec![
-            Argument { name: "a".into(), ty: ctx.i32_ty, index: 0 },
-            Argument { name: "b".into(), ty: ctx.i32_ty, index: 1 },
+            Argument {
+                name: "a".into(),
+                ty: ctx.i32_ty,
+                index: 0,
+            },
+            Argument {
+                name: "b".into(),
+                ty: ctx.i32_ty,
+                index: 1,
+            },
         ];
         let mut foo = Function::new("foo", foo_ty, foo_args, Linkage::External);
         let a_ref = ValueRef::Argument(ArgId(0));
@@ -978,12 +1188,18 @@ mod tests {
         let add_id = foo.alloc_instr(Instruction::new(
             Some("r".into()),
             ctx.i32_ty,
-            InstrKind::Add { flags: IntArithFlags::default(), lhs: a_ref, rhs: b_ref },
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs: a_ref,
+                rhs: b_ref,
+            },
         ));
         let ret_id = foo.alloc_instr(Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Instruction(add_id)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Instruction(add_id)),
+            },
         ));
         let mut entry_foo = BasicBlock::new("entry");
         entry_foo.append_instr(add_id);
@@ -997,7 +1213,9 @@ mod tests {
         let bar_ret_id = bar.alloc_instr(Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Constant(c42)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Constant(c42)),
+            },
         ));
         let mut entry_bar = BasicBlock::new("entry");
         entry_bar.set_terminator(bar_ret_id);
@@ -1021,7 +1239,9 @@ mod tests {
 
         // Predicate: IR must contain "foo" (the first function).
         // The second function "bar" is not required.
-        let pred = ContainsPredicate { substring: "@foo".to_string() };
+        let pred = ContainsPredicate {
+            substring: "@foo".to_string(),
+        };
         let reducer = Reducer::new();
         let (_ctx2, module2) = reducer.reduce(ctx, module, &pred);
 
@@ -1049,13 +1269,21 @@ mod tests {
         //   }
         let mut ctx = Context::new();
         let fn_ty = ctx.mk_fn_type(ctx.i32_ty, vec![ctx.i32_ty], false);
-        let args = vec![Argument { name: "x".into(), ty: ctx.i32_ty, index: 0 }];
+        let args = vec![Argument {
+            name: "x".into(),
+            ty: ctx.i32_ty,
+            index: 0,
+        }];
         let mut func = Function::new("compute", fn_ty, args, Linkage::External);
         let x_ref = ValueRef::Argument(ArgId(0));
         let dead_id = func.alloc_instr(Instruction::new(
             Some("dead".into()),
             ctx.i32_ty,
-            InstrKind::Mul { flags: IntArithFlags::default(), lhs: x_ref, rhs: x_ref },
+            InstrKind::Mul {
+                flags: IntArithFlags::default(),
+                lhs: x_ref,
+                rhs: x_ref,
+            },
         ));
         let ret_id = func.alloc_instr(Instruction::new(
             None,
@@ -1071,13 +1299,18 @@ mod tests {
         module.add_function(func);
 
         // Predicate: IR must contain "ret".  The dead mul is not needed.
-        let pred = ContainsPredicate { substring: "ret".to_string() };
+        let pred = ContainsPredicate {
+            substring: "ret".to_string(),
+        };
         let reducer = Reducer::new();
         let (_ctx2, module2) = reducer.reduce(ctx, module, &pred);
 
         // The dead mul should have been removed.
         let f = &module2.functions[0];
-        let has_mul = f.instructions.iter().any(|i| matches!(i.kind, InstrKind::Mul { .. }));
+        let has_mul = f
+            .instructions
+            .iter()
+            .any(|i| matches!(i.kind, InstrKind::Mul { .. }));
         assert!(!has_mul, "expected dead mul to be removed");
     }
 
@@ -1111,7 +1344,9 @@ mod tests {
         let ret_id = func.alloc_instr(Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Constant(c0)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Constant(c0)),
+            },
         ));
         let mut entry = BasicBlock::new("entry");
         entry.append_instr(add_id);
@@ -1121,13 +1356,18 @@ mod tests {
         let mut module = Module::new("test");
         module.add_function(func);
 
-        let pred = ContainsPredicate { substring: "ret".to_string() };
+        let pred = ContainsPredicate {
+            substring: "ret".to_string(),
+        };
         let reducer = Reducer::new();
         let (_ctx2, module2) = reducer.reduce(ctx, module, &pred);
 
         // The add should have been removed (its result was never used).
         let f = &module2.functions[0];
-        let has_add = f.instructions.iter().any(|i| matches!(i.kind, InstrKind::Add { .. }));
+        let has_add = f
+            .instructions
+            .iter()
+            .any(|i| matches!(i.kind, InstrKind::Add { .. }));
         assert!(!has_add, "expected add instruction to be removed");
     }
 
@@ -1146,18 +1386,28 @@ mod tests {
         // and remove the add (since ret i32 0 still satisfies the predicate).
         let mut ctx = Context::new();
         let fn_ty = ctx.mk_fn_type(ctx.i32_ty, vec![ctx.i32_ty], false);
-        let args = vec![Argument { name: "x".into(), ty: ctx.i32_ty, index: 0 }];
+        let args = vec![Argument {
+            name: "x".into(),
+            ty: ctx.i32_ty,
+            index: 0,
+        }];
         let mut func = Function::new("foo", fn_ty, args, Linkage::External);
         let x_ref = ValueRef::Argument(ArgId(0));
         let add_id = func.alloc_instr(Instruction::new(
             Some("a".into()),
             ctx.i32_ty,
-            InstrKind::Add { flags: IntArithFlags::default(), lhs: x_ref, rhs: x_ref },
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs: x_ref,
+                rhs: x_ref,
+            },
         ));
         let ret_id = func.alloc_instr(Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Instruction(add_id)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Instruction(add_id)),
+            },
         ));
         let mut entry = BasicBlock::new("entry");
         entry.append_instr(add_id);
@@ -1167,13 +1417,18 @@ mod tests {
         let mut module = Module::new("test");
         module.add_function(func);
 
-        let pred = ContainsPredicate { substring: "ret".to_string() };
+        let pred = ContainsPredicate {
+            substring: "ret".to_string(),
+        };
         let reducer = Reducer::new();
         let (_ctx2, module2) = reducer.reduce(ctx, module, &pred);
 
         // The add should have been reduced away (replaced by constant zero).
         let f = &module2.functions[0];
-        let has_add = f.instructions.iter().any(|i| matches!(i.kind, InstrKind::Add { .. }));
+        let has_add = f
+            .instructions
+            .iter()
+            .any(|i| matches!(i.kind, InstrKind::Add { .. }));
         assert!(!has_add, "expected add to be replaced by constant");
     }
 
@@ -1186,7 +1441,9 @@ mod tests {
         let (ctx, module) = two_function_module();
 
         // Predicate: contains "foo".
-        let pred = ContainsPredicate { substring: "@foo".to_string() };
+        let pred = ContainsPredicate {
+            substring: "@foo".to_string(),
+        };
         let reducer = Reducer::new();
         let (ctx1, module1) = reducer.reduce(ctx, module, &pred);
 
@@ -1195,7 +1452,10 @@ mod tests {
         let (ctx2, module2) = reducer.reduce(ctx1, module1, &pred);
         let text2 = Printer::new(&ctx2).print_module(&module2);
 
-        assert_eq!(text1, text2, "second reduction pass changed the output (not at fixed point)");
+        assert_eq!(
+            text1, text2,
+            "second reduction pass changed the output (not at fixed point)"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1206,7 +1466,9 @@ mod tests {
     fn reduce_preserves_predicate() {
         let (ctx, module) = two_function_module();
 
-        let pred = ContainsPredicate { substring: "@foo".to_string() };
+        let pred = ContainsPredicate {
+            substring: "@foo".to_string(),
+        };
         let reducer = Reducer::new();
         let (ctx2, module2) = reducer.reduce(ctx, module, &pred);
 
@@ -1227,8 +1489,16 @@ mod tests {
         let mut ctx = Context::new();
         let fn_ty = ctx.mk_fn_type(ctx.i32_ty, vec![ctx.i32_ty, ctx.i32_ty], false);
         let args = vec![
-            Argument { name: "a".into(), ty: ctx.i32_ty, index: 0 },
-            Argument { name: "b".into(), ty: ctx.i32_ty, index: 1 },
+            Argument {
+                name: "a".into(),
+                ty: ctx.i32_ty,
+                index: 0,
+            },
+            Argument {
+                name: "b".into(),
+                ty: ctx.i32_ty,
+                index: 1,
+            },
         ];
         let mut func = Function::new("add", fn_ty, args, Linkage::External);
         let a_ref = ValueRef::Argument(ArgId(0));
@@ -1236,12 +1506,18 @@ mod tests {
         let add_id = func.alloc_instr(Instruction::new(
             Some("r".into()),
             ctx.i32_ty,
-            InstrKind::Add { flags: IntArithFlags::default(), lhs: a_ref, rhs: b_ref },
+            InstrKind::Add {
+                flags: IntArithFlags::default(),
+                lhs: a_ref,
+                rhs: b_ref,
+            },
         ));
         let ret_id = func.alloc_instr(Instruction::new(
             None,
             ctx.void_ty,
-            InstrKind::Ret { val: Some(ValueRef::Instruction(add_id)) },
+            InstrKind::Ret {
+                val: Some(ValueRef::Instruction(add_id)),
+            },
         ));
         let mut entry = BasicBlock::new("entry");
         entry.append_instr(add_id);
@@ -1251,13 +1527,17 @@ mod tests {
         let mut module = Module::new("test");
         module.add_function(func);
 
-        let pred = ContainsPredicate { substring: "add".to_string() };
+        let pred = ContainsPredicate {
+            substring: "add".to_string(),
+        };
         assert!(
             pred.test(&ctx, &module),
             "ContainsPredicate should return true when module has an add instruction"
         );
 
-        let pred_false = ContainsPredicate { substring: "nonexistent_xyz".to_string() };
+        let pred_false = ContainsPredicate {
+            substring: "nonexistent_xyz".to_string(),
+        };
         assert!(
             !pred_false.test(&ctx, &module),
             "ContainsPredicate should return false for absent substring"

--- a/src/llvm-ir/src/types.rs
+++ b/src/llvm-ir/src/types.rs
@@ -15,10 +15,7 @@ pub enum TypeData {
     /// `Pointer` variant.
     Pointer,
     /// `Array` variant.
-    Array {
-        element: TypeId,
-        len: u64,
-    },
+    Array { element: TypeId, len: u64 },
     /// `Vector` variant.
     Vector {
         element: TypeId,

--- a/src/llvm-ir/src/value.rs
+++ b/src/llvm-ir/src/value.rs
@@ -178,7 +178,6 @@ impl Linkage {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/llvm-jit/src/lib.rs
+++ b/src/llvm-jit/src/lib.rs
@@ -12,8 +12,10 @@
 use llvm_codegen::{
     emit_object,
     isel::IselBackend,
-    regalloc::{allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
-               RegAllocStrategy},
+    regalloc::{
+        allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
+        RegAllocStrategy,
+    },
     ObjectFormat,
 };
 use llvm_ir::{Context, Module};
@@ -133,7 +135,13 @@ impl ExecPage {
     /// Switch the page to `PROT_READ | PROT_EXEC` (removes write permission).
     fn make_exec(&self) -> Result<(), JitError> {
         // SAFETY: self.base and self.size describe the exact mapping we created.
-        let rc = unsafe { libc::mprotect(self.base as *mut libc::c_void, self.size, libc::PROT_READ | libc::PROT_EXEC) };
+        let rc = unsafe {
+            libc::mprotect(
+                self.base as *mut libc::c_void,
+                self.size,
+                libc::PROT_READ | libc::PROT_EXEC,
+            )
+        };
         if rc != 0 {
             Err(JitError::AllocationFailed)
         } else {
@@ -244,9 +252,20 @@ impl ExecutionEngine for SimpleJit {
             let mut mf = backend.lower_function(ctx, module, func);
 
             let intervals = compute_live_intervals(&mf);
-            let mut result =
-                allocate_registers(&intervals, &mf.allocatable_pregs, &mf.allocatable_fp_pregs, RegAllocStrategy::LinearScan);
-            insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+            let mut result = allocate_registers(
+                &intervals,
+                &mf.allocatable_pregs,
+                &mf.allocatable_fp_pregs,
+                RegAllocStrategy::LinearScan,
+            );
+            insert_spill_reloads(
+                &mut mf,
+                &mut result,
+                MOV_LOAD_MR,
+                MOV_STORE_RM,
+                MOV_LOAD_MR,
+                MOV_STORE_RM,
+            );
             apply_allocation(&mut mf, &result);
 
             let mut emitter = X86Emitter::new(fmt);
@@ -313,7 +332,8 @@ mod tests {
     fn jit_from_src(src: &str) -> SimpleJit {
         let (mut ctx, mut module) = parse(src).expect("parse failed");
         let mut jit = SimpleJit::new();
-        jit.add_module(&mut ctx, &mut module).expect("add_module failed");
+        jit.add_module(&mut ctx, &mut module)
+            .expect("add_module failed");
         jit
     }
 
@@ -329,7 +349,8 @@ entry:
 "#;
         let (mut ctx, mut module) = parse(src).expect("parse failed");
         let mut jit = SimpleJit::new();
-        jit.add_module(&mut ctx, &mut module).expect("add_module failed");
+        jit.add_module(&mut ctx, &mut module)
+            .expect("add_module failed");
         // At least one symbol must have been registered.
         assert!(jit.get_function_ptr("answer").is_some());
     }
@@ -457,7 +478,8 @@ declare i32 @printf(i8*, ...)
 "#;
         let (mut ctx, mut module) = parse(src).expect("parse failed");
         let mut jit = SimpleJit::new();
-        jit.add_module(&mut ctx, &mut module).expect("add_module should succeed");
+        jit.add_module(&mut ctx, &mut module)
+            .expect("add_module should succeed");
         assert!(jit.get_function_ptr("printf").is_none());
     }
 }

--- a/src/llvm-jit/tests/atomic_threads.rs
+++ b/src/llvm-jit/tests/atomic_threads.rs
@@ -61,7 +61,11 @@ entry:
         // SAFETY: ptr points to JIT-compiled x86-64 `void @increment(ptr %ctr)`.
         let f: fn(*mut i32) = unsafe { std::mem::transmute(ptr) };
         f(ctr_ptr);
-        assert_eq!(counter.load(Ordering::SeqCst), 1, "single call should increment by 1");
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "single call should increment by 1"
+        );
         for _ in 0..999 {
             f(ctr_ptr);
         }

--- a/src/llvm-rustc-backend/src/aggregate.rs
+++ b/src/llvm-rustc-backend/src/aggregate.rs
@@ -240,8 +240,14 @@ mod tests {
         let val2 = ValueRef::Constant(ctx.const_int(i64_ty, 2));
 
         let operands = vec![
-            AggOperand { val: val1, ty: i32_ty },
-            AggOperand { val: val2, ty: i64_ty },
+            AggOperand {
+                val: val1,
+                ty: i32_ty,
+            },
+            AggOperand {
+                val: val2,
+                ty: i64_ty,
+            },
         ];
 
         let result = lower_aggregate(
@@ -338,13 +344,19 @@ mod tests {
         let enum_ty = ctx.mk_struct_anon(vec![i8_ty, i32_ty], false);
 
         let data_val = ValueRef::Constant(ctx.const_int(i32_ty, 42));
-        let operands = vec![AggOperand { val: data_val, ty: i32_ty }];
+        let operands = vec![AggOperand {
+            val: data_val,
+            ty: i32_ty,
+        }];
 
         lower_aggregate(
             &mut ctx,
             &mut func,
             entry_bid,
-            &AggKind::Enum { variant_idx: 1, discriminant: 1 },
+            &AggKind::Enum {
+                variant_idx: 1,
+                discriminant: 1,
+            },
             &operands,
             enum_ty,
         );
@@ -355,8 +367,12 @@ mod tests {
         assert_eq!(count_instrs(&func, is_store), 2);
 
         // The first store must store an i8 constant with value 1.
-        let stores: Vec<&InstrKind> =
-            func.instructions.iter().map(|i| &i.kind).filter(|k| is_store(k)).collect();
+        let stores: Vec<&InstrKind> = func
+            .instructions
+            .iter()
+            .map(|i| &i.kind)
+            .filter(|k| is_store(k))
+            .collect();
         if let InstrKind::Store { val, .. } = stores[0] {
             if let ValueRef::Constant(cid) = val {
                 let cd = ctx.get_const(*cid);
@@ -384,23 +400,37 @@ mod tests {
         let enum_ty = ctx.mk_struct_anon(vec![i8_ty, i32_ty], false);
 
         let payload = ValueRef::Constant(ctx.const_int(i32_ty, 99));
-        let operands = vec![AggOperand { val: payload, ty: i32_ty }];
+        let operands = vec![AggOperand {
+            val: payload,
+            ty: i32_ty,
+        }];
 
         lower_aggregate(
             &mut ctx,
             &mut func,
             entry_bid,
-            &AggKind::Enum { variant_idx: 0, discriminant: 0 },
+            &AggKind::Enum {
+                variant_idx: 0,
+                discriminant: 0,
+            },
             &operands,
             enum_ty,
         );
 
         // Two stores: discriminant + payload
-        assert_eq!(count_instrs(&func, is_store), 2, "disc store + payload store");
+        assert_eq!(
+            count_instrs(&func, is_store),
+            2,
+            "disc store + payload store"
+        );
 
         // The GEP for the payload field must use field index 1.
-        let geps: Vec<&InstrKind> =
-            func.instructions.iter().map(|i| &i.kind).filter(|k| is_gep(k)).collect();
+        let geps: Vec<&InstrKind> = func
+            .instructions
+            .iter()
+            .map(|i| &i.kind)
+            .filter(|k| is_gep(k))
+            .collect();
         assert_eq!(geps.len(), 2, "disc GEP + payload GEP");
 
         if let InstrKind::GetElementPtr { indices, .. } = geps[1] {
@@ -464,6 +494,10 @@ mod tests {
         // Only the alloca; no GEPs or stores for a zero-field struct.
         assert_eq!(count_instrs(&func, is_alloca), 1, "alloca for unit struct");
         assert_eq!(count_instrs(&func, is_gep), 0, "no GEPs for unit struct");
-        assert_eq!(count_instrs(&func, is_store), 0, "no stores for unit struct");
+        assert_eq!(
+            count_instrs(&func, is_store),
+            0,
+            "no stores for unit struct"
+        );
     }
 }

--- a/src/llvm-rustc-backend/src/codegen_backend.rs
+++ b/src/llvm-rustc-backend/src/codegen_backend.rs
@@ -53,8 +53,7 @@ mod real_backend {
     /// mutex holds the lazily-initialised backend, which is selected based on
     /// the target triple provided to `init`.
     pub struct LlvmInRustBackend {
-        pub(crate) target_machine:
-            Arc<Mutex<Option<Box<dyn IselBackend + Send>>>>,
+        pub(crate) target_machine: Arc<Mutex<Option<Box<dyn IselBackend + Send>>>>,
     }
 
     impl LlvmInRustBackend {

--- a/src/llvm-rustc-backend/src/driver.rs
+++ b/src/llvm-rustc-backend/src/driver.rs
@@ -22,10 +22,10 @@
 
 use llvm_codegen::{emit_object, IselBackend, ObjectFile, ObjectFormat, Reloc, Section, Symbol};
 use llvm_ir::{Context, Module};
-use llvm_transforms::{build_pipeline, OptLevel};
-use llvm_target_x86::{TargetFeatures, X86Backend, X86Emitter};
-use llvm_target_arm::lower::{AArch64Backend, AArch64Features};
 use llvm_target_arm::encode::AArch64Emitter;
+use llvm_target_arm::lower::{AArch64Backend, AArch64Features};
+use llvm_target_x86::{TargetFeatures, X86Backend, X86Emitter};
+use llvm_transforms::{build_pipeline, OptLevel};
 
 /// Target architecture for code generation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -93,7 +93,11 @@ pub fn codegen_module(
     pm.run_until_fixed_point(ctx, module, 8);
 
     let fmt = opts.object_format();
-    let text_name = if fmt == ObjectFormat::MachO { "__text" } else { ".text" };
+    let text_name = if fmt == ObjectFormat::MachO {
+        "__text"
+    } else {
+        ".text"
+    };
 
     // 2 + 3. Lower each function and merge.
     let mut merged_text: Vec<u8> = Vec::new();
@@ -129,7 +133,11 @@ pub fn codegen_module(
         let text_off = merged_text.len();
         let sym_base = merged_symbols.len();
 
-        if let Some(sec) = obj.sections.iter().find(|s| s.name == ".text" || s.name == "__text") {
+        if let Some(sec) = obj
+            .sections
+            .iter()
+            .find(|s| s.name == ".text" || s.name == "__text")
+        {
             for mut r in sec.relocs.iter().cloned() {
                 r.symbol += sym_base;
                 r.offset += text_off as u64;

--- a/src/llvm-rustc-backend/src/drop_glue.rs
+++ b/src/llvm-rustc-backend/src/drop_glue.rs
@@ -24,11 +24,11 @@
 //! For types with `NeedsDrop = false` (integers, floats, raw pointers, etc.)
 //! no glue is emitted at all.
 
-use llvm_ir::{
-    BasicBlock, BlockId, Builder, Context, FunctionId, GlobalId, InstrKind, Instruction,
-    Module, TailCallKind, TypeId, ValueRef,
-};
 use llvm_ir::value::Linkage;
+use llvm_ir::{
+    BasicBlock, BlockId, Builder, Context, FunctionId, GlobalId, InstrKind, Instruction, Module,
+    TailCallKind, TypeId, ValueRef,
+};
 
 // ---------------------------------------------------------------------------
 // DropInfo
@@ -119,8 +119,8 @@ pub fn emit_drop_glue(
 
     // 1. Call the custom Drop::drop impl, if present.
     if info.has_custom_drop {
-        let custom_fid = custom_drop_fn
-            .expect("has_custom_drop is true but no custom_drop_fn was provided");
+        let custom_fid =
+            custom_drop_fn.expect("has_custom_drop is true but no custom_drop_fn was provided");
         let fn_ty = builder.ctx.mk_fn_type(void_ty, vec![ptr_ty], false);
         // Functions are referenced via ValueRef::Global(GlobalId(fn_id.0)).
         let callee = ValueRef::Global(GlobalId(custom_fid.0));
@@ -132,12 +132,7 @@ pub fn emit_drop_glue(
         // GEP: ptr to field at index `field_idx` within the struct.
         let zero = builder.const_i32(0);
         let idx = builder.const_i32(field_idx as i32);
-        let field_ptr = builder.build_gep_inbounds(
-            "field_ptr",
-            self_ty,
-            self_arg,
-            vec![zero, idx],
-        );
+        let field_ptr = builder.build_gep_inbounds("field_ptr", self_ty, self_arg, vec![zero, idx]);
 
         let fn_ty = builder.ctx.mk_fn_type(void_ty, vec![ptr_ty], false);
         let callee = ValueRef::Global(GlobalId(glue_fid.0));
@@ -205,11 +200,7 @@ pub fn emit_cleanup_block(
     func.block_mut(cleanup_bid).append_instr(call_id);
 
     // Terminator: unconditional branch to next_block.
-    let br_instr = Instruction::new(
-        None,
-        void_ty,
-        InstrKind::Br { dest: next_block },
-    );
+    let br_instr = Instruction::new(None, void_ty, InstrKind::Br { dest: next_block });
     let br_id = func.alloc_instr(br_instr);
     func.block_mut(cleanup_bid).set_terminator(br_id);
 
@@ -223,8 +214,8 @@ pub fn emit_cleanup_block(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Context, Module};
     use llvm_ir::value::Linkage;
+    use llvm_ir::{Context, Module};
 
     // ------------------------------------------------------------------
     // Helpers
@@ -283,14 +274,7 @@ mod tests {
         let mut module = Module::new("test");
         let self_ty = ctx.i32_ty; // placeholder — doesn't matter for trivial type
 
-        let result = emit_drop_glue(
-            &mut ctx,
-            &mut module,
-            &trivial_info(),
-            self_ty,
-            None,
-            &[],
-        );
+        let result = emit_drop_glue(&mut ctx, &mut module, &trivial_info(), self_ty, None, &[]);
 
         assert!(result.is_none(), "trivial type must not emit drop glue");
     }
@@ -307,7 +291,11 @@ mod tests {
         let custom_fn = llvm_ir::Function::new(
             "_ZN6MyType4dropE",
             fn_ty,
-            vec![llvm_ir::value::Argument { name: "self".to_string(), ty: ptr_ty, index: 0 }],
+            vec![llvm_ir::value::Argument {
+                name: "self".to_string(),
+                ty: ptr_ty,
+                index: 0,
+            }],
             Linkage::External,
         );
         let custom_fid = module.add_function(custom_fn);
@@ -321,16 +309,12 @@ mod tests {
             droppable_fields: vec![],
         };
 
-        let result = emit_drop_glue(
-            &mut ctx,
-            &mut module,
-            &info,
-            self_ty,
-            Some(custom_fid),
-            &[],
-        );
+        let result = emit_drop_glue(&mut ctx, &mut module, &info, self_ty, Some(custom_fid), &[]);
 
-        assert!(result.is_some(), "must emit a function for a type with custom Drop");
+        assert!(
+            result.is_some(),
+            "must emit a function for a type with custom Drop"
+        );
         let glue_fid = result.unwrap();
 
         // Check the name.
@@ -353,7 +337,11 @@ mod tests {
         let custom_fn = llvm_ir::Function::new(
             "_ZN6MyType4dropE",
             fn_ty,
-            vec![llvm_ir::value::Argument { name: "self".to_string(), ty: ptr_ty, index: 0 }],
+            vec![llvm_ir::value::Argument {
+                name: "self".to_string(),
+                ty: ptr_ty,
+                index: 0,
+            }],
             Linkage::External,
         );
         let custom_fid = module.add_function(custom_fn);
@@ -365,25 +353,22 @@ mod tests {
             droppable_fields: vec![],
         };
 
-        let glue_fid = emit_drop_glue(
-            &mut ctx,
-            &mut module,
-            &info,
-            self_ty,
-            Some(custom_fid),
-            &[],
-        )
-        .expect("must emit glue");
+        let glue_fid = emit_drop_glue(&mut ctx, &mut module, &info, self_ty, Some(custom_fid), &[])
+            .expect("must emit glue");
 
         // Inspect instructions: entry block must contain a Call.
         let func = module.function(glue_fid);
         let entry_bid = llvm_ir::context::BlockId(0);
         let entry_bb = func.block(entry_bid);
 
-        let has_call = entry_bb.body.iter().any(|&iid| {
-            matches!(func.instr(iid).kind, InstrKind::Call { .. })
-        });
-        assert!(has_call, "glue function entry block must contain a call instruction");
+        let has_call = entry_bb
+            .body
+            .iter()
+            .any(|&iid| matches!(func.instr(iid).kind, InstrKind::Call { .. }));
+        assert!(
+            has_call,
+            "glue function entry block must contain a call instruction"
+        );
     }
 
     #[test]
@@ -398,7 +383,11 @@ mod tests {
         let field_fn = llvm_ir::Function::new(
             "__drop_glue_FieldType",
             fn_ty,
-            vec![llvm_ir::value::Argument { name: "self".to_string(), ty: ptr_ty, index: 0 }],
+            vec![llvm_ir::value::Argument {
+                name: "self".to_string(),
+                ty: ptr_ty,
+                index: 0,
+            }],
             Linkage::External,
         );
         let field_fid = module.add_function(field_fn);
@@ -427,10 +416,14 @@ mod tests {
         let entry_bid = llvm_ir::context::BlockId(0);
         let entry_bb = func.block(entry_bid);
 
-        let has_gep = entry_bb.body.iter().any(|&iid| {
-            matches!(func.instr(iid).kind, InstrKind::GetElementPtr { .. })
-        });
-        assert!(has_gep, "glue for droppable fields must emit a GEP instruction");
+        let has_gep = entry_bb
+            .body
+            .iter()
+            .any(|&iid| matches!(func.instr(iid).kind, InstrKind::GetElementPtr { .. }));
+        assert!(
+            has_gep,
+            "glue for droppable fields must emit a GEP instruction"
+        );
     }
 
     #[test]
@@ -467,7 +460,11 @@ mod tests {
         let drop_fn = llvm_ir::Function::new(
             "__drop_glue_SomeType",
             drop_fn_ty,
-            vec![llvm_ir::value::Argument { name: "self".to_string(), ty: ptr_ty, index: 0 }],
+            vec![llvm_ir::value::Argument {
+                name: "self".to_string(),
+                ty: ptr_ty,
+                index: 0,
+            }],
             Linkage::External,
         );
         let drop_fid = module.add_function(drop_fn);
@@ -479,7 +476,9 @@ mod tests {
         // Verify the cleanup block ends with a Br to `next`.
         let func = module.function(fid);
         let cleanup_bb = func.block(cleanup_bid);
-        let term_id = cleanup_bb.terminator.expect("cleanup block must have a terminator");
+        let term_id = cleanup_bb
+            .terminator
+            .expect("cleanup block must have a terminator");
         let term = func.instr(term_id);
 
         assert!(

--- a/src/llvm-rustc-backend/src/place.rs
+++ b/src/llvm-rustc-backend/src/place.rs
@@ -63,7 +63,7 @@ pub use llvm_ir::context::ValueRef;
 
 // ── Core lowering function ────────────────────────────────────────────────────
 
-use llvm_ir::{Builder, context::TypeId, types::TypeData};
+use llvm_ir::{context::TypeId, types::TypeData, Builder};
 
 /// Lower a chain of MIR place projections into llvm-ir GEP / load instructions.
 ///
@@ -100,11 +100,7 @@ pub fn lower_projection(
             // obtain the inner pointer, then continue with the pointee type.
             PlaceElem::Deref => {
                 let ptr_ty = builder.ctx.ptr_ty;
-                let loaded = builder.build_load(
-                    format!("deref_{proj_idx}"),
-                    ptr_ty,
-                    ptr,
-                );
+                let loaded = builder.build_load(format!("deref_{proj_idx}"), ptr_ty, ptr);
                 // After a deref the element type is the inner pointee.
                 // We represent all pointers as opaque `ptr` in this IR, so
                 // we keep `ty` unchanged (the caller already knows the
@@ -142,12 +138,8 @@ pub fn lower_projection(
                     .expect("Index projection requires a corresponding index_operand entry");
                 index_slot += 1;
 
-                let gep = builder.build_gep_inbounds(
-                    format!("index_{proj_idx}"),
-                    ty,
-                    ptr,
-                    vec![idx_val],
-                );
+                let gep =
+                    builder.build_gep_inbounds(format!("index_{proj_idx}"), ty, ptr, vec![idx_val]);
                 // Advance ty to the array element type.
                 ty = array_element_type(builder, ty);
                 ptr = gep;
@@ -228,9 +220,7 @@ pub fn lower_projection(
 /// conservative fallback for opaque / non-struct types.
 fn field_type(builder: &Builder<'_>, struct_ty: TypeId, idx: usize) -> TypeId {
     match builder.ctx.get_type(struct_ty) {
-        TypeData::Struct(st) => {
-            st.fields.get(idx).copied().unwrap_or(builder.ctx.ptr_ty)
-        }
+        TypeData::Struct(st) => st.fields.get(idx).copied().unwrap_or(builder.ctx.ptr_ty),
         _ => builder.ctx.ptr_ty,
     }
 }
@@ -286,10 +276,7 @@ pub mod rustc_adapter {
 mod tests {
     use super::*;
     use llvm_ir::{
-        Builder, Context, Module,
-        context::ValueRef,
-        instruction::InstrKind,
-        value::Linkage,
+        context::ValueRef, instruction::InstrKind, value::Linkage, Builder, Context, Module,
     };
 
     // ── Test 1: Deref ─────────────────────────────────────────────────────────
@@ -305,7 +292,14 @@ mod tests {
         let void_ty = ctx.void_ty;
 
         let mut b = Builder::new(&mut ctx, &mut module);
-        let fid = b.add_function("test_deref", void_ty, vec![ptr_ty], vec!["p".into()], false, Linkage::Internal);
+        let fid = b.add_function(
+            "test_deref",
+            void_ty,
+            vec![ptr_ty],
+            vec!["p".into()],
+            false,
+            Linkage::Internal,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
 
@@ -313,7 +307,8 @@ mod tests {
         let base_ptr = b.get_arg(0);
 
         let projections = vec![PlaceElem::Deref];
-        let (result_ptr, _result_ty) = lower_projection(&mut b, base_ptr, i32_ty, &projections, &[None]);
+        let (result_ptr, _result_ty) =
+            lower_projection(&mut b, base_ptr, i32_ty, &projections, &[None]);
 
         // The result must be a new instruction (load).
         assert!(
@@ -323,8 +318,15 @@ mod tests {
 
         // Inspect the emitted instruction.
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
-        assert!(!instrs.is_empty(), "at least one instruction must be emitted");
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
+        assert!(
+            !instrs.is_empty(),
+            "at least one instruction must be emitted"
+        );
         let last_instr = func.instr(*instrs.last().unwrap());
         assert!(
             matches!(last_instr.kind, InstrKind::Load { .. }),
@@ -349,14 +351,22 @@ mod tests {
         let struct_ty = ctx.mk_struct_anon(vec![i32_ty, i64_ty], false);
 
         let mut b = Builder::new(&mut ctx, &mut module);
-        let fid = b.add_function("test_field", void_ty, vec![ptr_ty], vec!["p".into()], false, Linkage::Internal);
+        let fid = b.add_function(
+            "test_field",
+            void_ty,
+            vec![ptr_ty],
+            vec!["p".into()],
+            false,
+            Linkage::Internal,
+        );
         let entry = b.add_block("entry");
         b.position_at_end(entry);
 
         let base_ptr = b.get_arg(0);
 
         let projections = vec![PlaceElem::Field(1)];
-        let (result_ptr, result_ty) = lower_projection(&mut b, base_ptr, struct_ty, &projections, &[]);
+        let (result_ptr, result_ty) =
+            lower_projection(&mut b, base_ptr, struct_ty, &projections, &[]);
 
         assert!(
             matches!(result_ptr, ValueRef::Instruction(_)),
@@ -367,10 +377,16 @@ mod tests {
         assert_eq!(result_ty, i64_ty, "Field(1) result type must be i64");
 
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
         let last_instr = func.instr(*instrs.last().unwrap());
         match &last_instr.kind {
-            InstrKind::GetElementPtr { inbounds, indices, .. } => {
+            InstrKind::GetElementPtr {
+                inbounds, indices, ..
+            } => {
                 assert!(inbounds, "GEP must be inbounds");
                 assert_eq!(indices.len(), 2, "Field GEP must have 2 indices");
             }
@@ -421,10 +437,16 @@ mod tests {
         assert_eq!(result_ty, i32_ty, "Index result type must be i32");
 
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
         let last_instr = func.instr(*instrs.last().unwrap());
         match &last_instr.kind {
-            InstrKind::GetElementPtr { inbounds, indices, .. } => {
+            InstrKind::GetElementPtr {
+                inbounds, indices, ..
+            } => {
                 assert!(inbounds, "GEP must be inbounds");
                 assert_eq!(indices.len(), 1, "Index GEP must have 1 index");
                 // The one index must be the dynamic argument.
@@ -463,8 +485,7 @@ mod tests {
         let base_ptr = b.get_arg(0);
 
         let projections = vec![PlaceElem::ConstantIndex(2)];
-        let (result_ptr, result_ty) =
-            lower_projection(&mut b, base_ptr, arr_ty, &projections, &[]);
+        let (result_ptr, result_ty) = lower_projection(&mut b, base_ptr, arr_ty, &projections, &[]);
 
         assert!(
             matches!(result_ptr, ValueRef::Instruction(_)),
@@ -473,10 +494,16 @@ mod tests {
         assert_eq!(result_ty, i32_ty, "ConstantIndex result type must be i32");
 
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
         let last_instr = func.instr(*instrs.last().unwrap());
         match &last_instr.kind {
-            InstrKind::GetElementPtr { inbounds, indices, .. } => {
+            InstrKind::GetElementPtr {
+                inbounds, indices, ..
+            } => {
                 assert!(inbounds, "GEP must be inbounds");
                 assert_eq!(indices.len(), 1, "ConstantIndex GEP must have 1 index");
             }
@@ -526,8 +553,16 @@ mod tests {
 
         // Expect exactly 2 instructions: load then GEP.
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
-        assert_eq!(instrs.len(), 2, "must emit exactly 2 instructions (load + gep)");
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
+        assert_eq!(
+            instrs.len(),
+            2,
+            "must emit exactly 2 instructions (load + gep)"
+        );
         assert!(
             matches!(func.instr(instrs[0]).kind, InstrKind::Load { .. }),
             "first instruction must be Load"
@@ -588,11 +623,22 @@ mod tests {
 
         // Two GEP instructions must have been emitted.
         let func = b.module.function(fid);
-        let instrs: Vec<_> = func.blocks.iter().flat_map(|bb| bb.body.iter().copied()).collect();
-        assert_eq!(instrs.len(), 2, "Downcast must emit exactly 2 GEP instructions");
+        let instrs: Vec<_> = func
+            .blocks
+            .iter()
+            .flat_map(|bb| bb.body.iter().copied())
+            .collect();
+        assert_eq!(
+            instrs.len(),
+            2,
+            "Downcast must emit exactly 2 GEP instructions"
+        );
         for &id in &instrs {
             assert!(
-                matches!(func.instr(id).kind, InstrKind::GetElementPtr { inbounds: true, .. }),
+                matches!(
+                    func.instr(id).kind,
+                    InstrKind::GetElementPtr { inbounds: true, .. }
+                ),
                 "both instructions must be inbounds GEPs"
             );
         }

--- a/src/llvm-rustc-backend/src/shim.rs
+++ b/src/llvm-rustc-backend/src/shim.rs
@@ -6,7 +6,7 @@
 //! shims pass, the backend pipeline is correct enough to wire up to rustc once
 //! the nightly interface is available.
 
-use llvm_codegen::{emit_object, IselBackend, ObjectFormat, ObjectFile, Reloc, Section, Symbol};
+use llvm_codegen::{emit_object, IselBackend, ObjectFile, ObjectFormat, Reloc, Section, Symbol};
 use llvm_ir::{Context, Module};
 use llvm_ir_parser::parser::parse;
 use llvm_target_x86::{TargetFeatures, X86Backend, X86Emitter};
@@ -40,7 +40,11 @@ pub fn emit_module_to_bytes(
     module: &Module,
     fmt: ObjectFormat,
 ) -> Result<Vec<u8>, String> {
-    let text_name = if fmt == ObjectFormat::MachO { "__text" } else { ".text" };
+    let text_name = if fmt == ObjectFormat::MachO {
+        "__text"
+    } else {
+        ".text"
+    };
 
     let mut merged_text: Vec<u8> = Vec::new();
     let mut merged_symbols: Vec<Symbol> = Vec::new();
@@ -61,7 +65,11 @@ pub fn emit_module_to_bytes(
         let sym_base = merged_symbols.len();
 
         // Find the text section and accumulate.
-        if let Some(sec) = obj.sections.iter().find(|s| s.name == ".text" || s.name == "__text") {
+        if let Some(sec) = obj
+            .sections
+            .iter()
+            .find(|s| s.name == ".text" || s.name == "__text")
+        {
             for mut r in sec.relocs.iter().cloned() {
                 r.symbol += sym_base;
                 r.offset += text_off as u64;
@@ -169,14 +177,13 @@ mod tests {
 
     #[test]
     fn shim_multi_func_cgu_emits_both_symbols() {
-        let bytes =
-            compile_to_elf(MULTI_FUNC, OptLevel::O0).expect("multi-func must compile");
+        let bytes = compile_to_elf(MULTI_FUNC, OptLevel::O0).expect("multi-func must compile");
         // ELF strtab stores null-terminated symbol names; match the null bytes on
         // both sides to avoid false positives from section headers or other data.
         let has = |name: &[u8]| {
-            bytes.windows(name.len() + 2).any(|w| {
-                w[0] == 0 && &w[1..name.len() + 1] == name && w[name.len() + 1] == 0
-            })
+            bytes
+                .windows(name.len() + 2)
+                .any(|w| w[0] == 0 && &w[1..name.len() + 1] == name && w[name.len() + 1] == 0)
         };
         assert!(has(b"square"), "symbol 'square' must appear in strtab");
         assert!(has(b"main"), "symbol 'main' must appear in strtab");
@@ -207,7 +214,10 @@ mod tests {
     fn shim_declarations_only_returns_error() {
         let ir = "declare i32 @printf(i8*, ...)";
         let result = compile_to_elf(ir, OptLevel::O0);
-        assert!(result.is_err(), "declarations-only module must return an error");
+        assert!(
+            result.is_err(),
+            "declarations-only module must return an error"
+        );
     }
 
     // CGU idempotency: running the pipeline twice must not change function count.
@@ -236,7 +246,11 @@ mod tests {
         let bytes = emit_module_to_bytes(&ctx, &module, ObjectFormat::MachO)
             .expect("Mach-O emit must succeed");
         // Mach-O magic: 0xCFFAEDFE (little-endian 64-bit)
-        assert_eq!(&bytes[..4], b"\xcf\xfa\xed\xfe", "Mach-O magic must be present");
+        assert_eq!(
+            &bytes[..4],
+            b"\xcf\xfa\xed\xfe",
+            "Mach-O magic must be present"
+        );
     }
 
     #[test]
@@ -247,7 +261,11 @@ mod tests {
         let bytes = emit_module_to_bytes(&ctx, &module, ObjectFormat::Coff)
             .expect("COFF emit must succeed");
         // COFF x86-64 machine type: 0x8664 (little-endian)
-        assert_eq!(&bytes[..2], b"\x64\x86", "COFF x86-64 magic must be present");
+        assert_eq!(
+            &bytes[..2],
+            b"\x64\x86",
+            "COFF x86-64 magic must be present"
+        );
     }
 
     #[test]

--- a/src/llvm-rustc-backend/src/unwind.rs
+++ b/src/llvm-rustc-backend/src/unwind.rs
@@ -68,10 +68,26 @@ pub fn declare_personality_fn(ctx: &mut Context, module: &mut Module) -> Functio
     let fn_ty = ctx.mk_fn_type(i32_ty, vec![i32_ty, i64_ty, ptr_ty, ptr_ty], false);
 
     let args = vec![
-        Argument { name: String::new(), ty: i32_ty, index: 0 },
-        Argument { name: String::new(), ty: i64_ty, index: 1 },
-        Argument { name: String::new(), ty: ptr_ty, index: 2 },
-        Argument { name: String::new(), ty: ptr_ty, index: 3 },
+        Argument {
+            name: String::new(),
+            ty: i32_ty,
+            index: 0,
+        },
+        Argument {
+            name: String::new(),
+            ty: i64_ty,
+            index: 1,
+        },
+        Argument {
+            name: String::new(),
+            ty: ptr_ty,
+            index: 2,
+        },
+        Argument {
+            name: String::new(),
+            ty: ptr_ty,
+            index: 3,
+        },
     ];
     let decl = llvm_ir::function::Function::new_declaration(NAME, fn_ty, args, Linkage::External);
     module.add_function(decl)
@@ -121,11 +137,7 @@ pub fn emit_landingpad_block(
     );
 
     // Branch to cleanup_dest
-    let br_instr = Instruction::new(
-        None,
-        ctx.void_ty,
-        InstrKind::Br { dest: cleanup_dest },
-    );
+    let br_instr = Instruction::new(None, ctx.void_ty, InstrKind::Br { dest: cleanup_dest });
 
     let mut bb = BasicBlock::new("landingpad");
     let lp_id = func.alloc_instr(lp_instr);
@@ -182,7 +194,9 @@ pub struct LsdaBuilder {
 impl LsdaBuilder {
     /// Create an empty builder.
     pub fn new() -> Self {
-        LsdaBuilder { call_sites: Vec::new() }
+        LsdaBuilder {
+            call_sites: Vec::new(),
+        }
     }
 
     /// Append one call-site record.
@@ -296,8 +310,15 @@ mod tests {
         let (mut ctx, mut module) = mk_ctx_module();
         let id1 = declare_personality_fn(&mut ctx, &mut module);
         let id2 = declare_personality_fn(&mut ctx, &mut module);
-        assert_eq!(id1, id2, "double declaration must return the same FunctionId");
-        assert_eq!(module.num_functions(), 1, "only one function must be in the module");
+        assert_eq!(
+            id1, id2,
+            "double declaration must return the same FunctionId"
+        );
+        assert_eq!(
+            module.num_functions(),
+            1,
+            "only one function must be in the module"
+        );
     }
 
     // ── 3. landingpad_block_exists ────────────────────────────────────────────
@@ -341,7 +362,10 @@ mod tests {
         let first_iid = bb.body[0];
         let first_instr = func.instr(first_iid);
         assert!(
-            matches!(first_instr.kind, InstrKind::LandingPad { cleanup: true, .. }),
+            matches!(
+                first_instr.kind,
+                InstrKind::LandingPad { cleanup: true, .. }
+            ),
             "first instruction in landing-pad block must be LandingPad{{cleanup:true}}, got {:?}",
             first_instr.kind,
         );
@@ -363,7 +387,10 @@ mod tests {
         // Header: lpstart=0xff, ttype=0xff, cs_encoding=0x01
         assert_eq!(bytes[0], 0xff, "lpstart_encoding must be DW_EH_PE_omit");
         assert_eq!(bytes[1], 0xff, "ttype_encoding must be DW_EH_PE_omit");
-        assert_eq!(bytes[2], 0x01, "call_site_encoding must be DW_EH_PE_uleb128");
+        assert_eq!(
+            bytes[2], 0x01,
+            "call_site_encoding must be DW_EH_PE_uleb128"
+        );
 
         // After the header and the table-length uleb128, the record should
         // encode cs_start=10, cs_len=5, lp_offset=20, action=0.

--- a/src/llvm-rustc-backend/tests/driver.rs
+++ b/src/llvm-rustc-backend/tests/driver.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the standalone codegen driver.
 
 use llvm_ir::{Builder, Context, Linkage, Module};
-use llvm_rustc_backend::driver::{CodegenOptions, TargetArch, codegen_module};
+use llvm_rustc_backend::driver::{codegen_module, CodegenOptions, TargetArch};
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -59,7 +59,10 @@ fn make_decl_only() -> (Context, Module) {
 #[test]
 fn driver_emits_nonzero_bytes_for_trivial_function() {
     let (mut ctx, mut module) = make_ret42();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 0,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts)
         .expect("codegen must succeed for trivial function");
     assert!(!bytes.is_empty(), "output must be non-empty");
@@ -68,7 +71,10 @@ fn driver_emits_nonzero_bytes_for_trivial_function() {
 #[test]
 fn driver_x86_elf_magic() {
     let (mut ctx, mut module) = make_ret42();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 0,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("must compile");
     assert_eq!(&bytes[..4], b"\x7fELF", "x86-64 output must be an ELF file");
 }
@@ -76,7 +82,10 @@ fn driver_x86_elf_magic() {
 #[test]
 fn driver_x86_add_o0_compiles() {
     let (mut ctx, mut module) = make_add_fn();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 0,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("add O0 must compile");
     assert!(!bytes.is_empty());
 }
@@ -84,7 +93,10 @@ fn driver_x86_add_o0_compiles() {
 #[test]
 fn driver_x86_add_o2_compiles() {
     let (mut ctx, mut module) = make_add_fn();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 2 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 2,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("add O2 must compile");
     assert!(!bytes.is_empty());
 }
@@ -92,7 +104,10 @@ fn driver_x86_add_o2_compiles() {
 #[test]
 fn driver_x86_o3_pipeline_runs() {
     let (mut ctx, mut module) = make_add_fn();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 3 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 3,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("O3 must compile");
     assert!(!bytes.is_empty());
 }
@@ -100,9 +115,15 @@ fn driver_x86_o3_pipeline_runs() {
 #[test]
 fn driver_declarations_only_returns_error() {
     let (mut ctx, mut module) = make_decl_only();
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 0,
+    };
     let result = codegen_module(&mut ctx, &mut module, &opts);
-    assert!(result.is_err(), "declarations-only module must return an error");
+    assert!(
+        result.is_err(),
+        "declarations-only module must return an error"
+    );
 }
 
 // ── AArch64 tests ─────────────────────────────────────────────────────────────
@@ -110,7 +131,10 @@ fn driver_declarations_only_returns_error() {
 #[test]
 fn driver_aarch64_emits_nonzero_bytes() {
     let (mut ctx, mut module) = make_ret42();
-    let opts = CodegenOptions { target: TargetArch::AArch64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::AArch64,
+        opt_level: 0,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("AArch64 codegen must succeed");
     assert!(!bytes.is_empty(), "AArch64 output must be non-empty");
 }
@@ -118,15 +142,25 @@ fn driver_aarch64_emits_nonzero_bytes() {
 #[test]
 fn driver_aarch64_elf_magic() {
     let (mut ctx, mut module) = make_ret42();
-    let opts = CodegenOptions { target: TargetArch::AArch64, opt_level: 0 };
+    let opts = CodegenOptions {
+        target: TargetArch::AArch64,
+        opt_level: 0,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("must compile");
-    assert_eq!(&bytes[..4], b"\x7fELF", "AArch64 ELF output must have ELF magic");
+    assert_eq!(
+        &bytes[..4],
+        b"\x7fELF",
+        "AArch64 ELF output must have ELF magic"
+    );
 }
 
 #[test]
 fn driver_aarch64_add_compiles() {
     let (mut ctx, mut module) = make_add_fn();
-    let opts = CodegenOptions { target: TargetArch::AArch64, opt_level: 1 };
+    let opts = CodegenOptions {
+        target: TargetArch::AArch64,
+        opt_level: 1,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("AArch64 add must compile");
     assert!(!bytes.is_empty());
 }
@@ -140,7 +174,14 @@ fn backend_pipeline_smoke_via_driver() {
     let mut module = Module::new("smoke");
     let mut b = Builder::new(&mut ctx, &mut module);
     let i32_ty = b.ctx.i32_ty;
-    b.add_function("square", i32_ty, vec![i32_ty], vec!["x".into()], false, Linkage::External);
+    b.add_function(
+        "square",
+        i32_ty,
+        vec![i32_ty],
+        vec!["x".into()],
+        false,
+        Linkage::External,
+    );
     let entry = b.add_block("entry");
     b.position_at_end(entry);
     let x = b.get_arg(0);
@@ -148,10 +189,15 @@ fn backend_pipeline_smoke_via_driver() {
     b.build_ret(r);
     drop(b);
 
-    let opts = CodegenOptions { target: TargetArch::X86_64, opt_level: 2 };
+    let opts = CodegenOptions {
+        target: TargetArch::X86_64,
+        opt_level: 2,
+    };
     let bytes = codegen_module(&mut ctx, &mut module, &opts).expect("smoke codegen must succeed");
     assert!(!bytes.is_empty(), "smoke test must emit non-empty object");
     // Symbol name must appear in the ELF string table.
-    let has_sym = bytes.windows(b"\x00square\x00".len()).any(|w| w == b"\x00square\x00");
+    let has_sym = bytes
+        .windows(b"\x00square\x00".len())
+        .any(|w| w == b"\x00square\x00");
     assert!(has_sym, "symbol 'square' must appear in ELF strtab");
 }

--- a/src/llvm-target-arm/src/abi.rs
+++ b/src/llvm-target-arm/src/abi.rs
@@ -151,8 +151,8 @@ fn field_hfa_kind(ctx: &Context, ty: TypeId) -> Option<(FloatKind, usize)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::regs::{X0, X1, X2, X3, X4, X5, X6, X7};
     use crate::regs::{D0, D1, D2, D7};
+    use crate::regs::{X0, X1, X2, X3, X4, X5, X6, X7};
     use llvm_ir::{Context, FloatKind};
 
     #[test]
@@ -255,10 +255,7 @@ mod tests {
     fn hfa_double_x5_not_hfa() {
         let mut ctx = Context::new();
         let f64_ty = ctx.f64_ty;
-        let ty = ctx.mk_struct_anon(
-            vec![f64_ty, f64_ty, f64_ty, f64_ty, f64_ty],
-            false,
-        );
+        let ty = ctx.mk_struct_anon(vec![f64_ty, f64_ty, f64_ty, f64_ty, f64_ty], false);
         assert_eq!(detect_hfa(&ctx, ty), None);
     }
 

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -7,7 +7,10 @@
 //! Each AArch64 instruction is exactly 4 bytes.  Branches are patched in a
 //! second pass once all block offsets are known.
 
-use crate::{instructions::*, regs::{fp_enc, is_fp_reg, reg_enc}};
+use crate::{
+    instructions::*,
+    regs::{fp_enc, is_fp_reg, reg_enc},
+};
 use llvm_codegen::{
     emit::{DebugLineRow, Emitter, ObjectFormat, Reloc, Section},
     isel::{MInstr, MOperand, MachineFunction, PReg},
@@ -34,7 +37,10 @@ pub struct AArch64Emitter {
 impl AArch64Emitter {
     /// Public API for `new`.
     pub fn new(format: ObjectFormat) -> Self {
-        Self { format, lsda_section: None }
+        Self {
+            format,
+            lsda_section: None,
+        }
     }
 
     /// Return and clear the LSDA bytes produced during the last
@@ -666,7 +672,8 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         // Encoding (ADD immediate, 64-bit): 0x91000000 | (imm12<<10) | (Rn<<5) | Rd
         // Rn = 29 (FP), imm12 = (2 + cs_save_count + slot_idx) * 8.
         SUB_FP_IMM => {
-            if let (Some(dst), Some(MOperand::Imm(slot_idx))) = (instr.dst, instr.operands.first()) {
+            if let (Some(dst), Some(MOperand::Imm(slot_idx))) = (instr.dst, instr.operands.first())
+            {
                 let rd = reg_enc(PReg(dst.0 as u8)) as u32;
                 let byte_off = ((2 + ctx.cs_save_count + *slot_idx as u32) * 8) & 0xFFF;
                 ctx.emit4(0x91000000 | (byte_off << 10) | (29 << 5) | rd);
@@ -678,12 +685,13 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         // LDR_REG: ldr xd, [xn]  — 64-bit load via pointer register, no offset.
         // Encoding (unsigned offset = 0): 0xF9400000 | (0 << 10) | (Rn << 5) | Rd
         LDR_REG => {
-            if let (Some(dst), Some(ptr)) =
-                (instr.dst, instr.operands.first().and_then(|op| match op {
+            if let (Some(dst), Some(ptr)) = (
+                instr.dst,
+                instr.operands.first().and_then(|op| match op {
                     MOperand::PReg(r) => Some(*r),
                     _ => None,
-                }))
-            {
+                }),
+            ) {
                 let rd = reg_enc(PReg(dst.0 as u8)) as u32;
                 let rn = reg_enc(ptr) as u32;
                 ctx.emit4(0xF9400000 | (rn << 5) | rd);
@@ -943,13 +951,25 @@ fn encode_fp_rrr3(ctx: &mut EncodeCtx, instr: &MInstr, base: u32) {
     let rn = instr
         .operands
         .first()
-        .and_then(|op| if let MOperand::PReg(r) = op { Some(*r) } else { None })
+        .and_then(|op| {
+            if let MOperand::PReg(r) = op {
+                Some(*r)
+            } else {
+                None
+            }
+        })
         .map(|r| fp_enc(r) as u32)
         .unwrap_or(0);
     let rm = instr
         .operands
         .get(1)
-        .and_then(|op| if let MOperand::PReg(r) = op { Some(*r) } else { None })
+        .and_then(|op| {
+            if let MOperand::PReg(r) = op {
+                Some(*r)
+            } else {
+                None
+            }
+        })
         .map(|r| fp_enc(r) as u32)
         .unwrap_or(0);
     ctx.emit4(base | (rm << 16) | (rn << 5) | rd);
@@ -965,7 +985,13 @@ fn fp_dst_src(instr: &MInstr) -> (u32, u32) {
     let rn = instr
         .operands
         .iter()
-        .find_map(|op| if let MOperand::PReg(r) = op { Some(fp_enc(*r) as u32) } else { None })
+        .find_map(|op| {
+            if let MOperand::PReg(r) = op {
+                Some(fp_enc(*r) as u32)
+            } else {
+                None
+            }
+        })
         .unwrap_or(0);
     (rd, rn)
 }
@@ -974,7 +1000,11 @@ fn fp_dst_src(instr: &MInstr) -> (u32, u32) {
 /// (e.g. `FCMPE Dn, Dm`).
 fn fp_two_src_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
     let mut it = instr.operands.iter().filter_map(|op| {
-        if let MOperand::PReg(r) = op { Some(*r) } else { None }
+        if let MOperand::PReg(r) = op {
+            Some(*r)
+        } else {
+            None
+        }
     });
     (it.next(), it.next())
 }
@@ -983,7 +1013,11 @@ fn fp_two_src_pregs(instr: &MInstr) -> (Option<PReg>, Option<PReg>) {
 fn fp_first_src_preg(instr: &MInstr) -> Option<PReg> {
     instr.operands.iter().find_map(|op| {
         if let MOperand::PReg(r) = op {
-            if is_fp_reg(*r) { Some(*r) } else { None }
+            if is_fp_reg(*r) {
+                Some(*r)
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -997,7 +1031,9 @@ fn fp_second_src_preg(instr: &MInstr) -> Option<PReg> {
         if let MOperand::PReg(r) = op {
             if is_fp_reg(*r) {
                 count += 1;
-                if count == 2 { return Some(*r); }
+                if count == 2 {
+                    return Some(*r);
+                }
             }
         }
         None
@@ -1008,7 +1044,11 @@ fn fp_second_src_preg(instr: &MInstr) -> Option<PReg> {
 fn int_first_src_preg(instr: &MInstr) -> Option<PReg> {
     instr.operands.iter().find_map(|op| {
         if let MOperand::PReg(r) = op {
-            if !is_fp_reg(*r) { Some(*r) } else { None }
+            if !is_fp_reg(*r) {
+                Some(*r)
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -1805,7 +1845,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E602800u32 | (2 << 16) | (1 << 5) | 0;
-        assert_eq!(word, expected, "FADD D0, D1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FADD D0, D1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1818,7 +1861,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E603800u32 | (2 << 16) | (1 << 5) | 0;
-        assert_eq!(word, expected, "FSUB D0, D1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FSUB D0, D1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1831,7 +1877,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E600800u32 | (2 << 16) | (1 << 5) | 0;
-        assert_eq!(word, expected, "FMUL D0, D1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FMUL D0, D1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1844,7 +1893,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E601800u32 | (2 << 16) | (1 << 5) | 0;
-        assert_eq!(word, expected, "FDIV D0, D1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FDIV D0, D1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1857,7 +1909,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E614000u32 | (1 << 5) | 0;
-        assert_eq!(word, expected, "FNEG D0, D1 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FNEG D0, D1 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1870,7 +1925,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E61C000u32 | (1 << 5) | 0;
-        assert_eq!(word, expected, "FSQRT D0, D1 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FSQRT D0, D1 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1890,7 +1948,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E602010u32 | (2 << 16) | (1 << 5);
-        assert_eq!(word, expected, "FCMPE D1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FCMPE D1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1903,7 +1964,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E604000u32 | (1 << 5) | 0;
-        assert_eq!(word, expected, "FMOV D0, D1 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FMOV D0, D1 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1913,7 +1977,7 @@ mod tests {
         use crate::regs::{D0, X0};
         let mi = MInstr {
             opcode: FCVTZS_RR,
-            dst: Some(VReg(X0.0 as u32)), // integer destination
+            dst: Some(VReg(X0.0 as u32)),       // integer destination
             operands: vec![MOperand::PReg(D0)], // FP source
             phys_uses: vec![],
             clobbers: vec![],
@@ -1925,7 +1989,10 @@ mod tests {
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // Rd = X0 = reg 0 (low 5 bits of X0.0 = 0); Rn = fp_enc(D0) = 0
         let expected = 0x9E780000u32 | (0 << 5) | 0;
-        assert_eq!(word, expected, "FCVTZS X0, D0 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FCVTZS X0, D0 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1946,7 +2013,10 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x9E780000u32 | (2 << 5) | 1;
-        assert_eq!(word, expected, "FCVTZS X1, D2 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FCVTZS X1, D2 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1956,7 +2026,7 @@ mod tests {
         use crate::regs::{D0, X1};
         let mi = MInstr {
             opcode: SCVTF_RR,
-            dst: Some(VReg(D0.0 as u32)), // FP destination
+            dst: Some(VReg(D0.0 as u32)),       // FP destination
             operands: vec![MOperand::PReg(X1)], // integer source
             phys_uses: vec![],
             clobbers: vec![],
@@ -1968,7 +2038,10 @@ mod tests {
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // rd = dst.0 & 0x1F = 32 & 0x1F = 0; rn = reg_enc(X1) = 1
         let expected = 0x9E620000u32 | (1 << 5) | 0;
-        assert_eq!(word, expected, "SCVTF D0, X1 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "SCVTF D0, X1 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -1978,7 +2051,7 @@ mod tests {
         use crate::regs::D0;
         let mi = MInstr {
             opcode: MOVSD_LOAD_MR,
-            dst: Some(VReg(D0.0 as u32)), // D0 = PReg(32) → hw reg 0
+            dst: Some(VReg(D0.0 as u32)),     // D0 = PReg(32) → hw reg 0
             operands: vec![MOperand::Imm(0)], // slot 0
             phys_uses: vec![],
             clobbers: vec![],
@@ -1990,7 +2063,10 @@ mod tests {
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // rt = D0.0 & 0x1F = 32 & 0x1F = 0; imm12 = 2 + 0 + 0 = 2
         let expected = 0xFD400000u32 | (2 << 10) | (29 << 5) | 0;
-        assert_eq!(word, expected, "MOVSD_LOAD_MR D0, [x29, #16] should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "MOVSD_LOAD_MR D0, [x29, #16] should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -2000,7 +2076,7 @@ mod tests {
         use crate::regs::D1;
         let mi = MInstr {
             opcode: MOVSD_STORE_RM,
-            dst: None, // no destination
+            dst: None,                                            // no destination
             operands: vec![MOperand::Imm(0), MOperand::PReg(D1)], // slot 0, src
             phys_uses: vec![],
             clobbers: vec![],
@@ -2012,7 +2088,10 @@ mod tests {
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // rt = fp_enc(D1) = 1; imm12 = 2 + 0 + 0 = 2
         let expected = 0xFD000000u32 | (2 << 10) | (29 << 5) | 1;
-        assert_eq!(word, expected, "MOVSD_STORE_RM [x29, #16], D1 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "MOVSD_STORE_RM [x29, #16], D1 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
@@ -2028,15 +2107,18 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         let expected = 0x1E602800u32 | (18 << 16) | (17 << 5) | 16;
-        assert_eq!(word, expected, "FADD D16, D17, D18 should encode as 0x{expected:08X}");
+        assert_eq!(
+            word, expected,
+            "FADD D16, D17, D18 should encode as 0x{expected:08X}"
+        );
     }
 
     #[test]
     fn fp_lower_fadd_produces_fadd_rr_opcode() {
         // End-to-end lowering test: an FAdd IR instruction must produce FADD_RR opcode.
         use crate::lower::AArch64Backend;
-        use llvm_ir::{Builder, Context, FloatKind, Linkage, Module};
         use llvm_codegen::isel::IselBackend;
+        use llvm_ir::{Builder, Context, FloatKind, Linkage, Module};
 
         let mut ctx = Context::new();
         let f64_ty = ctx.mk_float(FloatKind::Double);
@@ -2060,7 +2142,10 @@ mod tests {
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
-        let has_fadd = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FADD_RR));
+        let has_fadd = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FADD_RR));
         assert!(has_fadd, "FAdd IR must lower to FADD_RR opcode");
     }
 }

--- a/src/llvm-target-arm/src/lower.rs
+++ b/src/llvm-target-arm/src/lower.rs
@@ -633,7 +633,9 @@ fn lower_instr(
         }
 
         // ── calls ──────────────────────────────────────────────────────────
-        Call { callee, args, tail, .. } => {
+        Call {
+            callee, args, tail, ..
+        } => {
             if let Some(ip) = instrprof_from_callee(ctx, *callee) {
                 eprintln!(
                     "warning: PGO intrinsic {} elided — counter emission not implemented",
@@ -698,7 +700,9 @@ fn lower_instr(
             // DMB ISH — data memory barrier, inner-shareable domain.
             mf.push(mblock, MInstr::new(DMB_ISH));
         }
-        CmpXchg { ptr, cmp, new_val, .. } => {
+        CmpXchg {
+            ptr, cmp, new_val, ..
+        } => {
             let ptr_vr = res!(*ptr);
             let cmp_vr = res!(*cmp);
             let new_vr = res!(*new_val);
@@ -717,10 +721,7 @@ fn lower_instr(
             } else {
                 // LL/SC pair (non-LSE path).
                 // Full retry loop is a follow-up; emit the basic pair here.
-                mf.push(
-                    mblock,
-                    MInstr::new(LDXR).with_dst(dst).with_vreg(ptr_vr),
-                );
+                mf.push(mblock, MInstr::new(LDXR).with_dst(dst).with_vreg(ptr_vr));
                 // STXR: status dst (not exposed as an SSA result), val, ptr.
                 let status = mf.fresh_vreg();
                 mf.push(
@@ -755,10 +756,7 @@ fn lower_instr(
                 );
             } else {
                 // LL/SC pair (non-LSE path).
-                mf.push(
-                    mblock,
-                    MInstr::new(LDXR).with_dst(dst).with_vreg(ptr_vr),
-                );
+                mf.push(mblock, MInstr::new(LDXR).with_dst(dst).with_vreg(ptr_vr));
                 let status = mf.fresh_vreg();
                 mf.push(
                     mblock,
@@ -778,7 +776,9 @@ fn lower_instr(
         // ── memory: non-promotable alloca/load/store (FP-relative frame slots) ──
         // mem2reg eliminates promotable alloca/load/store; what remains here is
         // non-promotable (address escapes or non-constant GEP index).
-        Alloca { alloc_ty, align, .. } => {
+        Alloca {
+            alloc_ty, align, ..
+        } => {
             let dst = new_dst!();
             let size_bytes = sizeof_ty(ctx, *alloc_ty) as u32;
             let align_bytes = align.unwrap_or(8);
@@ -801,10 +801,7 @@ fn lower_instr(
             let dst = new_dst!();
             // LDR_REG: ldr xd, [xn]
             let ptr_vr = res!(*ptr);
-            mf.push(
-                mblock,
-                MInstr::new(LDR_REG).with_dst(dst).with_vreg(ptr_vr),
-            );
+            mf.push(mblock, MInstr::new(LDR_REG).with_dst(dst).with_vreg(ptr_vr));
         }
         Store { val, ptr, .. } => {
             // STR_REG: str xs, [xn]
@@ -856,10 +853,20 @@ fn lower_instr(
         }
 
         // Terminators handled in lower_terminator.
-        Ret { .. } | Br { .. } | CondBr { .. } | Invoke { .. } | Switch { .. } | Unreachable | Resume { .. } => {}
+        Ret { .. }
+        | Br { .. }
+        | CondBr { .. }
+        | Invoke { .. }
+        | Switch { .. }
+        | Unreachable
+        | Resume { .. } => {}
 
         // Funclet pads — not yet fully supported; emit a NOP stub.
-        CatchPad { .. } | CleanupPad { .. } | CatchSwitch { .. } | CatchRet { .. } | CleanupRet { .. } => {}
+        CatchPad { .. }
+        | CleanupPad { .. }
+        | CatchSwitch { .. }
+        | CatchRet { .. }
+        | CleanupRet { .. } => {}
     }
 }
 
@@ -971,12 +978,8 @@ fn lower_terminator(
                 action: 0,
             });
             // Track: (machine_block, call_instr_in_block, lsda_record_idx, unwind_dest_mblock)
-            mf.invoke_tracking.push((
-                mblock,
-                call_instr_idx,
-                lsda_rec_idx,
-                unwind_dest.0 as usize,
-            ));
+            mf.invoke_tracking
+                .push((mblock, call_instr_idx, lsda_rec_idx, unwind_dest.0 as usize));
             if term.ty != ctx.void_ty {
                 let dst = mf.fresh_vreg();
                 vmap.insert(ValueRef::Instruction(tid), dst);
@@ -1018,7 +1021,9 @@ fn lower_terminator(
         }
 
         // CatchSwitch — lower first handler as unconditional branch (stub).
-        CatchSwitch { handlers, default, .. } => {
+        CatchSwitch {
+            handlers, default, ..
+        } => {
             if let Some(&h) = handlers.first() {
                 mf.push(mblock, MInstr::new(B).with_block(h.0 as usize));
             } else if let Some(d) = default {
@@ -1520,10 +1525,7 @@ mod tests {
         let mut emitter = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = emitter.emit_function(&mf);
         // DMB ISH = 0xD5033BBF in LE: [BF, 3B, 03, D5]
-        let found_dmb = sec
-            .data
-            .windows(4)
-            .any(|w| w == [0xBF, 0x3B, 0x03, 0xD5]);
+        let found_dmb = sec.data.windows(4).any(|w| w == [0xBF, 0x3B, 0x03, 0xD5]);
         assert!(found_dmb, "DMB ISH bytes [BF 3B 03 D5] must appear in code");
     }
 
@@ -1633,10 +1635,7 @@ mod tests {
             .blocks
             .iter()
             .any(|bl| bl.instrs.iter().any(|i| i.opcode == CASAL));
-        assert!(
-            !has_casal,
-            "CmpXchg with LSE=false must NOT emit CASAL"
-        );
+        assert!(!has_casal, "CmpXchg with LSE=false must NOT emit CASAL");
     }
 
     #[test]
@@ -1676,7 +1675,10 @@ mod tests {
             .blocks
             .iter()
             .any(|bl| bl.instrs.iter().any(|i| i.opcode == LDADDAL));
-        assert!(has_ldaddal, "AtomicRmw(Add) with LSE=true must emit LDADDAL");
+        assert!(
+            has_ldaddal,
+            "AtomicRmw(Add) with LSE=true must emit LDADDAL"
+        );
     }
 
     #[test]
@@ -1797,7 +1799,10 @@ mod tests {
         let (ctx, module) = make_fp_binop_fn("fadd_fn", |b, a, bv| b.build_fadd("r", a, bv));
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fadd = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FADD_RR));
+        let has_fadd = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FADD_RR));
         assert!(has_fadd, "FAdd must lower to FADD_RR");
     }
 
@@ -1806,7 +1811,10 @@ mod tests {
         let (ctx, module) = make_fp_binop_fn("fsub_fn", |b, a, bv| b.build_fsub("r", a, bv));
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fsub = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FSUB_RR));
+        let has_fsub = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FSUB_RR));
         assert!(has_fsub, "FSub must lower to FSUB_RR");
     }
 
@@ -1815,7 +1823,10 @@ mod tests {
         let (ctx, module) = make_fp_binop_fn("fmul_fn", |b, a, bv| b.build_fmul("r", a, bv));
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fmul = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FMUL_RR));
+        let has_fmul = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FMUL_RR));
         assert!(has_fmul, "FMul must lower to FMUL_RR");
     }
 
@@ -1824,7 +1835,10 @@ mod tests {
         let (ctx, module) = make_fp_binop_fn("fdiv_fn", |b, a, bv| b.build_fdiv("r", a, bv));
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fdiv = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FDIV_RR));
+        let has_fdiv = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FDIV_RR));
         assert!(has_fdiv, "FDiv must lower to FDIV_RR");
     }
 
@@ -1851,7 +1865,10 @@ mod tests {
 
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fneg = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FNEG_R));
+        let has_fneg = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FNEG_R));
         assert!(has_fneg, "FNeg must lower to FNEG_R");
     }
 
@@ -1882,7 +1899,10 @@ mod tests {
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
 
         // Must emit FMOV_RR to copy from D0 argument register.
-        let has_fmov = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FMOV_RR));
+        let has_fmov = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FMOV_RR));
         assert!(
             has_fmov,
             "Float function argument must be copied using FMOV_RR (not MOV_RR)"
@@ -1913,7 +1933,10 @@ mod tests {
 
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_scvtf = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == SCVTF_RR));
+        let has_scvtf = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == SCVTF_RR));
         assert!(has_scvtf, "SIToFP must lower to SCVTF_RR");
     }
 
@@ -1941,7 +1964,10 @@ mod tests {
 
         let mut be = AArch64Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let has_fcvtzs = mf.blocks.iter().any(|bl| bl.instrs.iter().any(|i| i.opcode == FCVTZS_RR));
+        let has_fcvtzs = mf
+            .blocks
+            .iter()
+            .any(|bl| bl.instrs.iter().any(|i| i.opcode == FCVTZS_RR));
         assert!(has_fcvtzs, "FPToSI must lower to FCVTZS_RR");
     }
 }

--- a/src/llvm-target-arm/src/regs.rs
+++ b/src/llvm-target-arm/src/regs.rs
@@ -178,8 +178,7 @@ pub const D31: PReg = PReg(63);
 /// AAPCS64: D8–D15 are callee-saved; D24–D31 are callee-saved.
 /// D0–D7 and D16–D23 are caller-saved (allocate freely).
 pub const FP_ALLOCATABLE: &[PReg] = &[
-    D0, D1, D2, D3, D4, D5, D6, D7,
-    D16, D17, D18, D19, D20, D21, D22, D23,
+    D0, D1, D2, D3, D4, D5, D6, D7, D16, D17, D18, D19, D20, D21, D22, D23,
 ];
 
 /// FP/SIMD callee-saved registers (D8–D15, AAPCS64).

--- a/src/llvm-target-arm/src/tti.rs
+++ b/src/llvm-target-arm/src/tti.rs
@@ -157,9 +157,9 @@ impl TargetTransformInfo for AArch64Tti {
     /// Recommended SIMD vector factor for NEON (128-bit) baseline.
     fn vector_factor(&self, scalar_bits: u32) -> u32 {
         match scalar_bits {
-            16 => 8,  // 8x i16 in 128 bits (NEON)
-            32 => 4,  // 4x i32 / f32 in 128 bits (NEON)
-            64 => 2,  // 2x i64 / f64 in 128 bits (NEON)
+            16 => 8, // 8x i16 in 128 bits (NEON)
+            32 => 4, // 4x i32 / f32 in 128 bits (NEON)
+            64 => 2, // 2x i64 / f64 in 128 bits (NEON)
             _ => 1,
         }
     }

--- a/src/llvm-target-riscv/src/abi.rs
+++ b/src/llvm-target-riscv/src/abi.rs
@@ -51,7 +51,9 @@ pub const FP_RET: PReg = FP_RET_REG;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::regs::{F10, F11, F12, F13, F14, F15, F16, F17, X10, X11, X12, X13, X14, X15, X16, X17};
+    use crate::regs::{
+        F10, F11, F12, F13, F14, F15, F16, F17, X10, X11, X12, X13, X14, X15, X16, X17,
+    };
 
     #[test]
     fn first_eight_go_to_a0_a7() {

--- a/src/llvm-target-riscv/src/encode.rs
+++ b/src/llvm-target-riscv/src/encode.rs
@@ -1,6 +1,9 @@
 //! RV64 encoder and object emission.
 
-use crate::{instructions::*, regs::{fp_enc, is_fp_reg}};
+use crate::{
+    instructions::*,
+    regs::{fp_enc, is_fp_reg},
+};
 use llvm_codegen::emit::{DebugLineRow, Emitter, ObjectFormat, Section};
 use llvm_codegen::isel::{MInstr, MOpcode, MOperand, MachineFunction, PReg, VReg};
 
@@ -122,7 +125,11 @@ fn fp_reg_of_dst(v: VReg) -> u8 {
     // Post-allocation: v.0 = PReg.0 (8-bit physical reg number stored in u32).
     // FP regs: PReg(32..63) → fp_enc = PReg.0 - 32.
     let raw = (v.0 & 0xFF) as u8;
-    if raw >= 32 { raw - 32 } else { raw }
+    if raw >= 32 {
+        raw - 32
+    } else {
+        raw
+    }
 }
 
 /// Extract the 5-bit hardware FP register number from a PReg operand.
@@ -135,7 +142,11 @@ fn fp_reg_of_op(op: &MOperand) -> Option<u8> {
             let raw = (*v & 0xFF) as u8;
             // If it was an FP VReg, the bit pattern in the class-bit was stripped
             // by apply_allocation, so use raw directly.
-            if raw >= 32 { Some(raw - 32) } else { Some(raw) }
+            if raw >= 32 {
+                Some(raw - 32)
+            } else {
+                Some(raw)
+            }
         }
         _ => None,
     }
@@ -150,12 +161,7 @@ fn imm_of_op(op: Option<&MOperand>) -> i32 {
 }
 
 fn enc_r(f7: u32, rs2: u8, rs1: u8, f3: u32, rd: u8, opc: u32) -> u32 {
-    (f7 << 25)
-        | ((rs2 as u32) << 20)
-        | ((rs1 as u32) << 15)
-        | (f3 << 12)
-        | ((rd as u32) << 7)
-        | opc
+    (f7 << 25) | ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | (f3 << 12) | ((rd as u32) << 7) | opc
 }
 
 fn enc_i(imm: i32, rs1: u8, f3: u32, rd: u8, opc: u32) -> u32 {
@@ -167,12 +173,7 @@ fn enc_s(imm: i32, rs2: u8, rs1: u8, f3: u32, opc: u32) -> u32 {
     let i = (imm as u32) & 0xFFF;
     let hi = (i >> 5) & 0x7F;
     let lo = i & 0x1F;
-    (hi << 25)
-        | ((rs2 as u32) << 20)
-        | ((rs1 as u32) << 15)
-        | (f3 << 12)
-        | (lo << 7)
-        | opc
+    (hi << 25) | ((rs2 as u32) << 20) | ((rs1 as u32) << 15) | (f3 << 12) | (lo << 7) | opc
 }
 
 fn enc_b(imm: i32, rs2: u8, rs1: u8, f3: u32, opc: u32) -> u32 {
@@ -266,9 +267,16 @@ fn encode_instr(instr: &MInstr) -> u32 {
 
         JAL => enc_j(imm_of_op(instr.operands.first()), rd, 0x6F),
         JALR => {
-            let d = instr.dst.map(reg_of_dst).unwrap_or_else(|| instr.operands.first().and_then(reg_of_op).unwrap_or(0));
+            let d = instr
+                .dst
+                .map(reg_of_dst)
+                .unwrap_or_else(|| instr.operands.first().and_then(reg_of_op).unwrap_or(0));
             let base_idx = if instr.dst.is_some() { 0 } else { 1 };
-            let base = instr.operands.get(base_idx).and_then(reg_of_op).unwrap_or(0);
+            let base = instr
+                .operands
+                .get(base_idx)
+                .and_then(reg_of_op)
+                .unwrap_or(0);
             let imm = imm_of_op(instr.operands.get(base_idx + 1));
             enc_i(imm, base, 0x0, d, 0x67)
         }
@@ -285,26 +293,58 @@ fn encode_instr(instr: &MInstr) -> u32 {
         LR_D => enc_amo(0b00010, true, true, 0, rs1 as u32, 0b011, rd as u32),
 
         // SC.W / SC.D: operands[0]=rs1(ptr), operands[1]=rs2(new value)
-        SC_W => enc_amo(0b00011, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        SC_D => enc_amo(0b00011, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
+        SC_W => enc_amo(
+            0b00011, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        SC_D => enc_amo(
+            0b00011, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
 
         // AMO word variants
-        AMOADD_W  => enc_amo(0b00000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOSWAP_W => enc_amo(0b00001, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOXOR_W  => enc_amo(0b00100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOAND_W  => enc_amo(0b01100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOOR_W   => enc_amo(0b01000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOMIN_W  => enc_amo(0b10000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOMAX_W  => enc_amo(0b10100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOMINU_W => enc_amo(0b11000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
-        AMOMAXU_W => enc_amo(0b11100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32),
+        AMOADD_W => enc_amo(
+            0b00000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOSWAP_W => enc_amo(
+            0b00001, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOXOR_W => enc_amo(
+            0b00100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOAND_W => enc_amo(
+            0b01100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOOR_W => enc_amo(
+            0b01000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOMIN_W => enc_amo(
+            0b10000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOMAX_W => enc_amo(
+            0b10100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOMINU_W => enc_amo(
+            0b11000, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
+        AMOMAXU_W => enc_amo(
+            0b11100, true, true, rs2 as u32, rs1 as u32, 0b010, rd as u32,
+        ),
 
         // AMO doubleword variants
-        AMOADD_D  => enc_amo(0b00000, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
-        AMOSWAP_D => enc_amo(0b00001, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
-        AMOXOR_D  => enc_amo(0b00100, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
-        AMOAND_D  => enc_amo(0b01100, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
-        AMOOR_D   => enc_amo(0b01000, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32),
+        AMOADD_D => enc_amo(
+            0b00000, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
+        AMOSWAP_D => enc_amo(
+            0b00001, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
+        AMOXOR_D => enc_amo(
+            0b00100, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
+        AMOAND_D => enc_amo(
+            0b01100, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
+        AMOOR_D => enc_amo(
+            0b01000, true, true, rs2 as u32, rs1 as u32, 0b011, rd as u32,
+        ),
 
         // ── non-promotable alloca frame-slot access ────────────────────────
         // ADDI_FP_SLOT: addi rd, s0(x8), -(slot_idx+1)*8
@@ -442,7 +482,7 @@ fn encode_instr(instr: &MInstr) -> u32 {
             let rd = fp_reg_of_dst(instr.dst.unwrap_or(VReg(0)));
             let slot = imm_of_op(instr.operands.first());
             let byte_off = slot * 8; // slot index → byte offset
-            // Use x8 (s0/fp) as frame pointer, same as integer spill reloads.
+                                     // Use x8 (s0/fp) as frame pointer, same as integer spill reloads.
             enc_i(byte_off, 8, 0x3, rd, 0x07)
         }
         // FP_STORE_RM: FP spill save — FSD Fs, slot*8(sp)
@@ -567,35 +607,65 @@ mod tests {
     }
 
     #[test]
-    fn enc_r_add() { assert_eq!(encode_instr(&rr(ADD_RR)), enc_r(0x00, 2, 1, 0, 3, 0x33)); }
+    fn enc_r_add() {
+        assert_eq!(encode_instr(&rr(ADD_RR)), enc_r(0x00, 2, 1, 0, 3, 0x33));
+    }
     #[test]
-    fn enc_r_sub() { assert_eq!(encode_instr(&rr(SUB_RR)), enc_r(0x20, 2, 1, 0, 3, 0x33)); }
+    fn enc_r_sub() {
+        assert_eq!(encode_instr(&rr(SUB_RR)), enc_r(0x20, 2, 1, 0, 3, 0x33));
+    }
     #[test]
-    fn enc_r_mul() { assert_eq!(encode_instr(&rr(MUL_RR)), enc_r(0x01, 2, 1, 0, 3, 0x33)); }
+    fn enc_r_mul() {
+        assert_eq!(encode_instr(&rr(MUL_RR)), enc_r(0x01, 2, 1, 0, 3, 0x33));
+    }
     #[test]
-    fn enc_r_div() { assert_eq!(encode_instr(&rr(DIV_RR)), enc_r(0x01, 2, 1, 4, 3, 0x33)); }
+    fn enc_r_div() {
+        assert_eq!(encode_instr(&rr(DIV_RR)), enc_r(0x01, 2, 1, 4, 3, 0x33));
+    }
     #[test]
-    fn enc_r_udiv() { assert_eq!(encode_instr(&rr(UDIV_RR)), enc_r(0x01, 2, 1, 5, 3, 0x33)); }
+    fn enc_r_udiv() {
+        assert_eq!(encode_instr(&rr(UDIV_RR)), enc_r(0x01, 2, 1, 5, 3, 0x33));
+    }
     #[test]
-    fn enc_r_rem() { assert_eq!(encode_instr(&rr(REM_RR)), enc_r(0x01, 2, 1, 6, 3, 0x33)); }
+    fn enc_r_rem() {
+        assert_eq!(encode_instr(&rr(REM_RR)), enc_r(0x01, 2, 1, 6, 3, 0x33));
+    }
     #[test]
-    fn enc_r_urem() { assert_eq!(encode_instr(&rr(UREM_RR)), enc_r(0x01, 2, 1, 7, 3, 0x33)); }
+    fn enc_r_urem() {
+        assert_eq!(encode_instr(&rr(UREM_RR)), enc_r(0x01, 2, 1, 7, 3, 0x33));
+    }
     #[test]
-    fn enc_r_and() { assert_eq!(encode_instr(&rr(AND_RR)), enc_r(0x00, 2, 1, 7, 3, 0x33)); }
+    fn enc_r_and() {
+        assert_eq!(encode_instr(&rr(AND_RR)), enc_r(0x00, 2, 1, 7, 3, 0x33));
+    }
     #[test]
-    fn enc_r_or() { assert_eq!(encode_instr(&rr(OR_RR)), enc_r(0x00, 2, 1, 6, 3, 0x33)); }
+    fn enc_r_or() {
+        assert_eq!(encode_instr(&rr(OR_RR)), enc_r(0x00, 2, 1, 6, 3, 0x33));
+    }
     #[test]
-    fn enc_r_xor() { assert_eq!(encode_instr(&rr(XOR_RR)), enc_r(0x00, 2, 1, 4, 3, 0x33)); }
+    fn enc_r_xor() {
+        assert_eq!(encode_instr(&rr(XOR_RR)), enc_r(0x00, 2, 1, 4, 3, 0x33));
+    }
     #[test]
-    fn enc_r_sll() { assert_eq!(encode_instr(&rr(SLL_RR)), enc_r(0x00, 2, 1, 1, 3, 0x33)); }
+    fn enc_r_sll() {
+        assert_eq!(encode_instr(&rr(SLL_RR)), enc_r(0x00, 2, 1, 1, 3, 0x33));
+    }
     #[test]
-    fn enc_r_srl() { assert_eq!(encode_instr(&rr(SRL_RR)), enc_r(0x00, 2, 1, 5, 3, 0x33)); }
+    fn enc_r_srl() {
+        assert_eq!(encode_instr(&rr(SRL_RR)), enc_r(0x00, 2, 1, 5, 3, 0x33));
+    }
     #[test]
-    fn enc_r_sra() { assert_eq!(encode_instr(&rr(SRA_RR)), enc_r(0x20, 2, 1, 5, 3, 0x33)); }
+    fn enc_r_sra() {
+        assert_eq!(encode_instr(&rr(SRA_RR)), enc_r(0x20, 2, 1, 5, 3, 0x33));
+    }
     #[test]
-    fn enc_r_slt() { assert_eq!(encode_instr(&rr(SLT_RR)), enc_r(0x00, 2, 1, 2, 3, 0x33)); }
+    fn enc_r_slt() {
+        assert_eq!(encode_instr(&rr(SLT_RR)), enc_r(0x00, 2, 1, 2, 3, 0x33));
+    }
     #[test]
-    fn enc_r_sltu() { assert_eq!(encode_instr(&rr(SLTU_RR)), enc_r(0x00, 2, 1, 3, 3, 0x33)); }
+    fn enc_r_sltu() {
+        assert_eq!(encode_instr(&rr(SLTU_RR)), enc_r(0x00, 2, 1, 3, 3, 0x33));
+    }
 
     #[test]
     fn enc_mov_rr() {
@@ -615,69 +685,110 @@ mod tests {
 
     #[test]
     fn enc_i_addi() {
-        let mi = MInstr::new(ADDI).with_dst(VReg(1)).with_preg(PReg(2)).with_imm(7);
+        let mi = MInstr::new(ADDI)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_imm(7);
         assert_eq!(encode_instr(&mi), enc_i(7, 2, 0, 1, 0x13));
     }
     #[test]
     fn enc_i_xori() {
-        let mi = MInstr::new(XORI).with_dst(VReg(1)).with_preg(PReg(2)).with_imm(1);
+        let mi = MInstr::new(XORI)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_imm(1);
         assert_eq!(encode_instr(&mi), enc_i(1, 2, 4, 1, 0x13));
     }
     #[test]
     fn enc_i_sltiu() {
-        let mi = MInstr::new(SLTIU).with_dst(VReg(1)).with_preg(PReg(2)).with_imm(1);
+        let mi = MInstr::new(SLTIU)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_imm(1);
         assert_eq!(encode_instr(&mi), enc_i(1, 2, 3, 1, 0x13));
     }
 
     #[test]
     fn enc_i_lw() {
-        let mi = MInstr::new(LW).with_dst(VReg(3)).with_preg(PReg(1)).with_preg(PReg(0)).with_imm(16);
+        let mi = MInstr::new(LW)
+            .with_dst(VReg(3))
+            .with_preg(PReg(1))
+            .with_preg(PReg(0))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_i(16, 1, 2, 3, 0x03));
     }
     #[test]
     fn enc_i_ld() {
-        let mi = MInstr::new(LD).with_dst(VReg(3)).with_preg(PReg(1)).with_preg(PReg(0)).with_imm(24);
+        let mi = MInstr::new(LD)
+            .with_dst(VReg(3))
+            .with_preg(PReg(1))
+            .with_preg(PReg(0))
+            .with_imm(24);
         assert_eq!(encode_instr(&mi), enc_i(24, 1, 3, 3, 0x03));
     }
     #[test]
     fn enc_s_sw() {
-        let mi = MInstr::new(SW).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(20);
+        let mi = MInstr::new(SW)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(20);
         assert_eq!(encode_instr(&mi), enc_s(20, 2, 1, 2, 0x23));
     }
     #[test]
     fn enc_s_sd() {
-        let mi = MInstr::new(SD).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(28);
+        let mi = MInstr::new(SD)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(28);
         assert_eq!(encode_instr(&mi), enc_s(28, 2, 1, 3, 0x23));
     }
 
     #[test]
     fn enc_b_beq() {
-        let mi = MInstr::new(BEQ).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BEQ)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 0, 0x63));
     }
     #[test]
     fn enc_b_bne() {
-        let mi = MInstr::new(BNE).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BNE)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 1, 0x63));
     }
     #[test]
     fn enc_b_blt() {
-        let mi = MInstr::new(BLT).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BLT)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 4, 0x63));
     }
     #[test]
     fn enc_b_bge() {
-        let mi = MInstr::new(BGE).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BGE)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 5, 0x63));
     }
     #[test]
     fn enc_b_bltu() {
-        let mi = MInstr::new(BLTU).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BLTU)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 6, 0x63));
     }
     #[test]
     fn enc_b_bgeu() {
-        let mi = MInstr::new(BGEU).with_preg(PReg(1)).with_preg(PReg(2)).with_imm(16);
+        let mi = MInstr::new(BGEU)
+            .with_preg(PReg(1))
+            .with_preg(PReg(2))
+            .with_imm(16);
         assert_eq!(encode_instr(&mi), enc_b(16, 2, 1, 7, 0x63));
     }
 
@@ -688,11 +799,16 @@ mod tests {
     }
     #[test]
     fn enc_i_jalr() {
-        let mi = MInstr::new(JALR).with_dst(VReg(1)).with_preg(PReg(2)).with_imm(12);
+        let mi = MInstr::new(JALR)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_imm(12);
         assert_eq!(encode_instr(&mi), enc_i(12, 2, 0, 1, 0x67));
     }
     #[test]
-    fn enc_ret() { assert_eq!(encode_instr(&MInstr::new(RET)), enc_i(0, 1, 0, 0, 0x67)); }
+    fn enc_ret() {
+        assert_eq!(encode_instr(&MInstr::new(RET)), enc_i(0, 1, 0, 0, 0x67));
+    }
 
     #[test]
     fn enc_u_lui() {
@@ -706,15 +822,28 @@ mod tests {
     }
 
     #[test]
-    fn helper_i_sign_wrap() { assert_eq!(enc_i(-1, 1, 0, 2, 0x13) >> 20, 0xFFF); }
+    fn helper_i_sign_wrap() {
+        assert_eq!(enc_i(-1, 1, 0, 2, 0x13) >> 20, 0xFFF);
+    }
     #[test]
-    fn helper_s_splits_imm() { assert_eq!((enc_s(0x7F, 2, 1, 0, 0x23) >> 7) & 0x1F, 0x1F); }
+    fn helper_s_splits_imm() {
+        assert_eq!((enc_s(0x7F, 2, 1, 0, 0x23) >> 7) & 0x1F, 0x1F);
+    }
     #[test]
-    fn helper_b_encodes_bit11() { assert_eq!((enc_b(0x800, 2, 1, 0, 0x63) >> 7) & 1, 1); }
+    fn helper_b_encodes_bit11() {
+        assert_eq!((enc_b(0x800, 2, 1, 0, 0x63) >> 7) & 1, 1);
+    }
     #[test]
-    fn helper_j_encodes_bit20() { assert_eq!((enc_j(0x100000, 1, 0x6F) >> 31) & 1, 1); }
+    fn helper_j_encodes_bit20() {
+        assert_eq!((enc_j(0x100000, 1, 0x6F) >> 31) & 1, 1);
+    }
     #[test]
-    fn helper_u_keeps_upper_20() { assert_eq!(enc_u(0xABCD1000u32 as i32, 1, 0x37) & 0xFFFFF000, 0xABCD1000); }
+    fn helper_u_keeps_upper_20() {
+        assert_eq!(
+            enc_u(0xABCD1000u32 as i32, 1, 0x37) & 0xFFFFF000,
+            0xABCD1000
+        );
+    }
 
     #[test]
     fn emitter_outputs_words() {
@@ -771,7 +900,10 @@ mod tests {
     #[test]
     fn enc_amo_amoadd_w() {
         // amoadd.w.aqrl rd=x1, rs2=x2, (rs1=x3)
-        let mi = MInstr::new(AMOADD_W).with_dst(VReg(1)).with_preg(PReg(3)).with_preg(PReg(2));
+        let mi = MInstr::new(AMOADD_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(3))
+            .with_preg(PReg(2));
         let expected = enc_amo(0b00000, true, true, 2, 3, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected, "amoadd.w encoding mismatch");
     }
@@ -787,7 +919,10 @@ mod tests {
     #[test]
     fn enc_amo_sc_w() {
         // sc.w.aqrl rd=x1, rs2=x2, (rs1=x3)
-        let mi = MInstr::new(SC_W).with_dst(VReg(1)).with_preg(PReg(3)).with_preg(PReg(2));
+        let mi = MInstr::new(SC_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(3))
+            .with_preg(PReg(2));
         let expected = enc_amo(0b00011, true, true, 2, 3, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
@@ -795,56 +930,80 @@ mod tests {
     #[test]
     fn enc_amo_amoswap_d() {
         // amoswap.d.aqrl rd=x1, rs2=x3, (rs1=x2) — 64-bit variant
-        let mi = MInstr::new(AMOSWAP_D).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+        let mi = MInstr::new(AMOSWAP_D)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_preg(PReg(3));
         let expected = enc_amo(0b00001, true, true, 3, 2, 0b011, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amoxor_w() {
-        let mi = MInstr::new(AMOXOR_W).with_dst(VReg(2)).with_preg(PReg(4)).with_preg(PReg(5));
+        let mi = MInstr::new(AMOXOR_W)
+            .with_dst(VReg(2))
+            .with_preg(PReg(4))
+            .with_preg(PReg(5));
         let expected = enc_amo(0b00100, true, true, 5, 4, 0b010, 2);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amoand_w() {
-        let mi = MInstr::new(AMOAND_W).with_dst(VReg(3)).with_preg(PReg(1)).with_preg(PReg(2));
+        let mi = MInstr::new(AMOAND_W)
+            .with_dst(VReg(3))
+            .with_preg(PReg(1))
+            .with_preg(PReg(2));
         let expected = enc_amo(0b01100, true, true, 2, 1, 0b010, 3);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amoor_w() {
-        let mi = MInstr::new(AMOOR_W).with_dst(VReg(4)).with_preg(PReg(5)).with_preg(PReg(6));
+        let mi = MInstr::new(AMOOR_W)
+            .with_dst(VReg(4))
+            .with_preg(PReg(5))
+            .with_preg(PReg(6));
         let expected = enc_amo(0b01000, true, true, 6, 5, 0b010, 4);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amomin_w() {
-        let mi = MInstr::new(AMOMIN_W).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+        let mi = MInstr::new(AMOMIN_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_preg(PReg(3));
         let expected = enc_amo(0b10000, true, true, 3, 2, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amomax_w() {
-        let mi = MInstr::new(AMOMAX_W).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+        let mi = MInstr::new(AMOMAX_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_preg(PReg(3));
         let expected = enc_amo(0b10100, true, true, 3, 2, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amominu_w() {
-        let mi = MInstr::new(AMOMINU_W).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+        let mi = MInstr::new(AMOMINU_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_preg(PReg(3));
         let expected = enc_amo(0b11000, true, true, 3, 2, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
 
     #[test]
     fn enc_amo_amomaxu_w() {
-        let mi = MInstr::new(AMOMAXU_W).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+        let mi = MInstr::new(AMOMAXU_W)
+            .with_dst(VReg(1))
+            .with_preg(PReg(2))
+            .with_preg(PReg(3));
         let expected = enc_amo(0b11100, true, true, 3, 2, 0b010, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
@@ -858,7 +1017,10 @@ mod tests {
 
     #[test]
     fn enc_amo_sc_d() {
-        let mi = MInstr::new(SC_D).with_dst(VReg(1)).with_preg(PReg(3)).with_preg(PReg(2));
+        let mi = MInstr::new(SC_D)
+            .with_dst(VReg(1))
+            .with_preg(PReg(3))
+            .with_preg(PReg(2));
         let expected = enc_amo(0b00011, true, true, 2, 3, 0b011, 1);
         assert_eq!(encode_instr(&mi), expected);
     }
@@ -867,16 +1029,25 @@ mod tests {
     fn enc_amo_opcode_field() {
         // All AMO instructions must have opcode bits [6:0] = 0x2F
         let opcodes = [
-            FENCE, LR_W, SC_W, AMOADD_W, AMOSWAP_W, AMOXOR_W, AMOAND_W,
-            AMOOR_W, AMOMIN_W, AMOMAX_W, AMOMINU_W, AMOMAXU_W,
-            LR_D, SC_D, AMOADD_D, AMOSWAP_D, AMOXOR_D, AMOAND_D, AMOOR_D,
+            FENCE, LR_W, SC_W, AMOADD_W, AMOSWAP_W, AMOXOR_W, AMOAND_W, AMOOR_W, AMOMIN_W,
+            AMOMAX_W, AMOMINU_W, AMOMAXU_W, LR_D, SC_D, AMOADD_D, AMOSWAP_D, AMOXOR_D, AMOAND_D,
+            AMOOR_D,
         ];
         // FENCE is not an AMO instruction; skip it in this check
         let amo_opcodes = &opcodes[1..]; // skip FENCE
         for &op in amo_opcodes {
-            let mi = MInstr::new(op).with_dst(VReg(1)).with_preg(PReg(2)).with_preg(PReg(3));
+            let mi = MInstr::new(op)
+                .with_dst(VReg(1))
+                .with_preg(PReg(2))
+                .with_preg(PReg(3));
             let word = encode_instr(&mi);
-            assert_eq!(word & 0x7F, 0x2F, "opcode 0x{:X} should have AMO opcode 0x2F in bits[6:0], got 0x{:X}", op.0, word & 0x7F);
+            assert_eq!(
+                word & 0x7F,
+                0x2F,
+                "opcode 0x{:X} should have AMO opcode 0x2F in bits[6:0], got 0x{:X}",
+                op.0,
+                word & 0x7F
+            );
         }
     }
 
@@ -886,7 +1057,7 @@ mod tests {
     /// FP PRegs are offset by 32: PReg(32+fd), etc.
     fn fp_rr(op: llvm_codegen::isel::MOpcode, fd: u8, fs1: u8, fs2: u8) -> MInstr {
         MInstr::new(op)
-            .with_dst(VReg((32 + fd) as u32))  // post-regalloc: VReg holds PReg number
+            .with_dst(VReg((32 + fd) as u32)) // post-regalloc: VReg holds PReg number
             .with_preg(PReg(32 + fs1))
             .with_preg(PReg(32 + fs2))
     }
@@ -949,11 +1120,15 @@ mod tests {
     fn enc_fneg_d_uses_fsgnjn_encoding() {
         // fneg.d is FSGNJN.D rd, rs, rs: funct7=0x21, funct3=0x1, rs2=rs1
         let mi = MInstr::new(FNEG_D)
-            .with_dst(VReg(32 + 0))  // fd=f0
+            .with_dst(VReg(32 + 0)) // fd=f0
             .with_preg(PReg(32 + 1)) // rs1=f1
             .with_preg(PReg(32 + 1)); // rs2=f1 (same)
         let word = encode_instr(&mi);
-        assert_eq!((word >> 25) & 0x7F, 0x21, "fneg.d funct7 must be 0x21 (FSGNJN)");
+        assert_eq!(
+            (word >> 25) & 0x7F,
+            0x21,
+            "fneg.d funct7 must be 0x21 (FSGNJN)"
+        );
         assert_eq!((word >> 12) & 0x7, 0x1, "fneg.d funct3 must be 0x1");
         // rs1 == rs2 == 1
         assert_eq!((word >> 15) & 0x1F, 1, "rs1 must be f1");
@@ -964,7 +1139,7 @@ mod tests {
     fn enc_feq_d_produces_integer_dest() {
         // feq.d uses integer rd, FP rs1/rs2: funct7=0x51, funct3=0x2
         let mi = MInstr::new(FCMP_EQ_D)
-            .with_dst(VReg(3))       // integer rd=x3
+            .with_dst(VReg(3)) // integer rd=x3
             .with_preg(PReg(32 + 0)) // rs1=f0
             .with_preg(PReg(32 + 1)); // rs2=f1
         let word = encode_instr(&mi);
@@ -1001,7 +1176,7 @@ mod tests {
     fn enc_fcvt_l_d_funct7_and_rs2() {
         // fcvt.l.d: funct7=0x61, rs2=2 (L), rounding=RTZ=0x1
         let mi = MInstr::new(FCVT_L_D)
-            .with_dst(VReg(1))        // integer rd
+            .with_dst(VReg(1)) // integer rd
             .with_preg(PReg(32 + 0)); // fp rs1
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x61, "fcvt.l.d funct7 must be 0x61");
@@ -1024,8 +1199,8 @@ mod tests {
     fn enc_fcvt_d_l_funct7_and_rs2() {
         // fcvt.d.l: funct7=0x69, rs2=2
         let mi = MInstr::new(FCVT_D_L)
-            .with_dst(VReg(32 + 0))  // fp rd
-            .with_preg(PReg(1));      // int rs1
+            .with_dst(VReg(32 + 0)) // fp rd
+            .with_preg(PReg(1)); // int rs1
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x69, "fcvt.d.l funct7 must be 0x69");
         assert_eq!((word >> 20) & 0x1F, 2, "fcvt.d.l rs2 must be 2 (L)");
@@ -1050,7 +1225,11 @@ mod tests {
             .with_dst(VReg(32 + 5))
             .with_preg(PReg(32 + 6));
         let word = encode_instr(&mi);
-        assert_eq!((word >> 25) & 0x7F, 0x11, "fmv.d funct7 must be 0x11 (FSGNJ)");
+        assert_eq!(
+            (word >> 25) & 0x7F,
+            0x11,
+            "fmv.d funct7 must be 0x11 (FSGNJ)"
+        );
         assert_eq!((word >> 12) & 0x7, 0x0, "fmv.d funct3 must be 0x0");
         // Both rs1 and rs2 must be the same source register (f6=6)
         assert_eq!((word >> 15) & 0x1F, 6, "fmv.d rs1 must be f6");
@@ -1062,7 +1241,7 @@ mod tests {
         // fld f1, 8(x2): opcode=0x07, funct3=0x3
         let mi = MInstr::new(FLD)
             .with_dst(VReg(32 + 1)) // fd=f1
-            .with_preg(PReg(2))      // rs1=x2
+            .with_preg(PReg(2)) // rs1=x2
             .with_imm(8);
         let word = encode_instr(&mi);
         assert_eq!(word & 0x7F, 0x07, "fld opcode must be 0x07");
@@ -1077,8 +1256,8 @@ mod tests {
     fn enc_fsd_s_type_opcode_and_funct3() {
         // fsd f2, 16(x3): opcode=0x27, funct3=0x3
         let mi = MInstr::new(FSD)
-            .with_preg(PReg(3))       // rs1=x3 (base)
-            .with_preg(PReg(32 + 2))  // rs2=f2 (source)
+            .with_preg(PReg(3)) // rs1=x3 (base)
+            .with_preg(PReg(32 + 2)) // rs2=f2 (source)
             .with_imm(16);
         let word = encode_instr(&mi);
         assert_eq!(word & 0x7F, 0x27, "fsd opcode must be 0x27");
@@ -1091,14 +1270,15 @@ mod tests {
     fn enc_fp_arith_all_have_opcode_53() {
         // All FP arithmetic instructions must have opcode 0x53.
         let fp_arith_ops = [
-            FADD_D, FSUB_D, FMUL_D, FDIV_D, FSQRT_D, FNEG_D,
-            FCMP_EQ_D, FCMP_LT_D, FCMP_LE_D,
-            FADD_S, FSUB_S, FMUL_S, FDIV_S, FNEG_S,
-            FCMP_EQ_S, FCMP_LT_S, FCMP_LE_S,
+            FADD_D, FSUB_D, FMUL_D, FDIV_D, FSQRT_D, FNEG_D, FCMP_EQ_D, FCMP_LT_D, FCMP_LE_D,
+            FADD_S, FSUB_S, FMUL_S, FDIV_S, FNEG_S, FCMP_EQ_S, FCMP_LT_S, FCMP_LE_S,
         ];
         for &op in &fp_arith_ops {
             // Build a generic instruction: for compare ops dst is int, for arith dst is fp.
-            let mi = if matches!(op, FCMP_EQ_D | FCMP_LT_D | FCMP_LE_D | FCMP_EQ_S | FCMP_LT_S | FCMP_LE_S) {
+            let mi = if matches!(
+                op,
+                FCMP_EQ_D | FCMP_LT_D | FCMP_LE_D | FCMP_EQ_S | FCMP_LT_S | FCMP_LE_S
+            ) {
                 MInstr::new(op)
                     .with_dst(VReg(1))
                     .with_preg(PReg(32))
@@ -1106,9 +1286,15 @@ mod tests {
             } else if matches!(op, FSQRT_D) {
                 MInstr::new(op).with_dst(VReg(32)).with_preg(PReg(33))
             } else if matches!(op, FNEG_D | FNEG_S) {
-                MInstr::new(op).with_dst(VReg(32)).with_preg(PReg(33)).with_preg(PReg(33))
+                MInstr::new(op)
+                    .with_dst(VReg(32))
+                    .with_preg(PReg(33))
+                    .with_preg(PReg(33))
             } else {
-                MInstr::new(op).with_dst(VReg(32)).with_preg(PReg(33)).with_preg(PReg(34))
+                MInstr::new(op)
+                    .with_dst(VReg(32))
+                    .with_preg(PReg(33))
+                    .with_preg(PReg(34))
             };
             let word = encode_instr(&mi);
             assert_eq!(word & 0x7F, 0x53, "FP op {:?} must have opcode 0x53", op);
@@ -1150,7 +1336,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has_fadd = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FADD_D);
+        let has_fadd = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FADD_D);
         assert!(has_fadd, "fadd double must lower to FADD_D");
     }
 
@@ -1168,7 +1358,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FSUB_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FSUB_D);
         assert!(has, "fsub double must lower to FSUB_D");
     }
 
@@ -1186,7 +1380,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FMUL_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FMUL_D);
         assert!(has, "fmul double must lower to FMUL_D");
     }
 
@@ -1204,7 +1402,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FDIV_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FDIV_D);
         assert!(has, "fdiv double must lower to FDIV_D");
     }
 
@@ -1222,7 +1424,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FNEG_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FNEG_D);
         assert!(has, "fneg double must lower to FNEG_D");
     }
 
@@ -1240,7 +1446,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FCMP_EQ_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FCMP_EQ_D);
         assert!(has, "fcmp oeq double must lower to FCMP_EQ_D");
     }
 
@@ -1258,7 +1468,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FCMP_LT_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FCMP_LT_D);
         assert!(has, "fcmp olt double must lower to FCMP_LT_D");
     }
 
@@ -1276,7 +1490,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FCVT_D_L);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FCVT_D_L);
         assert!(has, "sitofp i64 to double must lower to FCVT_D_L");
     }
 
@@ -1294,7 +1512,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FCVT_L_D);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FCVT_L_D);
         assert!(has, "fptosi double to i64 must lower to FCVT_L_D");
     }
 
@@ -1312,7 +1534,11 @@ entry:
         let func = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, func);
-        let has = mf.blocks.iter().flat_map(|b| b.instrs.iter()).any(|i| i.opcode == FADD_S);
+        let has = mf
+            .blocks
+            .iter()
+            .flat_map(|b| b.instrs.iter())
+            .any(|i| i.opcode == FADD_S);
         assert!(has, "fadd float must lower to FADD_S");
     }
 

--- a/src/llvm-target-riscv/src/lower.rs
+++ b/src/llvm-target-riscv/src/lower.rs
@@ -122,7 +122,10 @@ fn is_fp_type(ctx: &Context, ty: llvm_ir::TypeId) -> bool {
 
 /// Returns `true` if `ty` is specifically a double-precision (f64) type.
 fn is_double(ctx: &Context, ty: llvm_ir::TypeId) -> bool {
-    matches!(ctx.get_type(ty), TypeData::Float(llvm_ir::FloatKind::Double))
+    matches!(
+        ctx.get_type(ty),
+        TypeData::Float(llvm_ir::FloatKind::Double)
+    )
 }
 
 fn resolve(
@@ -149,7 +152,10 @@ fn resolve(
                 // would be most correct, but for the IR-level tests we emit a
                 // MOV_IMM carrying the bit pattern.  The encoder treats the dst
                 // class when producing the output register number.
-                mf.push(mblock, MInstr::new(MOV_IMM).with_dst(vreg).with_imm(*bits as i64));
+                mf.push(
+                    mblock,
+                    MInstr::new(MOV_IMM).with_dst(vreg).with_imm(*bits as i64),
+                );
                 vreg
             } else {
                 let vreg = mf.fresh_vreg();
@@ -186,47 +192,128 @@ fn lower_icmp_to_bool(
     match pred {
         IntPredicate::Eq => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(XOR_RR).with_dst(t).with_vreg(lhs).with_vreg(rhs));
+            mf.push(
+                mblock,
+                MInstr::new(XOR_RR)
+                    .with_dst(t)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
             // dst = (t == 0) ? 1 : 0
-            mf.push(mblock, MInstr::new(SLTIU).with_dst(dst).with_vreg(t).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(SLTIU).with_dst(dst).with_vreg(t).with_imm(1),
+            );
         }
         IntPredicate::Ne => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(XOR_RR).with_dst(t).with_vreg(lhs).with_vreg(rhs));
+            mf.push(
+                mblock,
+                MInstr::new(XOR_RR)
+                    .with_dst(t)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
             // dst = (t != 0) ? 1 : 0 => sltu x0, t
-            mf.push(mblock, MInstr::new(SLTU_RR).with_dst(dst).with_preg(X0).with_vreg(t));
+            mf.push(
+                mblock,
+                MInstr::new(SLTU_RR)
+                    .with_dst(dst)
+                    .with_preg(X0)
+                    .with_vreg(t),
+            );
         }
         IntPredicate::Slt => {
-            mf.push(mblock, MInstr::new(SLT_RR).with_dst(dst).with_vreg(lhs).with_vreg(rhs));
+            mf.push(
+                mblock,
+                MInstr::new(SLT_RR)
+                    .with_dst(dst)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
         }
         IntPredicate::Sle => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(SLT_RR).with_dst(t).with_vreg(rhs).with_vreg(lhs));
-            mf.push(mblock, MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(SLT_RR)
+                    .with_dst(t)
+                    .with_vreg(rhs)
+                    .with_vreg(lhs),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1),
+            );
         }
         IntPredicate::Sgt => {
-            mf.push(mblock, MInstr::new(SLT_RR).with_dst(dst).with_vreg(rhs).with_vreg(lhs));
+            mf.push(
+                mblock,
+                MInstr::new(SLT_RR)
+                    .with_dst(dst)
+                    .with_vreg(rhs)
+                    .with_vreg(lhs),
+            );
         }
         IntPredicate::Sge => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(SLT_RR).with_dst(t).with_vreg(lhs).with_vreg(rhs));
-            mf.push(mblock, MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(SLT_RR)
+                    .with_dst(t)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1),
+            );
         }
         IntPredicate::Ult => {
-            mf.push(mblock, MInstr::new(SLTU_RR).with_dst(dst).with_vreg(lhs).with_vreg(rhs));
+            mf.push(
+                mblock,
+                MInstr::new(SLTU_RR)
+                    .with_dst(dst)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
         }
         IntPredicate::Ule => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(SLTU_RR).with_dst(t).with_vreg(rhs).with_vreg(lhs));
-            mf.push(mblock, MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(SLTU_RR)
+                    .with_dst(t)
+                    .with_vreg(rhs)
+                    .with_vreg(lhs),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1),
+            );
         }
         IntPredicate::Ugt => {
-            mf.push(mblock, MInstr::new(SLTU_RR).with_dst(dst).with_vreg(rhs).with_vreg(lhs));
+            mf.push(
+                mblock,
+                MInstr::new(SLTU_RR)
+                    .with_dst(dst)
+                    .with_vreg(rhs)
+                    .with_vreg(lhs),
+            );
         }
         IntPredicate::Uge => {
             let t = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(SLTU_RR).with_dst(t).with_vreg(lhs).with_vreg(rhs));
-            mf.push(mblock, MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(SLTU_RR)
+                    .with_dst(t)
+                    .with_vreg(lhs)
+                    .with_vreg(rhs),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1),
+            );
         }
     }
 }
@@ -277,7 +364,10 @@ fn lower_instr(
             let dst = new_dst!();
             let l = res!($lhs);
             let r = res!($rhs);
-            mf.push(mblock, MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r));
+            mf.push(
+                mblock,
+                MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r),
+            );
         }};
     }
     macro_rules! emit_fp_binop3 {
@@ -285,7 +375,10 @@ fn lower_instr(
             let dst = new_fp_dst!();
             let l = res!($lhs);
             let r = res!($rhs);
-            mf.push(mblock, MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r));
+            mf.push(
+                mblock,
+                MInstr::new($op).with_dst(dst).with_vreg(l).with_vreg(r),
+            );
         }};
     }
 
@@ -322,12 +415,10 @@ fn lower_instr(
                 match lhs {
                     ValueRef::Instruction(i) => func.instr(*i).ty,
                     ValueRef::Argument(ArgId(a)) => func.args[*a as usize].ty,
-                    ValueRef::Constant(c) => {
-                        match ctx.get_const(*c) {
-                            ConstantData::Float { ty, .. } => *ty,
-                            _ => instr_ty,
-                        }
-                    }
+                    ValueRef::Constant(c) => match ctx.get_const(*c) {
+                        ConstantData::Float { ty, .. } => *ty,
+                        _ => instr_ty,
+                    },
                     _ => instr_ty,
                 }
             };
@@ -338,34 +429,55 @@ fn lower_instr(
                 // Ordered equal: feq.d
                 FloatPredicate::Oeq | FloatPredicate::Ueq => {
                     let op = if double { FCMP_EQ_D } else { FCMP_EQ_S };
-                    mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r));
+                    mf.push(
+                        mblock,
+                        MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r),
+                    );
                 }
                 // Ordered less-than: flt.d
                 FloatPredicate::Olt | FloatPredicate::Ult => {
                     let op = if double { FCMP_LT_D } else { FCMP_LT_S };
-                    mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r));
+                    mf.push(
+                        mblock,
+                        MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r),
+                    );
                 }
                 // Ordered less-or-equal: fle.d
                 FloatPredicate::Ole | FloatPredicate::Ule => {
                     let op = if double { FCMP_LE_D } else { FCMP_LE_S };
-                    mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r));
+                    mf.push(
+                        mblock,
+                        MInstr::new(op).with_dst(dst).with_vreg(l).with_vreg(r),
+                    );
                 }
                 // Ordered greater-than: flt.d with swapped operands
                 FloatPredicate::Ogt | FloatPredicate::Ugt => {
                     let op = if double { FCMP_LT_D } else { FCMP_LT_S };
-                    mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(r).with_vreg(l));
+                    mf.push(
+                        mblock,
+                        MInstr::new(op).with_dst(dst).with_vreg(r).with_vreg(l),
+                    );
                 }
                 // Ordered greater-or-equal: fle.d with swapped operands
                 FloatPredicate::Oge | FloatPredicate::Uge => {
                     let op = if double { FCMP_LE_D } else { FCMP_LE_S };
-                    mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(r).with_vreg(l));
+                    mf.push(
+                        mblock,
+                        MInstr::new(op).with_dst(dst).with_vreg(r).with_vreg(l),
+                    );
                 }
                 // Not-equal: !(feq.d a, b) = xori(feq.d a b, 1)
                 FloatPredicate::One | FloatPredicate::Une => {
                     let eq_op = if double { FCMP_EQ_D } else { FCMP_EQ_S };
                     let t = mf.fresh_vreg();
-                    mf.push(mblock, MInstr::new(eq_op).with_dst(t).with_vreg(l).with_vreg(r));
-                    mf.push(mblock, MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1));
+                    mf.push(
+                        mblock,
+                        MInstr::new(eq_op).with_dst(t).with_vreg(l).with_vreg(r),
+                    );
+                    mf.push(
+                        mblock,
+                        MInstr::new(XORI).with_dst(dst).with_vreg(t).with_imm(1),
+                    );
                 }
                 // True/False/Ord/Uno: trivial constants
                 FloatPredicate::True => {
@@ -384,19 +496,44 @@ fn lower_instr(
             }
         }
 
-        Select { cond, then_val, else_val } => {
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             let dst = new_dst!();
             let c = res!(*cond);
             let tv = res!(*then_val);
             let fv = res!(*else_val);
             // cond is i1 (0/1): dst = tv*cond + fv*(cond^1)
             let notc = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(XORI).with_dst(notc).with_vreg(c).with_imm(1));
+            mf.push(
+                mblock,
+                MInstr::new(XORI).with_dst(notc).with_vreg(c).with_imm(1),
+            );
             let tpart = mf.fresh_vreg();
             let fpart = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(MUL_RR).with_dst(tpart).with_vreg(tv).with_vreg(c));
-            mf.push(mblock, MInstr::new(MUL_RR).with_dst(fpart).with_vreg(fv).with_vreg(notc));
-            mf.push(mblock, MInstr::new(ADD_RR).with_dst(dst).with_vreg(tpart).with_vreg(fpart));
+            mf.push(
+                mblock,
+                MInstr::new(MUL_RR)
+                    .with_dst(tpart)
+                    .with_vreg(tv)
+                    .with_vreg(c),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(MUL_RR)
+                    .with_dst(fpart)
+                    .with_vreg(fv)
+                    .with_vreg(notc),
+            );
+            mf.push(
+                mblock,
+                MInstr::new(ADD_RR)
+                    .with_dst(dst)
+                    .with_vreg(tpart)
+                    .with_vreg(fpart),
+            );
         }
 
         Phi { .. } => {}
@@ -418,10 +555,10 @@ fn lower_instr(
                 _ => 64,
             };
             let op = match (double, bits) {
-                (true,  64) => FCVT_L_D,
-                (true,  _)  => FCVT_W_D,
+                (true, 64) => FCVT_L_D,
+                (true, _) => FCVT_W_D,
                 (false, 64) => FCVT_L_S,
-                (false, _)  => FCVT_W_S,
+                (false, _) => FCVT_W_S,
             };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
@@ -442,10 +579,10 @@ fn lower_instr(
                 _ => 64,
             };
             let op = match (double, bits) {
-                (true,  64) => FCVT_L_D,
-                (true,  _)  => FCVT_W_D,
+                (true, 64) => FCVT_L_D,
+                (true, _) => FCVT_W_D,
                 (false, 64) => FCVT_L_S,
-                (false, _)  => FCVT_W_S,
+                (false, _) => FCVT_W_S,
             };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
@@ -466,10 +603,10 @@ fn lower_instr(
             };
             let double = is_double(ctx, result_ty);
             let op = match (double, src_bits) {
-                (true,  64) => FCVT_D_L,
-                (true,  _)  => FCVT_D_W,
+                (true, 64) => FCVT_D_L,
+                (true, _) => FCVT_D_W,
                 (false, 64) => FCVT_S_L,
-                (false, _)  => FCVT_S_W,
+                (false, _) => FCVT_S_W,
             };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
@@ -490,10 +627,10 @@ fn lower_instr(
             };
             let double = is_double(ctx, result_ty);
             let op = match (double, src_bits) {
-                (true,  64) => FCVT_D_L,
-                (true,  _)  => FCVT_D_W,
+                (true, 64) => FCVT_D_L,
+                (true, _) => FCVT_D_W,
                 (false, 64) => FCVT_S_L,
-                (false, _)  => FCVT_S_W,
+                (false, _) => FCVT_S_W,
             };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
@@ -546,7 +683,10 @@ fn lower_instr(
                 }
             }
             let callee_vr = res!(*callee);
-            let mut call_mi = MInstr::new(JALR).with_preg(PReg(1)).with_vreg(callee_vr).with_imm(0);
+            let mut call_mi = MInstr::new(JALR)
+                .with_preg(PReg(1))
+                .with_vreg(callee_vr)
+                .with_imm(0);
             call_mi.clobbers = ALLOCATABLE.to_vec();
             mf.push(mblock, call_mi);
 
@@ -569,31 +709,43 @@ fn lower_instr(
         Fence { .. } => {
             mf.push(mblock, MInstr::new(FENCE));
         }
-        CmpXchg { ptr, cmp: _cmp, new_val, .. } => {
+        CmpXchg {
+            ptr,
+            cmp: _cmp,
+            new_val,
+            ..
+        } => {
             let ptr_vr = res!(*ptr);
             let _cmp_vr = res!(*_cmp);
             let new_vr = res!(*new_val);
             // Determine width from instruction result type (struct { val_ty, i1 }).
             // Use W vs D based on pointer-width assumption; default to W (32-bit).
             let ty_bits = match ctx.get_type(instr.ty) {
-                TypeData::Struct(st) if !st.fields.is_empty() => {
-                    match ctx.get_type(st.fields[0]) {
-                        TypeData::Integer(b) => *b,
-                        _ => 32,
-                    }
-                }
+                TypeData::Struct(st) if !st.fields.is_empty() => match ctx.get_type(st.fields[0]) {
+                    TypeData::Integer(b) => *b,
+                    _ => 32,
+                },
                 _ => 32,
             };
             let use_d = ty_bits == 64;
             // LR.W/LR.D old, (ptr)
             let old_vr = mf.fresh_vreg();
             let lr_op = if use_d { LR_D } else { LR_W };
-            mf.push(mblock, MInstr::new(lr_op).with_dst(old_vr).with_vreg(ptr_vr));
+            mf.push(
+                mblock,
+                MInstr::new(lr_op).with_dst(old_vr).with_vreg(ptr_vr),
+            );
             // SC.W/SC.D status, new_val, (ptr)
             // (Simplified: no retry loop — follow-up per issue #239)
             let status_vr = mf.fresh_vreg();
             let sc_op = if use_d { SC_D } else { SC_W };
-            mf.push(mblock, MInstr::new(sc_op).with_dst(status_vr).with_vreg(ptr_vr).with_vreg(new_vr));
+            mf.push(
+                mblock,
+                MInstr::new(sc_op)
+                    .with_dst(status_vr)
+                    .with_vreg(ptr_vr)
+                    .with_vreg(new_vr),
+            );
             // Result is the old value from LR.
             let dst = new_dst!();
             mf.push(mblock, MInstr::new(MOV_RR).with_dst(dst).with_vreg(old_vr));
@@ -608,28 +760,78 @@ fn lower_instr(
             };
             let use_d = ty_bits == 64;
             let opcode = match op {
-                RmwOp::Add => if use_d { AMOADD_D } else { AMOADD_W },
-                RmwOp::Xchg => if use_d { AMOSWAP_D } else { AMOSWAP_W },
-                RmwOp::Xor => if use_d { AMOXOR_D } else { AMOXOR_W },
-                RmwOp::And | RmwOp::Nand => if use_d { AMOAND_D } else { AMOAND_W },
-                RmwOp::Or => if use_d { AMOOR_D } else { AMOOR_W },
+                RmwOp::Add => {
+                    if use_d {
+                        AMOADD_D
+                    } else {
+                        AMOADD_W
+                    }
+                }
+                RmwOp::Xchg => {
+                    if use_d {
+                        AMOSWAP_D
+                    } else {
+                        AMOSWAP_W
+                    }
+                }
+                RmwOp::Xor => {
+                    if use_d {
+                        AMOXOR_D
+                    } else {
+                        AMOXOR_W
+                    }
+                }
+                RmwOp::And | RmwOp::Nand => {
+                    if use_d {
+                        AMOAND_D
+                    } else {
+                        AMOAND_W
+                    }
+                }
+                RmwOp::Or => {
+                    if use_d {
+                        AMOOR_D
+                    } else {
+                        AMOOR_W
+                    }
+                }
                 // Sub: negate val then add — use amoadd (caller is responsible for negation;
                 // here we emit amoadd as the closest approximation without modifying val).
-                RmwOp::Sub => if use_d { AMOADD_D } else { AMOADD_W },
+                RmwOp::Sub => {
+                    if use_d {
+                        AMOADD_D
+                    } else {
+                        AMOADD_W
+                    }
+                }
                 RmwOp::Min => AMOMIN_W,
                 RmwOp::Max => AMOMAX_W,
                 RmwOp::UMin => AMOMINU_W,
                 RmwOp::UMax => AMOMAXU_W,
-                _ => if use_d { AMOADD_D } else { AMOADD_W },
+                _ => {
+                    if use_d {
+                        AMOADD_D
+                    } else {
+                        AMOADD_W
+                    }
+                }
             };
             let dst = new_dst!();
-            mf.push(mblock, MInstr::new(opcode).with_dst(dst).with_vreg(ptr_vr).with_vreg(val_vr));
+            mf.push(
+                mblock,
+                MInstr::new(opcode)
+                    .with_dst(dst)
+                    .with_vreg(ptr_vr)
+                    .with_vreg(val_vr),
+            );
         }
 
         // ── memory: non-promotable alloca/load/store (FP-relative frame slots) ──
         // mem2reg eliminates promotable alloca/load/store; what remains here is
         // non-promotable (address escapes or non-constant GEP index).
-        Alloca { alloc_ty, align, .. } => {
+        Alloca {
+            alloc_ty, align, ..
+        } => {
             let dst = new_dst!();
             let size_bytes = sizeof_ty(ctx, *alloc_ty) as u32;
             let align_bytes = align.unwrap_or(8);
@@ -652,19 +854,13 @@ fn lower_instr(
             let dst = new_dst!();
             // LD_REG: ld dst, 0(ptr_reg)
             let ptr_vr = res!(*ptr);
-            mf.push(
-                mblock,
-                MInstr::new(LD_REG).with_dst(dst).with_vreg(ptr_vr),
-            );
+            mf.push(mblock, MInstr::new(LD_REG).with_dst(dst).with_vreg(ptr_vr));
         }
         Store { val, ptr, .. } => {
             // SD_REG: sd src, 0(ptr_reg)
             let src = res!(*val);
             let ptr_vr = res!(*ptr);
-            mf.push(
-                mblock,
-                MInstr::new(SD_REG).with_vreg(ptr_vr).with_vreg(src),
-            );
+            mf.push(mblock, MInstr::new(SD_REG).with_vreg(ptr_vr).with_vreg(src));
         }
 
         FAdd { lhs, rhs, .. } => {
@@ -699,7 +895,10 @@ fn lower_instr(
             let src = res!(*operand);
             // fsgnjn.d rd, rs, rs negates the sign bit: FNEG_D uses rs1=rs2.
             let op = if is_double(ctx, ty) { FNEG_D } else { FNEG_S };
-            mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src).with_vreg(src));
+            mf.push(
+                mblock,
+                MInstr::new(op).with_dst(dst).with_vreg(src).with_vreg(src),
+            );
         }
 
         ExtractValue { .. }
@@ -716,10 +915,20 @@ fn lower_instr(
             mf.push(mblock, MInstr::new(MOV_IMM).with_dst(dst).with_imm(0));
         }
 
-        Ret { .. } | Br { .. } | CondBr { .. } | Invoke { .. } | Switch { .. } | Unreachable | Resume { .. } => {}
+        Ret { .. }
+        | Br { .. }
+        | CondBr { .. }
+        | Invoke { .. }
+        | Switch { .. }
+        | Unreachable
+        | Resume { .. } => {}
 
         // Funclet pads — not yet fully supported; emit a NOP stub.
-        CatchPad { .. } | CleanupPad { .. } | CatchSwitch { .. } | CatchRet { .. } | CleanupRet { .. } => {}
+        CatchPad { .. }
+        | CleanupPad { .. }
+        | CatchSwitch { .. }
+        | CatchRet { .. }
+        | CleanupRet { .. } => {}
     }
 }
 
@@ -748,7 +957,11 @@ fn lower_terminator(
             mf.push(mblock, MInstr::new(JAL).with_block(dest.0 as usize));
         }
 
-        CondBr { cond, then_dest, else_dest } => {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => {
             let c = resolve(ctx, mf, mblock, vmap, *cond);
             let pred_label = mf.blocks[mblock].label.clone();
             let then_edge = mf.add_block(format!("{}.then_edge", pred_label));
@@ -758,11 +971,22 @@ fn lower_terminator(
             emit_phi_copies(ctx, func, mf, mblock, else_edge, *else_dest, vmap);
             mf.push(else_edge, MInstr::new(JAL).with_block(else_dest.0 as usize));
             // if c == 0 goto else_edge else then_edge
-            mf.push(mblock, MInstr::new(BEQ).with_vreg(c).with_preg(X0).with_block(else_edge));
+            mf.push(
+                mblock,
+                MInstr::new(BEQ)
+                    .with_vreg(c)
+                    .with_preg(X0)
+                    .with_block(else_edge),
+            );
             mf.push(mblock, MInstr::new(JAL).with_block(then_edge));
         }
 
-        Invoke { callee, args, normal_dest, .. } => {
+        Invoke {
+            callee,
+            args,
+            normal_dest,
+            ..
+        } => {
             let arg_locs = classify_rv64_int_args(args.len());
             for (i, &arg_vref) in args.iter().enumerate() {
                 let src = resolve(ctx, mf, mblock, vmap, arg_vref);
@@ -784,12 +1008,22 @@ fn lower_terminator(
             mf.push(mblock, MInstr::new(JAL).with_block(normal_dest.0 as usize));
         }
 
-        Switch { val, default, cases } => {
+        Switch {
+            val,
+            default,
+            cases,
+        } => {
             let v = resolve(ctx, mf, mblock, vmap, *val);
             for (case_val, case_dest) in cases {
                 let cv = resolve(ctx, mf, mblock, vmap, *case_val);
                 emit_phi_copies(ctx, func, mf, mblock, mblock, *case_dest, vmap);
-                mf.push(mblock, MInstr::new(BEQ).with_vreg(v).with_vreg(cv).with_block(case_dest.0 as usize));
+                mf.push(
+                    mblock,
+                    MInstr::new(BEQ)
+                        .with_vreg(v)
+                        .with_vreg(cv)
+                        .with_block(case_dest.0 as usize),
+                );
             }
             emit_phi_copies(ctx, func, mf, mblock, mblock, *default, vmap);
             mf.push(mblock, MInstr::new(JAL).with_block(default.0 as usize));
@@ -801,7 +1035,9 @@ fn lower_terminator(
         Resume { .. } => mf.push(mblock, MInstr::new(NOP)),
 
         // CatchSwitch — lower first handler as unconditional branch (stub).
-        CatchSwitch { handlers, default, .. } => {
+        CatchSwitch {
+            handlers, default, ..
+        } => {
             if let Some(&h) = handlers.first() {
                 mf.push(mblock, MInstr::new(JAL).with_block(h.0 as usize));
             } else if let Some(d) = default {
@@ -849,7 +1085,10 @@ fn emit_phi_copies(
                     None => continue,
                 };
                 let src_vreg = resolve(ctx, mf, emit_to_mblock, vmap, *incoming_val);
-                mf.push(emit_to_mblock, MInstr::new(MOV_RR).with_dst(phi_vreg).with_vreg(src_vreg));
+                mf.push(
+                    emit_to_mblock,
+                    MInstr::new(MOV_RR).with_dst(phi_vreg).with_vreg(src_vreg),
+                );
             }
         }
     }
@@ -875,7 +1114,14 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("m");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function("decl", b.ctx.i64_ty, vec![], vec![], true, Linkage::External);
+        b.add_function(
+            "decl",
+            b.ctx.i64_ty,
+            vec![],
+            vec![],
+            true,
+            Linkage::External,
+        );
         let f = &module.functions[0];
         let mut be = RiscVBackend;
         let mf = be.lower_function(&ctx, &module, f);
@@ -1006,7 +1252,10 @@ entry:
             .iter()
             .flat_map(|b| b.instrs.iter())
             .any(|i| i.opcode == AMOADD_D);
-        assert!(has_amoadd_d, "expected AMOADD_D in lowered atomicrmw add i64");
+        assert!(
+            has_amoadd_d,
+            "expected AMOADD_D in lowered atomicrmw add i64"
+        );
     }
 
     #[test]
@@ -1026,7 +1275,10 @@ entry:
             .iter()
             .flat_map(|b| b.instrs.iter())
             .any(|i| i.opcode == AMOSWAP_W);
-        assert!(has_amoswap, "expected AMOSWAP_W in lowered atomicrmw xchg i32");
+        assert!(
+            has_amoswap,
+            "expected AMOSWAP_W in lowered atomicrmw xchg i32"
+        );
     }
 
     #[test]

--- a/src/llvm-target-riscv/src/regs.rs
+++ b/src/llvm-target-riscv/src/regs.rs
@@ -90,25 +90,25 @@ pub fn reg_enc(r: PReg) -> u8 {
 // ── F/D extension floating-point registers (F0-F31 = PReg(32)-PReg(63)) ────
 
 /// Public API for `F0` (ft0).
-pub const F0:  PReg = PReg(32);
+pub const F0: PReg = PReg(32);
 /// Public API for `F1` (ft1).
-pub const F1:  PReg = PReg(33);
+pub const F1: PReg = PReg(33);
 /// Public API for `F2` (ft2).
-pub const F2:  PReg = PReg(34);
+pub const F2: PReg = PReg(34);
 /// Public API for `F3` (ft3).
-pub const F3:  PReg = PReg(35);
+pub const F3: PReg = PReg(35);
 /// Public API for `F4` (ft4).
-pub const F4:  PReg = PReg(36);
+pub const F4: PReg = PReg(36);
 /// Public API for `F5` (ft5).
-pub const F5:  PReg = PReg(37);
+pub const F5: PReg = PReg(37);
 /// Public API for `F6` (ft6).
-pub const F6:  PReg = PReg(38);
+pub const F6: PReg = PReg(38);
 /// Public API for `F7` (ft7).
-pub const F7:  PReg = PReg(39);
+pub const F7: PReg = PReg(39);
 /// Public API for `F8` (fs0).
-pub const F8:  PReg = PReg(40);
+pub const F8: PReg = PReg(40);
 /// Public API for `F9` (fs1).
-pub const F9:  PReg = PReg(41);
+pub const F9: PReg = PReg(41);
 /// Public API for `F10` (fa0).
 pub const F10: PReg = PReg(42);
 /// Public API for `F11` (fa1).
@@ -169,9 +169,9 @@ pub const FP_CALLEE_SAVED: &[PReg] = &[F8, F9, F18, F19, F20, F21, F22, F23, F24
 /// ft8-ft11 (F28-F31, caller-saved temporaries).
 /// fs0-fs11 (F8-F9, F18-F27) are callee-saved and included for completeness.
 pub const FP_ALLOCATABLE: &[PReg] = &[
-    F0, F1, F2, F3, F4, F5, F6, F7,     // ft0-ft7 (caller-saved temporaries)
+    F0, F1, F2, F3, F4, F5, F6, F7, // ft0-ft7 (caller-saved temporaries)
     F10, F11, F12, F13, F14, F15, F16, F17, // fa0-fa7 (caller-saved args)
-    F28, F29, F30, F31,                   // ft8-ft11 (caller-saved temporaries)
+    F28, F29, F30, F31, // ft8-ft11 (caller-saved temporaries)
     F8, F9, F18, F19, F20, F21, F22, F23, F24, F25, F26, F27, // fs0-fs11 (callee-saved)
 ];
 

--- a/src/llvm-target-riscv/tests/e2e_objdump.rs
+++ b/src/llvm-target-riscv/tests/e2e_objdump.rs
@@ -14,19 +14,15 @@ use llvm_transforms::{pass::PassManager, DeadCodeElim, Mem2Reg};
 const SAMPLE_LL: &str = include_str!("../../llvm-bench/fixtures/sample.ll");
 
 fn find_objdump() -> Option<PathBuf> {
-    [
-        "riscv64-linux-gnu-objdump",
-        "llvm-objdump",
-        "objdump",
-    ]
-    .iter()
-    .find_map(|name| {
-        Command::new(name)
-            .arg("--version")
-            .output()
-            .ok()
-            .map(|_| PathBuf::from(name))
-    })
+    ["riscv64-linux-gnu-objdump", "llvm-objdump", "objdump"]
+        .iter()
+        .find_map(|name| {
+            Command::new(name)
+                .arg("--version")
+                .output()
+                .ok()
+                .map(|_| PathBuf::from(name))
+        })
 }
 
 #[test]

--- a/src/llvm-target-wasm/src/encode.rs
+++ b/src/llvm-target-wasm/src/encode.rs
@@ -204,11 +204,7 @@ fn encode_functype(buf: &mut Vec<u8>, params: &[u8], results: &[u8]) {
 /// The functions are expected to come from `WasmBackend::lower_module`.
 /// Each function in the list that corresponds to a non-declaration IR
 /// function will be placed in the type/function/export/code sections.
-pub fn assemble_module(
-    ctx: &Context,
-    module: &Module,
-    wasm_functions: &[WasmFunction],
-) -> Vec<u8> {
+pub fn assemble_module(ctx: &Context, module: &Module, wasm_functions: &[WasmFunction]) -> Vec<u8> {
     // ── magic + version ───────────────────────────────────────────────────
     let mut out: Vec<u8> = Vec::new();
     out.extend_from_slice(b"\0asm");

--- a/src/llvm-target-wasm/src/lib.rs
+++ b/src/llvm-target-wasm/src/lib.rs
@@ -34,11 +34,7 @@ use lower::WasmFunction;
 
 /// Assemble a complete WebAssembly binary from the given `WasmFunction` list
 /// and the IR context/module (needed for type-section construction).
-pub fn assemble_module(
-    ctx: &Context,
-    module: &Module,
-    wasm_functions: &[WasmFunction],
-) -> Vec<u8> {
+pub fn assemble_module(ctx: &Context, module: &Module, wasm_functions: &[WasmFunction]) -> Vec<u8> {
     encode::assemble_module(ctx, module, wasm_functions)
 }
 
@@ -104,18 +100,19 @@ mod tests {
             "binary must contain i32.const (0x41)"
         );
         // 42 in LEB128 is just 0x2A.
-        assert!(bytes.contains(&0x2A), "binary must contain LEB128 of 42 (0x2A)");
+        assert!(
+            bytes.contains(&0x2A),
+            "binary must contain LEB128 of 42 (0x2A)"
+        );
     }
 
     #[test]
     fn wasm_add_two_ints() {
-        let ir = "define i32 @add(i32 %a, i32 %b) {\nentry:\n  %r = add i32 %a, %b\n  ret i32 %r\n}";
+        let ir =
+            "define i32 @add(i32 %a, i32 %b) {\nentry:\n  %r = add i32 %a, %b\n  ret i32 %r\n}";
         let bytes = compile_to_wasm(ir).expect("compile");
         // Must contain i32.add (0x6A).
-        assert!(
-            bytes.contains(&0x6A),
-            "binary must contain i32.add (0x6A)"
-        );
+        assert!(bytes.contains(&0x6A), "binary must contain i32.add (0x6A)");
     }
 
     #[test]

--- a/src/llvm-target-wasm/src/lower.rs
+++ b/src/llvm-target-wasm/src/lower.rs
@@ -12,7 +12,7 @@ use crate::encode::{
 };
 use crate::instructions::*;
 use crate::types::{ir_ty_to_valtype, is_i64_type, VALTYPE_I32};
-use llvm_codegen::isel::{IselBackend, MachineFunction, MOpcode};
+use llvm_codegen::isel::{IselBackend, MOpcode, MachineFunction};
 use llvm_ir::{
     ArgId, BlockId, ConstantData, Context, Function, InstrId, InstrKind, IntPredicate, Module,
     TypeData, TypeId, ValueRef,
@@ -51,11 +51,7 @@ impl WasmBackend {
     }
 
     /// Lower all non-declaration functions in `module` to [`WasmFunction`]s.
-    pub fn lower_module(
-        &mut self,
-        ctx: &Context,
-        module: &Module,
-    ) -> Vec<WasmFunction> {
+    pub fn lower_module(&mut self, ctx: &Context, module: &Module) -> Vec<WasmFunction> {
         module
             .functions
             .iter()
@@ -108,9 +104,8 @@ fn lower_function_to_wasm(
     // indices in vmap but do not emit them in `local_types`.
     let n_args = func.args.len();
     for i in 0..n_args {
-        let vt = ir_ty_to_valtype(ctx, func.ty)
-            .unwrap_or(VALTYPE_I32); // fallback (won't be used for void)
-        // Use the actual argument type from the function type.
+        let vt = ir_ty_to_valtype(ctx, func.ty).unwrap_or(VALTYPE_I32); // fallback (won't be used for void)
+                                                                        // Use the actual argument type from the function type.
         let arg_vt = if let TypeData::Function(ft) = ctx.get_type(func.ty) {
             ft.params
                 .get(i)
@@ -160,7 +155,11 @@ fn lower_function_to_wasm(
                         is_loop_header[j] = true;
                     }
                 }
-                InstrKind::CondBr { then_dest, else_dest, .. } => {
+                InstrKind::CondBr {
+                    then_dest,
+                    else_dest,
+                    ..
+                } => {
                     for dest in [then_dest, else_dest] {
                         let j = block_index[dest];
                         if j <= i {
@@ -421,18 +420,10 @@ fn emit_instr(
             binop!(if is64 { WASM_I64_SHL } else { WASM_I32_SHL }, lhs, rhs);
         }
         LShr { lhs, rhs, .. } => {
-            binop!(
-                if is64 { WASM_I64_SHR_U } else { WASM_I32_SHR_U },
-                lhs,
-                rhs
-            );
+            binop!(if is64 { WASM_I64_SHR_U } else { WASM_I32_SHR_U }, lhs, rhs);
         }
         AShr { lhs, rhs, .. } => {
-            binop!(
-                if is64 { WASM_I64_SHR_S } else { WASM_I32_SHR_S },
-                lhs,
-                rhs
-            );
+            binop!(if is64 { WASM_I64_SHR_S } else { WASM_I32_SHR_S }, lhs, rhs);
         }
 
         // ── comparisons ───────────────────────────────────────────────────
@@ -513,7 +504,11 @@ fn emit_instr(
         }
 
         // ── select ────────────────────────────────────────────────────────
-        Select { cond, then_val, else_val } => {
+        Select {
+            cond,
+            then_val,
+            else_val,
+        } => {
             // Wasm doesn't have a direct select for arbitrary nesting here;
             // we use if/else.
             emit_value(ctx, vmap, code, *cond, false);
@@ -551,11 +546,15 @@ fn emit_instr(
                 _ => false,
             };
             emit_value(ctx, vmap, code, *val, store_is64);
-            let op = if store_is64 { WASM_I64_STORE } else { WASM_I32_STORE };
+            let op = if store_is64 {
+                WASM_I64_STORE
+            } else {
+                WASM_I32_STORE
+            };
             code.push(op.0 as u8);
             leb128_u(code, 2); // alignment hint
             leb128_u(code, 0); // memory offset
-            // Store is void — no local.set
+                               // Store is void — no local.set
         }
 
         // ── alloca (stub — wasm32 linear memory model) ───────────────────
@@ -605,7 +604,10 @@ fn emit_instr(
                 },
                 ValueRef::Global(gid) => {
                     // Look up by function index in the module.
-                    module.functions.get(gid.0 as usize).map(|f| f.name.as_str())
+                    module
+                        .functions
+                        .get(gid.0 as usize)
+                        .map(|f| f.name.as_str())
                 }
                 _ => None,
             };
@@ -727,7 +729,11 @@ fn emit_terminator(
             }
         }
 
-        CondBr { cond, then_dest, else_dest } => {
+        CondBr {
+            cond,
+            then_dest,
+            else_dest,
+        } => {
             let then_target = block_index[then_dest];
             let else_target = block_index[else_dest];
 
@@ -778,7 +784,11 @@ fn emit_terminator(
             }
         }
 
-        Switch { val, default, cases } => {
+        Switch {
+            val,
+            default,
+            cases,
+        } => {
             // TODO: implement switch via br_table.  For now: unconditional branch to default.
             let _ = (val, cases);
             let target = block_index[default];

--- a/src/llvm-target-wasm/src/reloop.rs
+++ b/src/llvm-target-wasm/src/reloop.rs
@@ -46,25 +46,26 @@ pub enum ControlNode {
 pub fn build_control_tree(func: &Function) -> ControlNode {
     if func.blocks.is_empty() {
         // Degenerate: return a sentinel node that callers can ignore.
-        return ControlNode::Simple { id: BlockId(0), next: None };
+        return ControlNode::Simple {
+            id: BlockId(0),
+            next: None,
+        };
     }
 
     // Step 1: compute RPO order (entry block first).
     let rpo = compute_rpo(func);
 
     // Step 2: build RPO-index map.
-    let rpo_index: HashMap<BlockId, usize> = rpo
-        .iter()
-        .enumerate()
-        .map(|(i, &b)| (b, i))
-        .collect();
+    let rpo_index: HashMap<BlockId, usize> = rpo.iter().enumerate().map(|(i, &b)| (b, i)).collect();
 
     // Step 3: detect which blocks are loop headers (back-edge targets).
     let loop_headers: HashSet<BlockId> = detect_loop_headers(func, &rpo_index);
 
     // Step 4: recursively build the tree over the RPO block sequence.
-    build_tree(func, &rpo, 0, &rpo_index, &loop_headers)
-        .unwrap_or(ControlNode::Simple { id: BlockId(0), next: None })
+    build_tree(func, &rpo, 0, &rpo_index, &loop_headers).unwrap_or(ControlNode::Simple {
+        id: BlockId(0),
+        next: None,
+    })
 }
 
 /// Returns `true` if a switch with the given case values should use a `br_table`
@@ -131,14 +132,13 @@ fn block_successors(func: &Function, bid: BlockId) -> Vec<BlockId> {
 
 /// Detect loop headers: a block H is a loop header iff there exists an edge
 /// A→H where `rpo_index[A] >= rpo_index[H]` (i.e. H appears earlier in RPO).
-fn detect_loop_headers(
-    func: &Function,
-    rpo_index: &HashMap<BlockId, usize>,
-) -> HashSet<BlockId> {
+fn detect_loop_headers(func: &Function, rpo_index: &HashMap<BlockId, usize>) -> HashSet<BlockId> {
     let mut headers = HashSet::new();
     for (i, bb) in func.blocks.iter().enumerate() {
         let src = BlockId(i as u32);
-        let Some(&src_rpo) = rpo_index.get(&src) else { continue };
+        let Some(&src_rpo) = rpo_index.get(&src) else {
+            continue;
+        };
         if let Some(tid) = bb.terminator {
             for dst in func.instr(tid).successors() {
                 if let Some(&dst_rpo) = rpo_index.get(&dst) {
@@ -249,7 +249,10 @@ fn build_tree(
 
         return Some(ControlNode::Loop {
             header: bid,
-            body: Box::new(body_node.unwrap_or(ControlNode::Simple { id: bid, next: None })),
+            body: Box::new(body_node.unwrap_or(ControlNode::Simple {
+                id: bid,
+                next: None,
+            })),
             next: next.map(Box::new),
         });
     }
@@ -298,13 +301,7 @@ fn build_tree(
             } else if then_start > else_start {
                 // else comes before then; then_start is join
                 // then branch is empty from else's perspective — emit a simple node
-                build_tree_over_slice(
-                    func,
-                    &rpo[then_start..],
-                    0,
-                    rpo_index,
-                    loop_headers,
-                )
+                build_tree_over_slice(func, &rpo[then_start..], 0, rpo_index, loop_headers)
             } else {
                 // Both branch to the same target — no then/else distinction.
                 None
@@ -319,13 +316,7 @@ fn build_tree(
                     loop_headers,
                 )
             } else if else_start > then_start {
-                build_tree_over_slice(
-                    func,
-                    &rpo[else_start..],
-                    0,
-                    rpo_index,
-                    loop_headers,
-                )
+                build_tree_over_slice(func, &rpo[else_start..], 0, rpo_index, loop_headers)
             } else {
                 None
             };
@@ -334,9 +325,10 @@ fn build_tree(
 
             return Some(ControlNode::Branch {
                 cond_block: bid,
-                then_node: Box::new(
-                    then_node.unwrap_or(ControlNode::Simple { id: then_dest, next: None }),
-                ),
+                then_node: Box::new(then_node.unwrap_or(ControlNode::Simple {
+                    id: then_dest,
+                    next: None,
+                })),
                 else_node: else_node.map(Box::new),
                 next: next.map(Box::new),
             });
@@ -378,14 +370,16 @@ fn build_tree_over_slice(
         let mut inner_headers = loop_headers.clone();
         inner_headers.remove(&bid);
 
-        let body_node =
-            build_tree_over_slice(func, &body_blocks, 0, rpo_index, &inner_headers);
+        let body_node = build_tree_over_slice(func, &body_blocks, 0, rpo_index, &inner_headers);
 
         let next = build_tree_over_slice(func, slice, after_loop, rpo_index, loop_headers);
 
         return Some(ControlNode::Loop {
             header: bid,
-            body: Box::new(body_node.unwrap_or(ControlNode::Simple { id: bid, next: None })),
+            body: Box::new(body_node.unwrap_or(ControlNode::Simple {
+                id: bid,
+                next: None,
+            })),
             next: next.map(Box::new),
         });
     }
@@ -424,10 +418,10 @@ fn build_tree_over_slice(
 
                 return Some(ControlNode::Branch {
                     cond_block: bid,
-                    then_node: Box::new(
-                        then_node
-                            .unwrap_or(ControlNode::Simple { id: then_dest, next: None }),
-                    ),
+                    then_node: Box::new(then_node.unwrap_or(ControlNode::Simple {
+                        id: then_dest,
+                        next: None,
+                    })),
                     else_node: else_node.map(Box::new),
                     next: next.map(Box::new),
                 });
@@ -472,7 +466,9 @@ mod tests {
             has_term[src] = true;
             let kind = match dsts {
                 [] => InstrKind::Unreachable,
-                [dst] => InstrKind::Br { dest: BlockId(*dst as u32) },
+                [dst] => InstrKind::Br {
+                    dest: BlockId(*dst as u32),
+                },
                 [t, f] => {
                     let cond = ValueRef::Constant(ctx.const_int(ctx.i1_ty, 0));
                     InstrKind::CondBr {
@@ -527,7 +523,12 @@ mod tests {
                     collect_variants_inner(n, out);
                 }
             }
-            ControlNode::Branch { then_node, else_node, next, .. } => {
+            ControlNode::Branch {
+                then_node,
+                else_node,
+                next,
+                ..
+            } => {
                 out.push("Branch");
                 collect_variants_inner(then_node, out);
                 if let Some(e) = else_node {
@@ -544,20 +545,35 @@ mod tests {
 
     fn has_loop_header(node: &ControlNode, header: BlockId) -> bool {
         match node {
-            ControlNode::Loop { header: h, body, next } => {
+            ControlNode::Loop {
+                header: h,
+                body,
+                next,
+            } => {
                 if *h == header {
                     return true;
                 }
                 has_loop_header(body, header)
-                    || next.as_deref().map_or(false, |n| has_loop_header(n, header))
+                    || next
+                        .as_deref()
+                        .map_or(false, |n| has_loop_header(n, header))
             }
-            ControlNode::Simple { next, .. } => {
-                next.as_deref().map_or(false, |n| has_loop_header(n, header))
-            }
-            ControlNode::Branch { then_node, else_node, next, .. } => {
+            ControlNode::Simple { next, .. } => next
+                .as_deref()
+                .map_or(false, |n| has_loop_header(n, header)),
+            ControlNode::Branch {
+                then_node,
+                else_node,
+                next,
+                ..
+            } => {
                 has_loop_header(then_node, header)
-                    || else_node.as_deref().map_or(false, |n| has_loop_header(n, header))
-                    || next.as_deref().map_or(false, |n| has_loop_header(n, header))
+                    || else_node
+                        .as_deref()
+                        .map_or(false, |n| has_loop_header(n, header))
+                    || next
+                        .as_deref()
+                        .map_or(false, |n| has_loop_header(n, header))
             }
         }
     }
@@ -566,20 +582,31 @@ mod tests {
 
     fn has_branch_at(node: &ControlNode, cond_block: BlockId) -> bool {
         match node {
-            ControlNode::Branch { cond_block: cb, then_node, else_node, next } => {
+            ControlNode::Branch {
+                cond_block: cb,
+                then_node,
+                else_node,
+                next,
+            } => {
                 if *cb == cond_block {
                     return true;
                 }
                 has_branch_at(then_node, cond_block)
-                    || else_node.as_deref().map_or(false, |n| has_branch_at(n, cond_block))
-                    || next.as_deref().map_or(false, |n| has_branch_at(n, cond_block))
+                    || else_node
+                        .as_deref()
+                        .map_or(false, |n| has_branch_at(n, cond_block))
+                    || next
+                        .as_deref()
+                        .map_or(false, |n| has_branch_at(n, cond_block))
             }
-            ControlNode::Simple { next, .. } => {
-                next.as_deref().map_or(false, |n| has_branch_at(n, cond_block))
-            }
+            ControlNode::Simple { next, .. } => next
+                .as_deref()
+                .map_or(false, |n| has_branch_at(n, cond_block)),
             ControlNode::Loop { body, next, .. } => {
                 has_branch_at(body, cond_block)
-                    || next.as_deref().map_or(false, |n| has_branch_at(n, cond_block))
+                    || next
+                        .as_deref()
+                        .map_or(false, |n| has_branch_at(n, cond_block))
             }
         }
     }
@@ -641,8 +668,7 @@ mod tests {
 
     #[test]
     fn if_else_detected_as_branch_node() {
-        let (_ctx, func) =
-            build_func(4, &[(0, &[1, 2]), (1, &[3]), (2, &[3]), (3, &[])]);
+        let (_ctx, func) = build_func(4, &[(0, &[1, 2]), (1, &[3]), (2, &[3]), (3, &[])]);
         let tree = build_control_tree(&func);
         assert!(
             has_branch_at(&tree, BlockId(0)),
@@ -657,10 +683,7 @@ mod tests {
 
     #[test]
     fn loop_with_exit_has_correct_structure() {
-        let (_ctx, func) = build_func(
-            4,
-            &[(0, &[1]), (1, &[2]), (2, &[1, 3]), (3, &[])],
-        );
+        let (_ctx, func) = build_func(4, &[(0, &[1]), (1, &[2]), (2, &[1, 3]), (3, &[])]);
         let tree = build_control_tree(&func);
         // Tree must contain a Loop node with header=1.
         assert!(
@@ -672,14 +695,20 @@ mod tests {
         fn has_simple_3(node: &ControlNode) -> bool {
             match node {
                 ControlNode::Simple { id, next } => {
-                    if *id == BlockId(3) { return true; }
+                    if *id == BlockId(3) {
+                        return true;
+                    }
                     next.as_deref().map_or(false, has_simple_3)
                 }
                 ControlNode::Loop { next, body, .. } => {
-                    has_simple_3(body)
-                        || next.as_deref().map_or(false, has_simple_3)
+                    has_simple_3(body) || next.as_deref().map_or(false, has_simple_3)
                 }
-                ControlNode::Branch { then_node, else_node, next, .. } => {
+                ControlNode::Branch {
+                    then_node,
+                    else_node,
+                    next,
+                    ..
+                } => {
                     has_simple_3(then_node)
                         || else_node.as_deref().map_or(false, has_simple_3)
                         || next.as_deref().map_or(false, has_simple_3)
@@ -700,10 +729,7 @@ mod tests {
 
     #[test]
     fn nested_loops_produce_nested_loop_nodes() {
-        let (_ctx, func) = build_func(
-            4,
-            &[(0, &[1]), (1, &[2]), (2, &[3]), (3, &[2, 1])],
-        );
+        let (_ctx, func) = build_func(4, &[(0, &[1]), (1, &[2]), (2, &[3]), (3, &[2, 1])]);
         let tree = build_control_tree(&func);
         // Must contain a Loop node at header 1 AND at header 2.
         assert!(

--- a/src/llvm-target-wasm/src/types.rs
+++ b/src/llvm-target-wasm/src/types.rs
@@ -47,4 +47,3 @@ pub fn ir_ty_to_valtype(ctx: &Context, ty: TypeId) -> Option<u8> {
 pub fn is_i64_type(ctx: &Context, ty: TypeId) -> bool {
     matches!(ctx.get_type(ty), TypeData::Integer(bits) if *bits > 32)
 }
-

--- a/src/llvm-target-x86/src/abi.rs
+++ b/src/llvm-target-x86/src/abi.rs
@@ -1,8 +1,8 @@
 //! x86_64 calling-convention support (System V AMD64 and Windows x64).
 
 use crate::regs::{
-    FP_ALLOCATABLE, R10, R11, R12, R13, R14, R15, R8, R9, RAX, RBP, RBX, RCX, RDI, RDX, RSI,
-    XMM0, XMM1, XMM2, XMM3,
+    FP_ALLOCATABLE, R10, R11, R12, R13, R14, R15, R8, R9, RAX, RBP, RBX, RCX, RDI, RDX, RSI, XMM0,
+    XMM1, XMM2, XMM3,
 };
 use llvm_codegen::isel::PReg;
 use llvm_ir::{Context, FloatKind, TypeData, TypeId};

--- a/src/llvm-target-x86/src/encode.rs
+++ b/src/llvm-target-x86/src/encode.rs
@@ -56,7 +56,11 @@ pub struct X86Emitter {
 impl X86Emitter {
     /// Create a new `X86Emitter` for the given object format.
     pub fn new(format: ObjectFormat) -> Self {
-        Self { format, cfi_section: None, lsda_section: None }
+        Self {
+            format,
+            cfi_section: None,
+            lsda_section: None,
+        }
     }
 
     /// Return and clear the CFI section bytes built during the last
@@ -96,7 +100,10 @@ impl Emitter for X86Emitter {
                 // After "push rbp" (1 byte): CFA = RSP+16, RBP saved at CFA-16.
                 CfiInstr::AdvanceLoc(1),
                 CfiInstr::DefCfaOffset(16),
-                CfiInstr::Offset { reg: 6, factored_offset: 2 },
+                CfiInstr::Offset {
+                    reg: 6,
+                    factored_offset: 2,
+                },
                 // After "mov rbp, rsp" (3 bytes): CFA register = RBP.
                 CfiInstr::AdvanceLoc(3),
                 CfiInstr::DefCfaRegister(6),
@@ -161,7 +168,7 @@ impl Emitter for X86Emitter {
                     ctx.emit64(sub_rsp as i64);
                     let call_site = ctx.pos();
                     ctx.emit(0xE8); // CALL rel32
-                    // rel32 placeholder — filled by linker via IMAGE_REL_AMD64_REL32
+                                    // rel32 placeholder — filled by linker via IMAGE_REL_AMD64_REL32
                     ctx.emit32(0);
                     ctx.relocs.push(Reloc {
                         offset: (call_site + 1) as u64,
@@ -1017,13 +1024,14 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         // Layout: RBP - callee_save_bytes - (slot_idx+1)*8
         // Encoding: REX.W 8D /r ModRM(mod=10, reg=dst, rm=5=RBP) disp32
         LEA_FRAME_MR => {
-            if let (Some(dst), Some(MOperand::Imm(slot_idx))) = (instr.dst, instr.operands.first()) {
+            if let (Some(dst), Some(MOperand::Imm(slot_idx))) = (instr.dst, instr.operands.first())
+            {
                 let dst_r = PReg(dst.0 as u8);
                 let disp = -((ctx.callee_save_bytes as i32) + (*slot_idx as i32 + 1) * 8);
                 let rex = 0x48 | (if is_extended(dst_r) { 0x04 } else { 0 });
                 ctx.emit(rex);
                 ctx.emit(0x8D); // LEA r64, m
-                // ModRM: mod=10 (disp32), reg=dst_enc, rm=5 (RBP)
+                                // ModRM: mod=10 (disp32), reg=dst_enc, rm=5 (RBP)
                 ctx.emit(0x80 | (reg_enc(dst_r) << 3) | 5);
                 ctx.emit32(disp);
             } else {
@@ -1059,35 +1067,35 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
         }
 
         // ── SSE2 scalar double: 66 0F <op> /r ─────────────────────────────
-        ADDSD_RR  => emit_sse2_rr(ctx, instr, 0x66, 0x58),
-        SUBSD_RR  => emit_sse2_rr(ctx, instr, 0x66, 0x5C),
-        MULSD_RR  => emit_sse2_rr(ctx, instr, 0x66, 0x59),
-        DIVSD_RR  => emit_sse2_rr(ctx, instr, 0x66, 0x5E),
-        SQRTSD_R  => emit_sse2_rr(ctx, instr, 0x66, 0x51),
+        ADDSD_RR => emit_sse2_rr(ctx, instr, 0x66, 0x58),
+        SUBSD_RR => emit_sse2_rr(ctx, instr, 0x66, 0x5C),
+        MULSD_RR => emit_sse2_rr(ctx, instr, 0x66, 0x59),
+        DIVSD_RR => emit_sse2_rr(ctx, instr, 0x66, 0x5E),
+        SQRTSD_R => emit_sse2_rr(ctx, instr, 0x66, 0x51),
         UCOMISD_RR => emit_sse2_cmp(ctx, instr, 0x66, 0x2E),
         MOVAPD_RR | MOVAPD_RR_F32 => emit_sse2_rr(ctx, instr, 0x66, 0x28),
 
         // ── SSE2 scalar single: F3 0F <op> /r ─────────────────────────────
-        ADDSS_RR  => emit_sse2_rr(ctx, instr, 0xF3, 0x58),
-        SUBSS_RR  => emit_sse2_rr(ctx, instr, 0xF3, 0x5C),
-        MULSS_RR  => emit_sse2_rr(ctx, instr, 0xF3, 0x59),
-        DIVSS_RR  => emit_sse2_rr(ctx, instr, 0xF3, 0x5E),
-        SQRTSS_R  => emit_sse2_rr(ctx, instr, 0xF3, 0x51),
+        ADDSS_RR => emit_sse2_rr(ctx, instr, 0xF3, 0x58),
+        SUBSS_RR => emit_sse2_rr(ctx, instr, 0xF3, 0x5C),
+        MULSS_RR => emit_sse2_rr(ctx, instr, 0xF3, 0x59),
+        DIVSS_RR => emit_sse2_rr(ctx, instr, 0xF3, 0x5E),
+        SQRTSS_R => emit_sse2_rr(ctx, instr, 0xF3, 0x51),
         UCOMISS_RR => emit_sse2_cmp(ctx, instr, 0x00, 0x2E), // no mandatory prefix for SSE UCOMISS
-        MOVSS_LOAD_MR  => emit_sse2_spill_load(ctx, instr, 0xF3, 0x10),
+        MOVSS_LOAD_MR => emit_sse2_spill_load(ctx, instr, 0xF3, 0x10),
         MOVSS_STORE_RM => emit_sse2_spill_store(ctx, instr, 0xF3, 0x11),
 
         // ── FP spill load/store: F2 0F 10/11 [rbp+disp32] ─────────────────
-        MOVSD_LOAD_MR  => emit_sse2_spill_load(ctx, instr, 0xF2, 0x10),
+        MOVSD_LOAD_MR => emit_sse2_spill_load(ctx, instr, 0xF2, 0x10),
         MOVSD_STORE_RM => emit_sse2_spill_store(ctx, instr, 0xF2, 0x11),
 
         // ── FP ↔ int conversions ──────────────────────────────────────────
         CVTTSD2SI_RR => emit_cvt_xmm_to_gpr(ctx, instr, 0xF2, 0x2C),
-        CVTSI2SD_RR  => emit_cvt_gpr_to_xmm(ctx, instr, 0xF2, 0x2A),
+        CVTSI2SD_RR => emit_cvt_gpr_to_xmm(ctx, instr, 0xF2, 0x2A),
         CVTTSS2SI_RR => emit_cvt_xmm_to_gpr(ctx, instr, 0xF3, 0x2C),
-        CVTSI2SS_RR  => emit_cvt_gpr_to_xmm(ctx, instr, 0xF3, 0x2A),
-        CVTSD2SS_RR  => emit_sse2_rr(ctx, instr, 0xF2, 0x5A),
-        CVTSS2SD_RR  => emit_sse2_rr(ctx, instr, 0xF3, 0x5A),
+        CVTSI2SS_RR => emit_cvt_gpr_to_xmm(ctx, instr, 0xF3, 0x2A),
+        CVTSD2SS_RR => emit_sse2_rr(ctx, instr, 0xF2, 0x5A),
+        CVTSS2SD_RR => emit_sse2_rr(ctx, instr, 0xF3, 0x5A),
 
         // ── unsupported: emit NOP ─────────────────────────────────────────
         _ => {
@@ -1101,9 +1109,8 @@ fn encode_instr(instr: &MInstr, ctx: &mut EncodeCtx) {
 /// Emit a REX byte for XMM ← XMM operations when extended registers are used.
 /// REX.R = dst XMM8-15; REX.B = src XMM8-15.  No REX.W for SSE2 scalar ops.
 fn xmm_rex(ctx: &mut EncodeCtx, dst_enc: u8, src_enc: u8) {
-    let rex = 0x40u8
-        | (if dst_enc >= 8 { 0x04 } else { 0 })
-        | (if src_enc >= 8 { 0x01 } else { 0 });
+    let rex =
+        0x40u8 | (if dst_enc >= 8 { 0x04 } else { 0 }) | (if src_enc >= 8 { 0x01 } else { 0 });
     if rex != 0x40 {
         ctx.emit(rex);
     }
@@ -1930,7 +1937,14 @@ mod tests {
             RegAllocStrategy::LinearScan,
         );
         assert!(!result.spilled.is_empty(), "must have spills");
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
 
         let mut e = X86Emitter::new(ObjectFormat::Elf);
@@ -1988,16 +2002,22 @@ mod tests {
             "missing: mov rax, 8192"
         );
         assert!(
-            sec.data.windows(call_chkstk.len()).any(|w| w == call_chkstk),
+            sec.data
+                .windows(call_chkstk.len())
+                .any(|w| w == call_chkstk),
             "missing: call __chkstk placeholder"
         );
         assert!(
-            sec.data.windows(sub_rsp_rax.len()).any(|w| w == sub_rsp_rax),
+            sec.data
+                .windows(sub_rsp_rax.len())
+                .any(|w| w == sub_rsp_rax),
             "missing: sub rsp, rax"
         );
         // Must have a reloc for the __chkstk call
         assert!(
-            sec.relocs.iter().any(|r| r.external_name.as_deref() == Some("__chkstk")),
+            sec.relocs
+                .iter()
+                .any(|r| r.external_name.as_deref() == Some("__chkstk")),
             "missing __chkstk reloc"
         );
     }
@@ -2033,11 +2053,15 @@ mod tests {
         // sub rsp, 8192 (imm32 form): 48 81 EC 00 20 00 00
         let sub_rsp_imm32: &[u8] = &[0x48, 0x81, 0xEC, 0x00, 0x20, 0x00, 0x00];
         assert!(
-            sec.data.windows(sub_rsp_imm32.len()).any(|w| w == sub_rsp_imm32),
+            sec.data
+                .windows(sub_rsp_imm32.len())
+                .any(|w| w == sub_rsp_imm32),
             "ELF large frame must use sub rsp, imm32 (not __chkstk)"
         );
         assert!(
-            !sec.relocs.iter().any(|r| r.external_name.as_deref() == Some("__chkstk")),
+            !sec.relocs
+                .iter()
+                .any(|r| r.external_name.as_deref() == Some("__chkstk")),
             "ELF must not emit __chkstk reloc"
         );
     }
@@ -2060,7 +2084,11 @@ mod tests {
         let mi = MInstr {
             opcode: LOCK_CMPXCHG_MR,
             dst: None,
-            operands: vec![MOperand::PReg(RCX), MOperand::PReg(RAX), MOperand::PReg(RDX)],
+            operands: vec![
+                MOperand::PReg(RCX),
+                MOperand::PReg(RAX),
+                MOperand::PReg(RDX),
+            ],
             phys_uses: vec![],
             clobbers: vec![],
             debug_loc: None,
@@ -2073,7 +2101,10 @@ mod tests {
         assert_eq!(sec.data[1], 0x48, "REX.W");
         assert_eq!(sec.data[2], 0x0F, "escape byte");
         assert_eq!(sec.data[3], 0xB1, "CMPXCHG opcode");
-        assert_eq!(sec.data[4], 0x11, "ModRM(00 010 001): mod=00 reg=RDX rm=RCX");
+        assert_eq!(
+            sec.data[4], 0x11,
+            "ModRM(00 010 001): mod=00 reg=RDX rm=RCX"
+        );
     }
 
     #[test]
@@ -2097,7 +2128,10 @@ mod tests {
         assert_eq!(sec.data[1], 0x48, "REX.W");
         assert_eq!(sec.data[2], 0x0F);
         assert_eq!(sec.data[3], 0xC1, "XADD opcode");
-        assert_eq!(sec.data[4], 0x37, "ModRM(00 110 111): mod=00 reg=RSI rm=RDI");
+        assert_eq!(
+            sec.data[4], 0x37,
+            "ModRM(00 110 111): mod=00 reg=RSI rm=RDI"
+        );
     }
 
     #[test]
@@ -2118,7 +2152,10 @@ mod tests {
         // 48, 87, ModRM(00 000 111) = 0x07
         assert_eq!(sec.data[0], 0x48, "REX.W");
         assert_eq!(sec.data[1], 0x87, "XCHG opcode");
-        assert_eq!(sec.data[2], 0x07, "ModRM(00 000 111): mod=00 reg=RAX rm=RDI");
+        assert_eq!(
+            sec.data[2], 0x07,
+            "ModRM(00 000 111): mod=00 reg=RAX rm=RDI"
+        );
     }
 
     #[test]
@@ -2225,7 +2262,10 @@ mod tests {
         assert_eq!(sec.data[0], 0xF0, "LOCK prefix");
         assert_eq!(sec.data[1], 0x48, "REX.W");
         assert_eq!(sec.data[2], 0x21, "AND opcode");
-        assert_eq!(sec.data[3], 0x75, "ModRM(01 110 101): mod=01 reg=RSI rm=RBP");
+        assert_eq!(
+            sec.data[3], 0x75,
+            "ModRM(01 110 101): mod=01 reg=RSI rm=RBP"
+        );
         assert_eq!(sec.data[4], 0x00, "disp8=0 for mod=01 RBP base");
     }
 

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -16,9 +16,8 @@ use llvm_codegen::isel::{
 use llvm_codegen::lsda::CallSiteRecord;
 use llvm_codegen::sizeof_ty;
 use llvm_ir::{
-    ArgId, BlockId, ConstantData, Context, FloatKind, FloatPredicate, Function, InstrId,
-    InstrKind, InstrprofIntrinsic, IntPredicate, Module, TailCallKind, TypeData, ValueRef,
-    VpIntrinsic,
+    ArgId, BlockId, ConstantData, Context, FloatKind, FloatPredicate, Function, InstrId, InstrKind,
+    InstrprofIntrinsic, IntPredicate, Module, TailCallKind, TypeData, ValueRef, VpIntrinsic,
 };
 use std::collections::HashMap;
 
@@ -161,11 +160,7 @@ impl IselBackend for X86Backend {
         }
 
         // Lower function arguments: copy from ABI registers into VRegs.
-        let is_fp_arg: Vec<bool> = func
-            .args
-            .iter()
-            .map(|a| is_fp_type(ctx, a.ty))
-            .collect();
+        let is_fp_arg: Vec<bool> = func.args.iter().map(|a| is_fp_type(ctx, a.ty)).collect();
         let arg_locs = cc.classify_args_typed(&is_fp_arg);
         for (i, _arg) in func.args.iter().enumerate() {
             let vr = if is_fp_arg[i] {
@@ -373,9 +368,15 @@ fn vector_fp_opcode(
         (TypeData::Float(FloatKind::Single), 8, VecFpOp::Add) if features.avx2 => Some(ADDPS_RR),
         (TypeData::Float(FloatKind::Single), 8, VecFpOp::Mul) if features.avx2 => Some(MULPS_RR),
         (TypeData::Float(FloatKind::Single), 8, VecFpOp::Div) if features.avx2 => Some(DIVPS_RR),
-        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Add) if features.avx512f => Some(ADDPS_RR),
-        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Mul) if features.avx512f => Some(MULPS_RR),
-        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Div) if features.avx512f => Some(DIVPS_RR),
+        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Add) if features.avx512f => {
+            Some(ADDPS_RR)
+        }
+        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Mul) if features.avx512f => {
+            Some(MULPS_RR)
+        }
+        (TypeData::Float(FloatKind::Single), 16, VecFpOp::Div) if features.avx512f => {
+            Some(DIVPS_RR)
+        }
 
         // f64 vectors: 128/256/512-bit lanes gate on SSE4.2/AVX2/AVX-512F.
         (TypeData::Float(FloatKind::Double), 2, VecFpOp::Add) if features.sse42 => Some(ADDPD_RR),
@@ -421,7 +422,11 @@ fn is_double(ctx: &Context, ty: llvm_ir::TypeId) -> bool {
 /// Return the SSE2 scalar binary opcode for the given FP type.
 /// Returns `(double_op, single_op)` and the caller picks by `is_double`.
 fn fp_binop(ctx: &Context, ty: llvm_ir::TypeId, sd_op: MOpcode, ss_op: MOpcode) -> MOpcode {
-    if is_double(ctx, ty) { sd_op } else { ss_op }
+    if is_double(ctx, ty) {
+        sd_op
+    } else {
+        ss_op
+    }
 }
 
 /// Resolve a constant FP value to the raw bit pattern stored in a fresh VReg.
@@ -448,7 +453,10 @@ fn resolve_fp(
             // correctness of arithmetic operations on FP variables).
             let bits_vreg = mf.fresh_vreg(); // int vreg for the raw bits
             let imm = const_to_imm(ctx.get_const(cid));
-            mf.push(mblock, MInstr::new(MOV_RI).with_dst(bits_vreg).with_imm(imm));
+            mf.push(
+                mblock,
+                MInstr::new(MOV_RI).with_dst(bits_vreg).with_imm(imm),
+            );
             // Convert the raw integer bits to float VReg via CVTSI2SD.
             // (Note: this converts the integer *value* not the bit pattern,
             // so a constant `1.0` stored as 0x3FF0000000000000 bits would
@@ -456,7 +464,10 @@ fn resolve_fp(
             // via rodata is deferred — for now zero is safe for the smoke tests
             // which only test arithmetic on function arguments.)
             let dst = mf.fresh_float_vreg();
-            mf.push(mblock, MInstr::new(CVTSI2SD_RR).with_dst(dst).with_vreg(bits_vreg));
+            mf.push(
+                mblock,
+                MInstr::new(CVTSI2SD_RR).with_dst(dst).with_vreg(bits_vreg),
+            );
             dst
         }
         _ => {
@@ -622,12 +633,24 @@ fn lower_instr(
                 let dst = new_dst!();
                 let l = res!(*lhs);
                 mf.push(mblock, MInstr::new(MOV_RR).with_dst(dst).with_vreg(l));
-                mf.push(mblock, MInstr::new(IMUL_RRI).with_dst(dst).with_vreg(dst).with_imm(k));
+                mf.push(
+                    mblock,
+                    MInstr::new(IMUL_RRI)
+                        .with_dst(dst)
+                        .with_vreg(dst)
+                        .with_imm(k),
+                );
             } else if let Some(k) = const_i64(ctx, *lhs).filter(|v| i32::try_from(*v).is_ok()) {
                 let dst = new_dst!();
                 let r = res!(*rhs);
                 mf.push(mblock, MInstr::new(MOV_RR).with_dst(dst).with_vreg(r));
-                mf.push(mblock, MInstr::new(IMUL_RRI).with_dst(dst).with_vreg(dst).with_imm(k));
+                mf.push(
+                    mblock,
+                    MInstr::new(IMUL_RRI)
+                        .with_dst(dst)
+                        .with_vreg(dst)
+                        .with_imm(k),
+                );
             } else {
                 emit_binop!(IMUL_RR, *lhs, *rhs);
             }
@@ -739,7 +762,11 @@ fn lower_instr(
             let l = res_fp!(*lhs);
             let r = res_fp!(*rhs);
             let op_ty = func.type_of_value(*lhs).unwrap_or(instr.ty);
-            let ucomi_op = if is_double(ctx, op_ty) { UCOMISD_RR } else { UCOMISS_RR };
+            let ucomi_op = if is_double(ctx, op_ty) {
+                UCOMISD_RR
+            } else {
+                UCOMISS_RR
+            };
             mf.push(mblock, MInstr::new(ucomi_op).with_vreg(l).with_vreg(r));
             let cc = match pred {
                 FloatPredicate::Oeq | FloatPredicate::Ueq => CC_EQ,
@@ -836,21 +863,31 @@ fn lower_instr(
             // f64 → f32
             let dst = new_dst_float!();
             let src = res_fp!(*val);
-            mf.push(mblock, MInstr::new(CVTSD2SS_RR).with_dst(dst).with_vreg(src));
+            mf.push(
+                mblock,
+                MInstr::new(CVTSD2SS_RR).with_dst(dst).with_vreg(src),
+            );
         }
 
         FPExt { val, .. } => {
             // f32 → f64
             let dst = new_dst_float!();
             let src = res_fp!(*val);
-            mf.push(mblock, MInstr::new(CVTSS2SD_RR).with_dst(dst).with_vreg(src));
+            mf.push(
+                mblock,
+                MInstr::new(CVTSS2SD_RR).with_dst(dst).with_vreg(src),
+            );
         }
 
         FPToSI { val, .. } => {
             let dst = new_dst!();
             let src_ty = func.type_of_value(*val).unwrap_or(instr.ty);
             let src = res_fp!(*val);
-            let op = if is_double(ctx, src_ty) { CVTTSD2SI_RR } else { CVTTSS2SI_RR };
+            let op = if is_double(ctx, src_ty) {
+                CVTTSD2SI_RR
+            } else {
+                CVTTSS2SI_RR
+            };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
 
@@ -860,14 +897,22 @@ fn lower_instr(
             let dst = new_dst!();
             let src_ty = func.type_of_value(*val).unwrap_or(instr.ty);
             let src = res_fp!(*val);
-            let op = if is_double(ctx, src_ty) { CVTTSD2SI_RR } else { CVTTSS2SI_RR };
+            let op = if is_double(ctx, src_ty) {
+                CVTTSD2SI_RR
+            } else {
+                CVTTSS2SI_RR
+            };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
 
         SIToFP { val, .. } => {
             let dst = new_dst_float!();
             let src = res!(*val);
-            let op = if is_double(ctx, instr.ty) { CVTSI2SD_RR } else { CVTSI2SS_RR };
+            let op = if is_double(ctx, instr.ty) {
+                CVTSI2SD_RR
+            } else {
+                CVTSI2SS_RR
+            };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
 
@@ -875,7 +920,11 @@ fn lower_instr(
             // No direct CVTSI2SD for unsigned; use signed (correct for [0, INT64_MAX]).
             let dst = new_dst_float!();
             let src = res!(*val);
-            let op = if is_double(ctx, instr.ty) { CVTSI2SD_RR } else { CVTSI2SS_RR };
+            let op = if is_double(ctx, instr.ty) {
+                CVTSI2SD_RR
+            } else {
+                CVTSI2SS_RR
+            };
             mf.push(mblock, MInstr::new(op).with_dst(dst).with_vreg(src));
         }
 
@@ -901,7 +950,9 @@ fn lower_instr(
         }
 
         // ── calls ──────────────────────────────────────────────────────────
-        Call { callee, args, tail, .. } => {
+        Call {
+            callee, args, tail, ..
+        } => {
             if let Some(ip) = instrprof_from_callee(ctx, *callee) {
                 eprintln!(
                     "warning: PGO intrinsic {} elided — counter emission not implemented",
@@ -1025,7 +1076,10 @@ fn lower_instr(
                     let dst = new_dst!();
                     // Placeholder: result formally exists but the JMP means we
                     // never actually read it; DCE will clean this up.
-                    mf.push(mblock, MInstr::new(MOV_RR).with_dst(dst).with_vreg(callee_vr));
+                    mf.push(
+                        mblock,
+                        MInstr::new(MOV_RR).with_dst(dst).with_vreg(callee_vr),
+                    );
                 }
             } else {
                 let mut call_mi = MInstr::new(CALL_R).with_vreg(callee_vr);
@@ -1043,7 +1097,9 @@ fn lower_instr(
             }
         }
 
-        InlineAsm { asm_string, args, .. } => {
+        InlineAsm {
+            asm_string, args, ..
+        } => {
             for &arg in args {
                 let _ = res!(arg);
             }
@@ -1059,7 +1115,9 @@ fn lower_instr(
         Fence { .. } => {
             mf.push(mblock, MInstr::new(MFENCE));
         }
-        CmpXchg { ptr, cmp, new_val, .. } => {
+        CmpXchg {
+            ptr, cmp, new_val, ..
+        } => {
             let ptr_vr = res!(*ptr);
             let cmp_vr = res!(*cmp);
             let new_vr = res!(*new_val);
@@ -1085,7 +1143,11 @@ fn lower_instr(
             let is_64bit = instr.ty == ctx.i64_ty;
             let (opcode, result_in_val) = match op {
                 RmwOp::Add | RmwOp::Sub => {
-                    if is_64bit { (LOCK_XADD_MR, true) } else { (LOCK_XADD32_MR, true) }
+                    if is_64bit {
+                        (LOCK_XADD_MR, true)
+                    } else {
+                        (LOCK_XADD32_MR, true)
+                    }
                 }
                 RmwOp::Xchg => (XCHG_MR, true),
                 RmwOp::And | RmwOp::Nand => (LOCK_AND_MR, false),
@@ -1124,7 +1186,9 @@ fn lower_instr(
         // ── memory: non-promotable alloca/load/store (SP-relative frame slots) ──
         // mem2reg eliminates promotable alloca/load/store; anything remaining here
         // is non-promotable (address escapes to a callee or non-constant GEP index).
-        Alloca { alloc_ty, align, .. } => {
+        Alloca {
+            alloc_ty, align, ..
+        } => {
             let dst = new_dst!();
             let size_bytes = sizeof_ty(ctx, *alloc_ty) as u32;
             let align_bytes = align.unwrap_or(8);
@@ -1180,7 +1244,9 @@ fn lower_instr(
             let ptr_vr = res!(*ptr);
             mf.push(
                 mblock,
-                MInstr::new(MOV_STORE_REG_RM).with_vreg(ptr_vr).with_vreg(src),
+                MInstr::new(MOV_STORE_REG_RM)
+                    .with_vreg(ptr_vr)
+                    .with_vreg(src),
             );
         }
 
@@ -1242,7 +1308,10 @@ fn lower_instr(
                 let zero = mf.fresh_float_vreg();
                 let zero_bits = mf.fresh_vreg();
                 mf.push(mblock, MInstr::new(MOV_RI).with_dst(zero_bits).with_imm(0));
-                mf.push(mblock, MInstr::new(CVTSI2SD_RR).with_dst(zero).with_vreg(zero_bits));
+                mf.push(
+                    mblock,
+                    MInstr::new(CVTSI2SD_RR).with_dst(zero).with_vreg(zero_bits),
+                );
                 let src = res_fp!(*operand);
                 let dst = new_dst_float!();
                 let op = fp_binop(ctx, instr.ty, SUBSD_RR, SUBSS_RR);
@@ -1299,8 +1368,16 @@ fn lower_instr(
         CatchPad { .. } | CleanupPad { .. } => {}
 
         // Terminators handled in lower_terminator.
-        Ret { .. } | Br { .. } | CondBr { .. } | Invoke { .. } | Switch { .. } | Unreachable
-        | Resume { .. } | CatchSwitch { .. } | CatchRet { .. } | CleanupRet { .. } => {}
+        Ret { .. }
+        | Br { .. }
+        | CondBr { .. }
+        | Invoke { .. }
+        | Switch { .. }
+        | Unreachable
+        | Resume { .. }
+        | CatchSwitch { .. }
+        | CatchRet { .. }
+        | CleanupRet { .. } => {}
     }
 }
 
@@ -1379,7 +1456,12 @@ fn lower_terminator(
             }
             let callee_src = resolve(ctx, mf, mblock, vmap, *callee);
             let callee_vr = mf.fresh_vreg();
-            mf.push(mblock, MInstr::new(MOV_RR).with_dst(callee_vr).with_vreg(callee_src));
+            mf.push(
+                mblock,
+                MInstr::new(MOV_RR)
+                    .with_dst(callee_vr)
+                    .with_vreg(callee_src),
+            );
             // Record the instruction index of the CALL before pushing it.
             let call_instr_idx = mf.blocks[mblock].instrs.len();
             let lsda_rec_idx = mf.lsda_call_sites.len();
@@ -1395,12 +1477,8 @@ fn lower_terminator(
                 action: 0,
             });
             // Track: (machine_block, call_instr_in_block, lsda_record_idx, unwind_dest_mblock)
-            mf.invoke_tracking.push((
-                mblock,
-                call_instr_idx,
-                lsda_rec_idx,
-                unwind_dest.0 as usize,
-            ));
+            mf.invoke_tracking
+                .push((mblock, call_instr_idx, lsda_rec_idx, unwind_dest.0 as usize));
             if term.ty != ctx.void_ty {
                 let dst = mf.fresh_vreg();
                 vmap.insert(ValueRef::Instruction(tid), dst);
@@ -1443,7 +1521,9 @@ fn lower_terminator(
         }
 
         // CatchSwitch — lower first handler as unconditional branch (stub).
-        CatchSwitch { handlers, default, .. } => {
+        CatchSwitch {
+            handlers, default, ..
+        } => {
             if let Some(&h) = handlers.first() {
                 mf.push(mblock, MInstr::new(JMP).with_block(h.0 as usize));
             } else if let Some(d) = default {
@@ -1578,8 +1658,9 @@ mod tests {
         allocate_registers, apply_allocation, compute_live_intervals, insert_spill_reloads,
         RegAllocStrategy,
     };
-    use llvm_ir::{Builder, ConstantData, Context, GlobalId, Linkage, MemOrdering, Module,
-                  RmwOp, ValueRef};
+    use llvm_ir::{
+        Builder, ConstantData, Context, GlobalId, Linkage, MemOrdering, Module, RmwOp, ValueRef,
+    };
 
     fn make_add_fn() -> (Context, Module) {
         let mut ctx = Context::new();
@@ -1733,7 +1814,10 @@ mod tests {
             .iter()
             .flat_map(|b| &b.instrs)
             .any(|i| i.opcode == LOCK_XADD32_MR);
-        assert!(has_xadd, "i32 AtomicRmw Add must lower to LOCK_XADD32_MR opcode");
+        assert!(
+            has_xadd,
+            "i32 AtomicRmw Add must lower to LOCK_XADD32_MR opcode"
+        );
 
         // No INLINE_ASM should appear for atomic ops anymore.
         let inline_asm_count = mf
@@ -1752,10 +1836,7 @@ mod tests {
 
         // MFENCE = 0F AE F0
         assert!(
-            section
-                .data
-                .windows(3)
-                .any(|w| w == [0x0F, 0xAE, 0xF0]),
+            section.data.windows(3).any(|w| w == [0x0F, 0xAE, 0xF0]),
             "MFENCE bytes (0F AE F0) not found in emitted text section"
         );
         // LOCK prefix should be present somewhere (CMPXCHG / XADD lowering)
@@ -1793,7 +1874,10 @@ mod tests {
 
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);
         let section = emitter.emit_function(&mf);
-        assert!(section.data.contains(&0x90), "x86 inline asm nop must emit 0x90");
+        assert!(
+            section.data.contains(&0x90),
+            "x86 inline asm nop must emit 0x90"
+        );
     }
 
     #[test]
@@ -2650,7 +2734,15 @@ mod tests {
         let ptr_arg = b.get_arg(0);
         let i32_ty = b.ctx.i32_ty;
         let one = b.const_int(i32_ty, 1);
-        b.build_atomicrmw("old", RmwOp::Add, i32_ty, ptr_arg, one, MemOrdering::SeqCst, false);
+        b.build_atomicrmw(
+            "old",
+            RmwOp::Add,
+            i32_ty,
+            ptr_arg,
+            one,
+            MemOrdering::SeqCst,
+            false,
+        );
         b.build_ret_void();
         drop(b);
 
@@ -2664,7 +2756,10 @@ mod tests {
             .iter()
             .flat_map(|b| &b.instrs)
             .any(|i| i.opcode == LOCK_XADD32_MR);
-        assert!(has_xadd32, "i32 atomicrmw add must lower to LOCK_XADD32_MR (not LOCK_XADD_MR)");
+        assert!(
+            has_xadd32,
+            "i32 atomicrmw add must lower to LOCK_XADD32_MR (not LOCK_XADD_MR)"
+        );
 
         // Must NOT use the 64-bit opcode for an i32 element type.
         let has_xadd64 = mf
@@ -2672,7 +2767,10 @@ mod tests {
             .iter()
             .flat_map(|b| &b.instrs)
             .any(|i| i.opcode == LOCK_XADD_MR);
-        assert!(!has_xadd64, "i32 atomicrmw must not emit the 64-bit LOCK_XADD_MR opcode");
+        assert!(
+            !has_xadd64,
+            "i32 atomicrmw must not emit the 64-bit LOCK_XADD_MR opcode"
+        );
 
         // Run register allocation
         let intervals = compute_live_intervals(&mf);
@@ -2697,7 +2795,10 @@ mod tests {
         let section = emitter.emit_function(&mf);
 
         // Print the bytes for diagnosis
-        eprintln!("increment text section bytes ({} bytes):", section.data.len());
+        eprintln!(
+            "increment text section bytes ({} bytes):",
+            section.data.len()
+        );
         for (i, chunk) in section.data.chunks(16).enumerate() {
             eprint!("  {:04x}: ", i * 16);
             for b in chunk {
@@ -2718,10 +2819,7 @@ mod tests {
         // For i32 atomicrmw: LOCK XADD32 = F0 [no REX.W] 0F C1 /r.
         // With typical registers (RAX/RCX/RDX — not R8-R15), no REX byte is emitted.
         // Check that 0xF0 0x0F 0xC1 appears (no REX.W = 0x48 between F0 and 0F).
-        let has_32bit_lock_xadd = section
-            .data
-            .windows(3)
-            .any(|w| w == [0xF0, 0x0F, 0xC1]);
+        let has_32bit_lock_xadd = section.data.windows(3).any(|w| w == [0xF0, 0x0F, 0xC1]);
         assert!(
             has_32bit_lock_xadd,
             "32-bit LOCK XADD sequence F0 0F C1 not found in emitted bytes — \
@@ -2770,7 +2868,10 @@ mod tests {
         // %p = alloca i64
         let p = b.build_alloca("p", b.ctx.i64_ty);
         // store i64 42, ptr %p
-        let v42 = ValueRef::Constant(b.ctx.push_const(ConstantData::Int { ty: b.ctx.i64_ty, val: 42 }));
+        let v42 = ValueRef::Constant(b.ctx.push_const(ConstantData::Int {
+            ty: b.ctx.i64_ty,
+            val: 42,
+        }));
         b.build_store(v42, p);
         // %v = load i64, ptr %p
         let v = b.build_load("v", b.ctx.i64_ty, p);
@@ -2836,10 +2937,7 @@ mod tests {
 
         // Verify LEA [RBP + disp32] (0x8D 0x85) appears in the emitted code.
         // This confirms that the alloca slot was materialized as a frame-pointer-relative address.
-        let has_lea_rbp = section
-            .data
-            .windows(2)
-            .any(|w| w == [0x8D, 0x85]);
+        let has_lea_rbp = section.data.windows(2).any(|w| w == [0x8D, 0x85]);
         assert!(
             has_lea_rbp,
             "alloca lowering must emit LEA [RBP+disp32] (bytes 8D 85); got: {:02X?}",
@@ -2848,11 +2946,17 @@ mod tests {
 
         // Verify MOV [ptr_reg] load (0x8B) appears — from the load through the alloca pointer.
         let has_load = section.data.contains(&0x8B);
-        assert!(has_load, "load through alloca pointer must emit 0x8B (MOV r64, r/m64)");
+        assert!(
+            has_load,
+            "load through alloca pointer must emit 0x8B (MOV r64, r/m64)"
+        );
 
         // Verify MOV [ptr_reg] store (0x89) appears — from the store through the alloca pointer.
         let has_store = section.data.contains(&0x89);
-        assert!(has_store, "store through alloca pointer must emit 0x89 (MOV r/m64, r64)");
+        assert!(
+            has_store,
+            "store through alloca pointer must emit 0x89 (MOV r/m64, r64)"
+        );
     }
 
     #[test]
@@ -2873,7 +2977,10 @@ mod tests {
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let p = b.get_arg(0);
-        let idx0 = ValueRef::Constant(b.ctx.push_const(ConstantData::Int { ty: b.ctx.i64_ty, val: 0 }));
+        let idx0 = ValueRef::Constant(b.ctx.push_const(ConstantData::Int {
+            ty: b.ctx.i64_ty,
+            val: 0,
+        }));
         let gep = b.build_gep("g", b.ctx.i64_ty, p, vec![idx0]);
         b.build_ret(gep);
 
@@ -2884,7 +2991,10 @@ mod tests {
             .iter()
             .flat_map(|b| &b.instrs)
             .any(|i| i.opcode == MOV_RR);
-        assert!(has_mov_rr, "GEP lowering should emit a MOV_RR (pointer copy)");
+        assert!(
+            has_mov_rr,
+            "GEP lowering should emit a MOV_RR (pointer copy)"
+        );
     }
 
     // ── SSE2 scalar FP lowering tests (issue #291) ────────────────────────────
@@ -3178,16 +3288,16 @@ mod tests {
         let mut be = X86Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
         // The entry block should contain MOVAPD_RR instructions for the FP args.
-        let has_movapd = mf.blocks[0]
-            .instrs
-            .iter()
-            .any(|i| i.opcode == MOVAPD_RR);
+        let has_movapd = mf.blocks[0].instrs.iter().any(|i| i.opcode == MOVAPD_RR);
         assert!(has_movapd, "FP args must use MOVAPD_RR copy from XMM reg");
         // All dst VRegs from MOVAPD_RR must be Float class.
         for instr in mf.blocks[0].instrs.iter().filter(|i| i.opcode == MOVAPD_RR) {
             if let Some(dst) = instr.dst {
-                assert_eq!(dst.class(), RegClass::Float,
-                           "FP arg copy dst vreg must have Float class");
+                assert_eq!(
+                    dst.class(),
+                    RegClass::Float,
+                    "FP arg copy dst vreg must have Float class"
+                );
             }
         }
     }
@@ -3198,10 +3308,14 @@ mod tests {
         let (ctx, module) = make_fp_add_fn();
         let mut be = X86Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        assert!(!mf.allocatable_fp_pregs.is_empty(),
-                "allocatable_fp_pregs must be populated for FP functions");
-        assert!(mf.allocatable_fp_pregs.contains(&crate::regs::XMM0),
-                "XMM0 must be in allocatable_fp_pregs");
+        assert!(
+            !mf.allocatable_fp_pregs.is_empty(),
+            "allocatable_fp_pregs must be populated for FP functions"
+        );
+        assert!(
+            mf.allocatable_fp_pregs.contains(&crate::regs::XMM0),
+            "XMM0 must be in allocatable_fp_pregs"
+        );
     }
 
     #[test]
@@ -3220,7 +3334,14 @@ mod tests {
             &fp_pregs,
             RegAllocStrategy::LinearScan,
         );
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOVSD_LOAD_MR, MOVSD_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOVSD_LOAD_MR,
+            MOVSD_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
 
         let mut emitter = X86Emitter::new(ObjectFormat::Elf);
@@ -3286,15 +3407,12 @@ mod tests {
         let (ctx, module) = make_fp_add_fn();
         let mut be = X86Backend::default();
         let mf = be.lower_function(&ctx, &module, &module.functions[0]);
-        let ret_to_xmm0 = mf
-            .blocks
-            .iter()
-            .flat_map(|bl| bl.instrs.iter())
-            .any(|i| {
-                i.opcode == MOV_PR
-                    && i.operands.first() == Some(&MOperand::PReg(crate::regs::XMM0))
-            });
-        assert!(ret_to_xmm0,
-                "FP return must emit MOV_PR with XMM0 as destination");
+        let ret_to_xmm0 = mf.blocks.iter().flat_map(|bl| bl.instrs.iter()).any(|i| {
+            i.opcode == MOV_PR && i.operands.first() == Some(&MOperand::PReg(crate::regs::XMM0))
+        });
+        assert!(
+            ret_to_xmm0,
+            "FP return must emit MOV_PR with XMM0 as destination"
+        );
     }
 }

--- a/src/llvm-target-x86/src/regs.rs
+++ b/src/llvm-target-x86/src/regs.rs
@@ -81,12 +81,10 @@ pub const XMM15: PReg = PReg(31);
 
 /// Caller-saved XMM registers available for FP allocation (System V AMD64).
 /// XMM0–XMM7 are caller-saved; XMM8–XMM15 are callee-saved under Win64.
-pub const FP_ALLOCATABLE: &[PReg] =
-    &[XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
+pub const FP_ALLOCATABLE: &[PReg] = &[XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];
 
 /// Callee-saved XMM registers under Windows x64 ABI.
-pub const FP_CALLEE_SAVED_WIN64: &[PReg] =
-    &[XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15];
+pub const FP_CALLEE_SAVED_WIN64: &[PReg] = &[XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15];
 
 /// Whether `r` is an XMM (FP/SIMD) register.
 #[inline]

--- a/src/llvm-target-x86/src/tti.rs
+++ b/src/llvm-target-x86/src/tti.rs
@@ -108,8 +108,8 @@ impl TargetTransformInfo for X86Tti {
             LEA_FRAME_MR | MOV_LOAD_REG_MR | MOV_STORE_REG_RM => 1,
 
             // ── atomics (fence-like cost) ──
-            MFENCE | LOCK_CMPXCHG_MR | LOCK_XADD_MR | LOCK_XADD32_MR | XCHG_MR
-            | LOCK_AND_MR | LOCK_OR_MR | LOCK_XOR_MR => 20,
+            MFENCE | LOCK_CMPXCHG_MR | LOCK_XADD_MR | LOCK_XADD32_MR | XCHG_MR | LOCK_AND_MR
+            | LOCK_OR_MR | LOCK_XOR_MR => 20,
 
             // ── SSE2 scalar double ──
             ADDSD_RR | SUBSD_RR => match self.profile {
@@ -150,8 +150,8 @@ impl TargetTransformInfo for X86Tti {
             UCOMISS_RR | MOVSS_LOAD_MR | MOVSS_STORE_RM => 1,
 
             // ── FP ↔ integer conversions ──
-            CVTTSD2SI_RR | CVTSI2SD_RR | CVTTSS2SI_RR | CVTSI2SS_RR | CVTSD2SS_RR
-            | CVTSS2SD_RR | MOVAPD_RR | MOVAPD_RR_F32 => 1,
+            CVTTSD2SI_RR | CVTSI2SD_RR | CVTTSS2SI_RR | CVTSI2SS_RR | CVTSD2SS_RR | CVTSS2SD_RR
+            | MOVAPD_RR | MOVAPD_RR_F32 => 1,
 
             // Default: conservatively 1 cycle.
             _ => 1,

--- a/src/llvm-transforms/src/asan.rs
+++ b/src/llvm-transforms/src/asan.rs
@@ -401,9 +401,7 @@ fn instrument_memory_accesses(
                 }
                 InstrKind::Store { val, .. } => {
                     let val_ty = value_type(func, *val);
-                    let bytes = val_ty
-                        .and_then(|ty| type_size_bytes(ctx, ty))
-                        .unwrap_or(4);
+                    let bytes = val_ty.and_then(|ty| type_size_bytes(ctx, ty)).unwrap_or(4);
                     accesses.push(MemAccess {
                         block_idx: bi,
                         body_pos: pos,
@@ -873,6 +871,9 @@ mod tests {
             .iter()
             .filter(|f| f.name == "__asan_module_ctor")
             .count();
-        assert_eq!(ctor_count_1, ctor_count_2, "module ctor must not be duplicated");
+        assert_eq!(
+            ctor_count_1, ctor_count_2,
+            "module ctor must not be duplicated"
+        );
     }
 }

--- a/src/llvm-transforms/src/cfg_simplify.rs
+++ b/src/llvm-transforms/src/cfg_simplify.rs
@@ -140,8 +140,10 @@ fn prune_unreachable(func: &mut Function) -> bool {
                     .collect();
                 if new_incoming.len() != incoming.len() {
                     let ty = *ty;
-                    func.instructions[iid.0 as usize].kind =
-                        InstrKind::Phi { ty, incoming: new_incoming };
+                    func.instructions[iid.0 as usize].kind = InstrKind::Phi {
+                        ty,
+                        incoming: new_incoming,
+                    };
                 }
             }
         }
@@ -242,7 +244,11 @@ fn remap_block_ids(func: &mut Function, new_idx: &[Option<u32>]) {
     for instr in &mut func.instructions {
         match &mut instr.kind {
             InstrKind::Br { dest } => remap(dest),
-            InstrKind::CondBr { then_dest, else_dest, .. } => {
+            InstrKind::CondBr {
+                then_dest,
+                else_dest,
+                ..
+            } => {
                 remap(then_dest);
                 remap(else_dest);
             }
@@ -252,7 +258,11 @@ fn remap_block_ids(func: &mut Function, new_idx: &[Option<u32>]) {
                     remap(blk);
                 }
             }
-            InstrKind::Invoke { normal_dest, unwind_dest, .. } => {
+            InstrKind::Invoke {
+                normal_dest,
+                unwind_dest,
+                ..
+            } => {
                 remap(normal_dest);
                 remap(unwind_dest);
             }
@@ -346,7 +356,10 @@ fn merge_fallthrough(func: &mut Function) -> bool {
         // B must not have phi nodes (they should have been eliminated by
         // simplify_trivial_phis, but guard anyway).
         let b_has_phi = func.blocks[b_idx].body.iter().any(|&iid| {
-            matches!(func.instructions[iid.0 as usize].kind, InstrKind::Phi { .. })
+            matches!(
+                func.instructions[iid.0 as usize].kind,
+                InstrKind::Phi { .. }
+            )
         });
         if b_has_phi {
             continue;
@@ -489,14 +502,12 @@ mod tests {
         match &f.instr(tid).kind {
             InstrKind::Ret {
                 val: Some(ValueRef::Constant(cid)),
-            } => {
-                match ctx.get_const(*cid) {
-                    llvm_ir::ConstantData::Int { val, .. } => {
-                        assert_eq!(*val, 1, "should return 1, not 99 from dead block")
-                    }
-                    other => panic!("unexpected constant: {other:?}"),
+            } => match ctx.get_const(*cid) {
+                llvm_ir::ConstantData::Int { val, .. } => {
+                    assert_eq!(*val, 1, "should return 1, not 99 from dead block")
                 }
-            }
+                other => panic!("unexpected constant: {other:?}"),
+            },
             other => panic!("expected ret i32 constant, got {other:?}"),
         }
     }
@@ -580,8 +591,11 @@ mod tests {
         let found_ret_const = f.blocks.iter().any(|bb| {
             bb.terminator
                 .map(|tid| {
-                    matches!(&f.instr(tid).kind,
-                        InstrKind::Ret { val: Some(ValueRef::Constant(_)) }
+                    matches!(
+                        &f.instr(tid).kind,
+                        InstrKind::Ret {
+                            val: Some(ValueRef::Constant(_))
+                        }
                     )
                 })
                 .unwrap_or(false)
@@ -692,8 +706,11 @@ mod tests {
         let found_ret_const = f.blocks.iter().any(|bb| {
             bb.terminator
                 .map(|tid| {
-                    matches!(&f.instr(tid).kind,
-                        InstrKind::Ret { val: Some(ValueRef::Constant(_)) }
+                    matches!(
+                        &f.instr(tid).kind,
+                        InstrKind::Ret {
+                            val: Some(ValueRef::Constant(_))
+                        }
                     )
                 })
                 .unwrap_or(false)

--- a/src/llvm-transforms/src/const_prop.rs
+++ b/src/llvm-transforms/src/const_prop.rs
@@ -14,7 +14,10 @@
 
 use crate::constant_fold::{try_fold, try_fold_fp};
 use crate::pass::FunctionPass;
-use llvm_ir::{ConstantData, Context, FloatKind, Function, InstrId, InstrKind, LandingPadClause, TypeData, ValueRef};
+use llvm_ir::{
+    ConstantData, Context, FloatKind, Function, InstrId, InstrKind, LandingPadClause, TypeData,
+    ValueRef,
+};
 use std::collections::{HashMap, HashSet};
 
 /// Constant propagation / constant folding pass.

--- a/src/llvm-transforms/src/constant_fold.rs
+++ b/src/llvm-transforms/src/constant_fold.rs
@@ -10,7 +10,9 @@
 //! The functions are pure: they only read `ctx` and `kind`; new constants are
 //! allocated with `ctx.const_int` / `ctx.const_float`.
 
-use llvm_ir::{ConstId, ConstantData, Context, FloatKind, InstrKind, IntPredicate, TypeData, ValueRef};
+use llvm_ir::{
+    ConstId, ConstantData, Context, FloatKind, InstrKind, IntPredicate, TypeData, ValueRef,
+};
 
 /// Try to constant-fold `kind`.
 ///

--- a/src/llvm-transforms/src/dead_arg_elim.rs
+++ b/src/llvm-transforms/src/dead_arg_elim.rs
@@ -1,9 +1,7 @@
 //! Inter-procedural dead argument elimination.
 
 use crate::pass::ModulePass;
-use llvm_ir::{
-    Context, FunctionId, GlobalId, InstrKind, Module, TypeData, ValueRef,
-};
+use llvm_ir::{Context, FunctionId, GlobalId, InstrKind, Module, TypeData, ValueRef};
 
 /// Removes trailing unused function parameters and rewrites direct callsites.
 ///
@@ -118,9 +116,11 @@ mod tests {
         let x = b.get_arg(0);
         let c1 = b.const_int(b.ctx.i64_ty, 1);
         let c2 = b.const_int(b.ctx.i64_ty, 2);
-        let call_ty = b
-            .ctx
-            .mk_fn_type(b.ctx.i64_ty, vec![b.ctx.i64_ty, b.ctx.i64_ty, b.ctx.i64_ty], false);
+        let call_ty = b.ctx.mk_fn_type(
+            b.ctx.i64_ty,
+            vec![b.ctx.i64_ty, b.ctx.i64_ty, b.ctx.i64_ty],
+            false,
+        );
         let r = b.build_call(
             "r",
             b.ctx.i64_ty,

--- a/src/llvm-transforms/src/gvn.rs
+++ b/src/llvm-transforms/src/gvn.rs
@@ -382,7 +382,16 @@ fn rewrite_block(
     }
 
     for &child in &dom_children[bid.0 as usize] {
-        rewrite_block(func, child, dom_children, &mut exprs, &mut loads, subst, remove, strictfp_mode);
+        rewrite_block(
+            func,
+            child,
+            dom_children,
+            &mut exprs,
+            &mut loads,
+            subst,
+            remove,
+            strictfp_mode,
+        );
     }
 }
 
@@ -625,7 +634,10 @@ mod tests {
 
         let mut pass = Gvn;
         let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
-        assert!(!changed, "sibling-block expressions are not dominance-equivalent");
+        assert!(
+            !changed,
+            "sibling-block expressions are not dominance-equivalent"
+        );
     }
 
     #[test]

--- a/src/llvm-transforms/src/ipcp.rs
+++ b/src/llvm-transforms/src/ipcp.rs
@@ -1,9 +1,7 @@
 //! Inter-procedural constant propagation (IPCP).
 
 use crate::{const_prop::ConstProp, pass::ModulePass, value_rewrite::rewrite_values_in_kind};
-use llvm_ir::{
-    ArgId, Context, Function, FunctionId, GlobalId, InstrKind, Module, ValueRef,
-};
+use llvm_ir::{ArgId, Context, Function, FunctionId, GlobalId, InstrKind, Module, ValueRef};
 
 /// Simple IPCP pass:
 /// - detect a direct callee argument that is constant across all direct callsites
@@ -21,7 +19,9 @@ impl ModulePass for Ipcp {
 
         for callee_idx in 0..module.functions.len() {
             let callee_id = FunctionId(callee_idx as u32);
-            if module.functions[callee_idx].is_declaration || module.functions[callee_idx].args.is_empty() {
+            if module.functions[callee_idx].is_declaration
+                || module.functions[callee_idx].args.is_empty()
+            {
                 continue;
             }
 
@@ -54,8 +54,12 @@ impl ModulePass for Ipcp {
             let spec_ty = module.functions[spec_id.0 as usize].ty;
             for cs in callsites {
                 if cs.const_args.get(arg_idx).copied() == Some(Some(const_val)) {
-                    let instr = &mut module.functions[cs.caller.0 as usize].instructions[cs.iid.0 as usize];
-                    if let InstrKind::Call { callee, callee_ty, .. } = &mut instr.kind {
+                    let instr =
+                        &mut module.functions[cs.caller.0 as usize].instructions[cs.iid.0 as usize];
+                    if let InstrKind::Call {
+                        callee, callee_ty, ..
+                    } = &mut instr.kind
+                    {
                         *callee = ValueRef::Global(GlobalId(spec_id.0));
                         *callee_ty = spec_ty;
                         changed = true;
@@ -200,7 +204,9 @@ mod tests {
         let x0 = b.get_arg(0);
         let c7 = b.const_int(b.ctx.i64_ty, 7);
         let c7b = b.const_int(b.ctx.i64_ty, 7);
-        let call_ty = b.ctx.mk_fn_type(b.ctx.i64_ty, vec![b.ctx.i64_ty, b.ctx.i64_ty], false);
+        let call_ty = b
+            .ctx
+            .mk_fn_type(b.ctx.i64_ty, vec![b.ctx.i64_ty, b.ctx.i64_ty], false);
         let t1 = b.build_call(
             "t1",
             b.ctx.i64_ty,
@@ -228,7 +234,10 @@ mod tests {
         let changed = pass.run_on_module(&mut ctx, &mut module);
         assert!(changed);
         assert!(
-            module.functions.iter().any(|f| f.name.starts_with("addk.ipcp")),
+            module
+                .functions
+                .iter()
+                .any(|f| f.name.starts_with("addk.ipcp")),
             "expected specialized clone"
         );
     }

--- a/src/llvm-transforms/src/jump_threading.rs
+++ b/src/llvm-transforms/src/jump_threading.rs
@@ -200,12 +200,7 @@ impl FunctionPass for JumpThreading {
 /// unreachable a later dead-block prune drops it.  We skip adding a duplicate
 /// when `succ` already lists `new_pred` as an incoming edge (the degenerate
 /// case where `new_pred` reaches `succ` via two edges).
-fn add_phi_edge_for_bypass(
-    func: &mut Function,
-    empty: BlockId,
-    succ: BlockId,
-    new_pred: BlockId,
-) {
+fn add_phi_edge_for_bypass(func: &mut Function, empty: BlockId, succ: BlockId, new_pred: BlockId) {
     // `empty` must itself be a pure pass-through (no body) for this to be a
     // value-preserving bypass; `bypass_if_empty` already guaranteed that.
     let body = func.blocks[succ.0 as usize].body.clone();
@@ -317,7 +312,9 @@ mod tests {
         let mut pass = JumpThreading;
         assert!(pass.run_on_function(&mut ctx, func));
 
-        let term = func.blocks[entry.0 as usize].terminator.expect("terminator");
+        let term = func.blocks[entry.0 as usize]
+            .terminator
+            .expect("terminator");
         match &func.instr(term).kind {
             InstrKind::Br { dest } => assert_eq!(*dest, then_b),
             other => panic!("expected Br after threading, got {other:?}"),
@@ -374,14 +371,7 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("jt_phi_true");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function(
-            "f",
-            b.ctx.void_ty,
-            vec![],
-            vec![],
-            false,
-            Linkage::External,
-        );
+        b.add_function("f", b.ctx.void_ty, vec![], vec![], false, Linkage::External);
 
         let pred_true = b.add_block("pred_true");
         let pred_false = b.add_block("pred_false");
@@ -440,14 +430,7 @@ mod tests {
         let mut ctx = Context::new();
         let mut module = Module::new("jt_phi_false");
         let mut b = Builder::new(&mut ctx, &mut module);
-        b.add_function(
-            "g",
-            b.ctx.void_ty,
-            vec![],
-            vec![],
-            false,
-            Linkage::External,
-        );
+        b.add_function("g", b.ctx.void_ty, vec![], vec![], false, Linkage::External);
 
         let pred_true = b.add_block("pred_true");
         let join = b.add_block("join");
@@ -566,11 +549,7 @@ mod tests {
 
         b.position_at_end(join);
         // Both incoming values are arguments (not constants) → no threading.
-        let phi = b.build_phi(
-            "c",
-            b.ctx.i1_ty,
-            vec![(arg_a, pred_a), (arg_b, pred_b)],
-        );
+        let phi = b.build_phi("c", b.ctx.i1_ty, vec![(arg_a, pred_a), (arg_b, pred_b)]);
         b.build_cond_br(phi, then_b, else_b);
 
         b.position_at_end(then_b);

--- a/src/llvm-transforms/src/lib.rs
+++ b/src/llvm-transforms/src/lib.rs
@@ -41,12 +41,12 @@ pub mod gvn;
 pub mod inline_pass;
 /// Public API for `ipcp`.
 pub mod ipcp;
+/// Public API for `jump_threading`.
+pub mod jump_threading;
 /// Public API for `licm`.
 pub mod licm;
 /// Public API for `loop_unroll`.
 pub mod loop_unroll;
-/// Public API for `jump_threading`.
-pub mod jump_threading;
 /// Public API for `mem2reg`.
 pub mod mem2reg;
 /// Public API for `msan`.
@@ -55,6 +55,8 @@ pub mod msan;
 pub mod pass;
 /// Public API for `pipeline`.
 pub mod pipeline;
+/// Public API for `reassoc`.
+pub mod reassoc;
 /// Public API for `slp`.
 pub mod slp;
 /// Public API for `sroa`.
@@ -65,8 +67,6 @@ pub mod tailcall;
 pub mod tsan;
 /// Public API for `ubsan`.
 pub mod ubsan;
-/// Public API for `reassoc`.
-pub mod reassoc;
 mod value_rewrite;
 
 /// Public API for `re-export`.
@@ -90,11 +90,11 @@ pub use inline_pass::Inliner;
 /// Public API for `re-export`.
 pub use ipcp::Ipcp;
 /// Public API for `re-export`.
+pub use jump_threading::JumpThreading;
+/// Public API for `re-export`.
 pub use licm::Licm;
 /// Public API for `re-export`.
 pub use loop_unroll::LoopUnroll;
-/// Public API for `re-export`.
-pub use jump_threading::JumpThreading;
 /// Public API for `re-export`.
 pub use mem2reg::Mem2Reg;
 /// Public API for `re-export`.
@@ -103,6 +103,8 @@ pub use msan::MsanPass;
 pub use pass::{FunctionPass, ModulePass, PassManager};
 /// Public API for `re-export`.
 pub use pipeline::{build_pipeline, OptLevel};
+/// Public API for `re-export`.
+pub use reassoc::ReassocPass;
 /// Public API for `re-export`.
 pub use slp::SlpVectorizer;
 /// Public API for `re-export`.
@@ -113,5 +115,3 @@ pub use tailcall::TailCallOpt;
 pub use tsan::TsanPass;
 /// Public API for `re-export`.
 pub use ubsan::{UbsanModulePass, UbsanPass};
-/// Public API for `re-export`.
-pub use reassoc::ReassocPass;

--- a/src/llvm-transforms/src/licm.rs
+++ b/src/llvm-transforms/src/licm.rs
@@ -26,7 +26,9 @@
 
 use crate::pass::FunctionPass;
 use llvm_analysis::{Cfg, DomTree, LoopInfo};
-use llvm_ir::{BasicBlock, BlockId, Context, Function, InstrId, InstrKind, Instruction, TypeId, ValueRef};
+use llvm_ir::{
+    BasicBlock, BlockId, Context, Function, InstrId, InstrKind, Instruction, TypeId, ValueRef,
+};
 use std::collections::HashSet;
 
 /// Loop-Invariant Code Motion pass.
@@ -62,8 +64,7 @@ impl FunctionPass for Licm {
 
         for loop_idx in loop_order {
             let header = li.loops()[loop_idx].header;
-            let loop_body: HashSet<BlockId> =
-                li.loops()[loop_idx].body.iter().copied().collect();
+            let loop_body: HashSet<BlockId> = li.loops()[loop_idx].body.iter().copied().collect();
 
             // Find or create the preheader once per loop.
             let preheader = ensure_preheader(func, &cfg, header, &loop_body);
@@ -207,9 +208,7 @@ fn is_loop_invariant(
             ValueRef::Constant(_) | ValueRef::Argument(_) | ValueRef::Global(_) => {}
             ValueRef::Instruction(def_iid) => {
                 // Look up which block defines this instruction.
-                let def_block = instr_to_block
-                    .get(def_iid.0 as usize)
-                    .and_then(|b| *b);
+                let def_block = instr_to_block.get(def_iid.0 as usize).and_then(|b| *b);
                 match def_block {
                     // Defined outside loop — OK.
                     Some(b) if !loop_body.contains(&b) => {}
@@ -342,9 +341,7 @@ fn ensure_preheader(
     // now come from `preheader_id`.
     let header_body: Vec<InstrId> = func.blocks[header.0 as usize].body.clone();
     for iid in header_body {
-        if let InstrKind::Phi { incoming, .. } =
-            &mut func.instructions[iid.0 as usize].kind
-        {
+        if let InstrKind::Phi { incoming, .. } = &mut func.instructions[iid.0 as usize].kind {
             for (_, pred_bid) in incoming.iter_mut() {
                 if outside_preds.contains(pred_bid) {
                     *pred_bid = preheader_id;
@@ -369,12 +366,7 @@ fn find_void_ty(func: &Function) -> TypeId {
 
 /// Rewrite all branch targets equal to `old_target` in `block`'s terminator
 /// to point to `new_target` instead.
-fn redirect_branch(
-    func: &mut Function,
-    block: BlockId,
-    old_target: BlockId,
-    new_target: BlockId,
-) {
+fn redirect_branch(func: &mut Function, block: BlockId, old_target: BlockId, new_target: BlockId) {
     let tid = match func.blocks[block.0 as usize].terminator {
         Some(t) => t,
         None => return,
@@ -759,7 +751,13 @@ mod tests {
                 b.ctx.i32_ty, // cv
                 b.ctx.i32_ty, // dv
             ],
-            vec!["n".into(), "a".into(), "bv".into(), "cv".into(), "dv".into()],
+            vec![
+                "n".into(),
+                "a".into(),
+                "bv".into(),
+                "cv".into(),
+                "dv".into(),
+            ],
             false,
             Linkage::External,
         );
@@ -840,8 +838,16 @@ mod tests {
 
         // Before LICM.
         let func = &module.functions[0];
-        assert_eq!(body_len(func, outer_body), 1, "outer_body: 1 instr before LICM");
-        assert_eq!(body_len(func, inner_body), 2, "inner_body: 2 instrs before LICM");
+        assert_eq!(
+            body_len(func, outer_body),
+            1,
+            "outer_body: 1 instr before LICM"
+        );
+        assert_eq!(
+            body_len(func, inner_body),
+            2,
+            "inner_body: 2 instrs before LICM"
+        );
 
         let mut pass = Licm;
         let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
@@ -851,13 +857,17 @@ mod tests {
         let func = &module.functions[0];
         let inner_inv_id = func.value_names["inner_inv"];
         assert!(
-            !func.blocks[inner_body.0 as usize].body.contains(&inner_inv_id),
+            !func.blocks[inner_body.0 as usize]
+                .body
+                .contains(&inner_inv_id),
             "%inner_inv must be hoisted out of inner_body"
         );
 
         let outer_inv_id = func.value_names["outer_inv"];
         assert!(
-            !func.blocks[outer_body.0 as usize].body.contains(&outer_inv_id),
+            !func.blocks[outer_body.0 as usize]
+                .body
+                .contains(&outer_inv_id),
             "%outer_inv must be hoisted out of outer_body"
         );
     }

--- a/src/llvm-transforms/src/loop_unroll.rs
+++ b/src/llvm-transforms/src/loop_unroll.rs
@@ -104,7 +104,11 @@ fn const_i64(ctx: &Context, v: ValueRef) -> Option<i64> {
 /// - `icmp sle %i, C`
 /// - `icmp ult %i, C`
 /// - `icmp ule %i, C`
-pub(crate) fn constant_trip_count(ctx: &Context, func: &Function, header: BlockId) -> Option<usize> {
+pub(crate) fn constant_trip_count(
+    ctx: &Context,
+    func: &Function,
+    header: BlockId,
+) -> Option<usize> {
     let hb = &func.blocks[header.0 as usize];
     let tid = hb.terminator?;
     let InstrKind::CondBr { cond, .. } = func.instr(tid).kind else {
@@ -150,11 +154,7 @@ mod tests {
 
         b.position_at_end(header);
         let zero = b.const_int(b.ctx.i32_ty, 0);
-        let i = b.build_phi(
-            "i",
-            b.ctx.i32_ty,
-            vec![(zero, entry), (zero, header)],
-        );
+        let i = b.build_phi("i", b.ctx.i32_ty, vec![(zero, entry), (zero, header)]);
         let c = b.const_int(b.ctx.i32_ty, n as u64);
         let cmp = b.build_icmp("cmp", pred, i, c);
         b.build_cond_br(cmp, header, exit);

--- a/src/llvm-transforms/src/msan.rs
+++ b/src/llvm-transforms/src/msan.rs
@@ -258,9 +258,7 @@ fn instrument_memory_accesses(ctx: &mut Context, module: &mut Module, fid: Funct
                 }
                 InstrKind::Store { val, ptr, .. } => {
                     let val_ty = value_type(func, *val);
-                    let bytes = val_ty
-                        .and_then(|ty| type_size_bytes(ctx, ty))
-                        .unwrap_or(4);
+                    let bytes = val_ty.and_then(|ty| type_size_bytes(ctx, ty)).unwrap_or(4);
                     accesses.push(MemAccess {
                         block_idx: bi,
                         body_pos: pos,
@@ -526,7 +524,10 @@ mod tests {
         let mut pass = MsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__msan_check_shadow8");
-        assert!(count >= 1, "__msan_check_shadow8 should be inserted for i64 load, got {count}");
+        assert!(
+            count >= 1,
+            "__msan_check_shadow8 should be inserted for i64 load, got {count}"
+        );
     }
 
     #[test]
@@ -535,7 +536,10 @@ mod tests {
         let mut pass = MsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__msan_store_shadow4");
-        assert!(count >= 1, "__msan_store_shadow4 should be inserted for i32 store, got {count}");
+        assert!(
+            count >= 1,
+            "__msan_store_shadow4 should be inserted for i32 store, got {count}"
+        );
     }
 
     #[test]
@@ -544,7 +548,10 @@ mod tests {
         let mut pass = MsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__msan_poison_stack");
-        assert!(count >= 1, "__msan_poison_stack should be inserted after alloca, got {count}");
+        assert!(
+            count >= 1,
+            "__msan_poison_stack should be inserted after alloca, got {count}"
+        );
     }
 
     #[test]
@@ -590,7 +597,10 @@ mod tests {
         let mut pass = MsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__msan_check_shadow1");
-        assert!(count >= 1, "i8 load should use __msan_check_shadow1, got {count}");
+        assert!(
+            count >= 1,
+            "i8 load should use __msan_check_shadow1, got {count}"
+        );
     }
 
     #[test]
@@ -599,7 +609,10 @@ mod tests {
         let mut pass = MsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__msan_store_shadow4");
-        assert!(count >= 1, "i32 store should use __msan_store_shadow4, got {count}");
+        assert!(
+            count >= 1,
+            "i32 store should use __msan_store_shadow4, got {count}"
+        );
     }
 
     #[test]
@@ -611,7 +624,13 @@ mod tests {
         pass.run_on_module(&mut ctx, &mut module);
         let store_count = count_calls_to(&module, 0, "__msan_store_shadow4");
         let load_count = count_calls_to(&module, 0, "__msan_check_shadow4");
-        assert!(store_count >= 1, "store should get shadow mark, got {store_count}");
-        assert!(load_count >= 1, "load should get shadow check, got {load_count}");
+        assert!(
+            store_count >= 1,
+            "store should get shadow mark, got {store_count}"
+        );
+        assert!(
+            load_count >= 1,
+            "load should get shadow check, got {load_count}"
+        );
     }
 }

--- a/src/llvm-transforms/src/reassoc.rs
+++ b/src/llvm-transforms/src/reassoc.rs
@@ -147,7 +147,9 @@ fn try_simplify_fp(
             if reassoc_or_fast {
                 if let Some(c2) = fp_constant_bits(ctx, *rhs) {
                     let inner_lhs = resolve(*lhs, subst);
-                    if let Some((inner_kind, _inner_lhs_id)) = get_instr_kind_by_ref(func, rewritten, inner_lhs) {
+                    if let Some((inner_kind, _inner_lhs_id)) =
+                        get_instr_kind_by_ref(func, rewritten, inner_lhs)
+                    {
                         if let InstrKind::FAdd {
                             flags: f2,
                             lhs: x,
@@ -274,17 +276,13 @@ fn is_fp_zero(ctx: &Context, vref: ValueRef) -> bool {
 fn is_fp_one(ctx: &Context, vref: ValueRef) -> bool {
     if let ValueRef::Constant(cid) = vref {
         match ctx.get_const(cid) {
-            ConstantData::Float { ty, bits } => {
-                match ctx.get_type(*ty) {
-                    TypeData::Float(llvm_ir::FloatKind::Single) => {
-                        f32::from_bits(*bits as u32) == 1.0f32
-                    }
-                    TypeData::Float(llvm_ir::FloatKind::Double) => {
-                        f64::from_bits(*bits) == 1.0f64
-                    }
-                    _ => false,
+            ConstantData::Float { ty, bits } => match ctx.get_type(*ty) {
+                TypeData::Float(llvm_ir::FloatKind::Single) => {
+                    f32::from_bits(*bits as u32) == 1.0f32
                 }
-            }
+                TypeData::Float(llvm_ir::FloatKind::Double) => f64::from_bits(*bits) == 1.0f64,
+                _ => false,
+            },
             _ => false,
         }
     } else {
@@ -297,16 +295,14 @@ fn is_fp_one(ctx: &Context, vref: ValueRef) -> bool {
 fn fp_constant_bits(ctx: &Context, vref: ValueRef) -> Option<u64> {
     if let ValueRef::Constant(cid) = vref {
         match ctx.get_const(cid) {
-            ConstantData::Float { ty, bits } => {
-                match ctx.get_type(*ty) {
-                    TypeData::Float(llvm_ir::FloatKind::Single) => {
-                        let f = f32::from_bits(*bits as u32) as f64;
-                        Some(f.to_bits())
-                    }
-                    TypeData::Float(llvm_ir::FloatKind::Double) => Some(*bits),
-                    _ => None,
+            ConstantData::Float { ty, bits } => match ctx.get_type(*ty) {
+                TypeData::Float(llvm_ir::FloatKind::Single) => {
+                    let f = f32::from_bits(*bits as u32) as f64;
+                    Some(f.to_bits())
                 }
-            }
+                TypeData::Float(llvm_ir::FloatKind::Double) => Some(*bits),
+                _ => None,
+            },
             _ => None,
         }
     } else {

--- a/src/llvm-transforms/src/slp.rs
+++ b/src/llvm-transforms/src/slp.rs
@@ -127,12 +127,7 @@ impl FunctionPass for SlpVectorizer {
 }
 
 impl SlpVectorizer {
-    fn process_block(
-        &mut self,
-        ctx: &mut Context,
-        func: &mut Function,
-        bid: BlockId,
-    ) -> bool {
+    fn process_block(&mut self, ctx: &mut Context, func: &mut Function, bid: BlockId) -> bool {
         // Collect instruction ids in this block (body only, not terminator).
         let body: Vec<InstrId> = func.blocks[bid.0 as usize].body.clone();
 
@@ -172,16 +167,14 @@ impl SlpVectorizer {
                 };
 
             // Check seed lhs and rhs are loads whose ptrs are GEPs.
-            let (lhs_base_0, lhs_idx_0) =
-                match load_gep_info(ctx, func, seed_lhs) {
-                    Some(x) => x,
-                    None => continue,
-                };
-            let (rhs_base_0, rhs_idx_0) =
-                match load_gep_info(ctx, func, seed_rhs) {
-                    Some(x) => x,
-                    None => continue,
-                };
+            let (lhs_base_0, lhs_idx_0) = match load_gep_info(ctx, func, seed_lhs) {
+                Some(x) => x,
+                None => continue,
+            };
+            let (rhs_base_0, rhs_idx_0) = match load_gep_info(ctx, func, seed_rhs) {
+                Some(x) => x,
+                None => continue,
+            };
 
             // Accumulate a group of `min_width` ops.
             let mut ops = vec![seed];
@@ -197,11 +190,10 @@ impl SlpVectorizer {
                     continue 'outer;
                 }
 
-                let (c_op, c_lhs, c_rhs, c_ty) =
-                    match unpack_fp_instr_typed(func, ctx, candidate) {
-                        Some(x) => x,
-                        None => continue 'outer,
-                    };
+                let (c_op, c_lhs, c_rhs, c_ty) = match unpack_fp_instr_typed(func, ctx, candidate) {
+                    Some(x) => x,
+                    None => continue 'outer,
+                };
 
                 if c_op != seed_op || c_ty != seed_ty {
                     continue 'outer;
@@ -369,8 +361,7 @@ fn apply_group(ctx: &mut Context, func: &mut Function, bid: BlockId, group: &Slp
             .position(|&id| id == group.ops[0])
             .unwrap()
             + 2;
-        let rhs_gep_id =
-            alloc_and_insert(func, bid, insert_pos, None, ptr_ty, rhs_gep_kind);
+        let rhs_gep_id = alloc_and_insert(func, bid, insert_pos, None, ptr_ty, rhs_gep_kind);
 
         let rhs_load_kind = InstrKind::Load {
             ty: vec_ty,
@@ -456,8 +447,12 @@ fn apply_group(ctx: &mut Context, func: &mut Function, bid: BlockId, group: &Slp
 
     // --- Rewrite uses of the old scalar ops throughout the block ---
     // Build a replacement map: old scalar op InstrId → new extract InstrId.
-    let replacements: HashMap<InstrId, InstrId> =
-        group.ops.iter().copied().zip(extract_ids.iter().copied()).collect();
+    let replacements: HashMap<InstrId, InstrId> = group
+        .ops
+        .iter()
+        .copied()
+        .zip(extract_ids.iter().copied())
+        .collect();
 
     // Rewrite all instructions in the block.
     rewrite_uses_in_block(func, bid, &replacements);
@@ -585,13 +580,23 @@ fn rewrite_kind(kind: InstrKind, rep: &HashMap<InstrId, InstrId>) -> InstrKind {
             lhs: rw(lhs, rep),
             rhs: rw(rhs, rep),
         },
-        InstrKind::Store { val, ptr, align, volatile } => InstrKind::Store {
+        InstrKind::Store {
+            val,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Store {
             val: rw(val, rep),
             ptr: rw(ptr, rep),
             align,
             volatile,
         },
-        InstrKind::Load { ty, ptr, align, volatile } => InstrKind::Load {
+        InstrKind::Load {
+            ty,
+            ptr,
+            align,
+            volatile,
+        } => InstrKind::Load {
             ty,
             ptr: rw(ptr, rep),
             align,
@@ -616,7 +621,12 @@ fn rewrite_kind(kind: InstrKind, rep: &HashMap<InstrId, InstrId>) -> InstrKind {
             lhs: rw(lhs, rep),
             rhs: rw(rhs, rep),
         },
-        InstrKind::FCmp { flags, pred, lhs, rhs } => InstrKind::FCmp {
+        InstrKind::FCmp {
+            flags,
+            pred,
+            lhs,
+            rhs,
+        } => InstrKind::FCmp {
             flags,
             pred,
             lhs: rw(lhs, rep),
@@ -760,8 +770,8 @@ fn instr_id_of(vref: ValueRef) -> Option<InstrId> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use llvm_ir::{Builder, Context, Linkage, Module};
     use llvm_ir::types::TypeData;
+    use llvm_ir::{Builder, Context, Linkage, Module};
 
     /// Build a function that loads 4 f64 values at consecutive GEP offsets
     /// and fadds each pair. Verify that SLP produces a vector load + vector
@@ -826,7 +836,11 @@ mod tests {
 
         // Build 4 fadds and store results so DCE cannot eliminate the computation.
         for i in 0..4i64 {
-            let r = b.build_fadd(format!("r{}", i), a_loads[i as usize], b_loads_vec[i as usize]);
+            let r = b.build_fadd(
+                format!("r{}", i),
+                a_loads[i as usize],
+                b_loads_vec[i as usize],
+            );
             let idx = ValueRef::Constant(b.ctx.const_int(i64_ty, i as u64));
             let gep_out = b.build_gep_inbounds(format!("out{}", i), f64_ty, out_ptr, vec![idx]);
             b.build_store(r, gep_out);
@@ -991,7 +1005,10 @@ mod tests {
         let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
         // Total FP ops = 4, but they are split between f32 and f64, so no valid
         // group of 4 with uniform type exists.
-        assert!(!changed, "mixed-type pairs below min_width must not vectorize");
+        assert!(
+            !changed,
+            "mixed-type pairs below min_width must not vectorize"
+        );
     }
 
     /// O2 pipeline with sequential f64 array adds must produce vector IR.
@@ -1008,9 +1025,10 @@ mod tests {
         pm.run_until_fixed_point(&mut ctx, &mut module, 8);
 
         let func = &module.functions[0];
-        let has_vector_ty = func.instructions.iter().any(|instr| {
-            matches!(ctx.get_type(instr.ty), TypeData::Vector { .. })
-        });
+        let has_vector_ty = func
+            .instructions
+            .iter()
+            .any(|instr| matches!(ctx.get_type(instr.ty), TypeData::Vector { .. }));
         assert!(
             has_vector_ty,
             "after O2+SLP, function should contain at least one instruction with vector type"

--- a/src/llvm-transforms/src/tailcall.rs
+++ b/src/llvm-transforms/src/tailcall.rs
@@ -20,11 +20,7 @@ impl ModulePass for TailCallOpt {
         let mut changed = false;
         // Collect (function_index, function_name) pairs so we can look up
         // callees by GlobalId later.
-        let name_by_idx: Vec<String> = module
-            .functions
-            .iter()
-            .map(|f| f.name.clone())
-            .collect();
+        let name_by_idx: Vec<String> = module.functions.iter().map(|f| f.name.clone()).collect();
 
         for fidx in 0..module.functions.len() {
             if module.functions[fidx].is_declaration {
@@ -106,12 +102,10 @@ fn run_on_function_with_name(
                     } else {
                         // Check for self-recursive call.
                         let is_self = match callee {
-                            ValueRef::Global(gid) => {
-                                name_by_idx
-                                    .get(gid.0 as usize)
-                                    .map(|n| n == func_name)
-                                    .unwrap_or(false)
-                            }
+                            ValueRef::Global(gid) => name_by_idx
+                                .get(gid.0 as usize)
+                                .map(|n| n == func_name)
+                                .unwrap_or(false),
                             _ => false,
                         };
                         Some(if is_self {
@@ -192,14 +186,7 @@ mod tests {
 
         let callee_ty = b.ctx.mk_fn_type(b.ctx.i32_ty, vec![], false);
         b.add_declaration("callee", b.ctx.i32_ty, vec![], false);
-        b.add_function(
-            "f",
-            b.ctx.i32_ty,
-            vec![],
-            vec![],
-            false,
-            Linkage::External,
-        );
+        b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let call = b.build_call(
@@ -260,7 +247,11 @@ mod tests {
         assert!(pass.run_on_module(&mut ctx, &mut module));
         match &module.functions[0].instr(call_id).kind {
             InstrKind::Call { tail, .. } => {
-                assert_eq!(*tail, TailCallKind::MustTail, "self-recursive call should be MustTail")
+                assert_eq!(
+                    *tail,
+                    TailCallKind::MustTail,
+                    "self-recursive call should be MustTail"
+                )
             }
             other => panic!("expected call, got {other:?}"),
         }
@@ -275,14 +266,7 @@ mod tests {
 
         let callee_ty = b.ctx.mk_fn_type(b.ctx.i32_ty, vec![], false);
         b.add_declaration("callee", b.ctx.i32_ty, vec![], false);
-        b.add_function(
-            "f",
-            b.ctx.i32_ty,
-            vec![],
-            vec![],
-            false,
-            Linkage::External,
-        );
+        b.add_function("f", b.ctx.i32_ty, vec![], vec![], false, Linkage::External);
         let entry = b.add_block("entry");
         b.position_at_end(entry);
         let call = b.build_call(
@@ -345,7 +329,11 @@ mod tests {
         assert!(pass.run_on_module(&mut ctx, &mut module));
         match &module.functions[1].instr(call_id).kind {
             InstrKind::Call { tail, .. } => {
-                assert_eq!(*tail, TailCallKind::Tail, "void tail call should be marked Tail")
+                assert_eq!(
+                    *tail,
+                    TailCallKind::Tail,
+                    "void tail call should be marked Tail"
+                )
             }
             other => panic!("expected call, got {other:?}"),
         }
@@ -389,7 +377,11 @@ mod tests {
 
         match &module.functions[1].instr(call_id).kind {
             InstrKind::Call { tail, .. } => {
-                assert_ne!(*tail, TailCallKind::None, "O2 pipeline should mark tail call");
+                assert_ne!(
+                    *tail,
+                    TailCallKind::None,
+                    "O2 pipeline should mark tail call"
+                );
             }
             other => panic!("expected call, got {other:?}"),
         }

--- a/src/llvm-transforms/src/tsan.rs
+++ b/src/llvm-transforms/src/tsan.rs
@@ -314,9 +314,7 @@ fn instrument_memory_accesses(
                 }
                 InstrKind::Store { val, ptr, .. } => {
                     let val_ty = value_type(func, *val);
-                    let bytes = val_ty
-                        .and_then(|ty| type_size_bytes(ctx, ty))
-                        .unwrap_or(4);
+                    let bytes = val_ty.and_then(|ty| type_size_bytes(ctx, ty)).unwrap_or(4);
                     let skip = is_alloca_derived(func, *ptr, alloca_vrefs);
                     accesses.push(MemAccess {
                         block_idx: bi,
@@ -590,7 +588,10 @@ mod tests {
         pass.run_on_module(&mut ctx, &mut module);
         // f is function index 0
         let count = count_calls_to(&module, 0, "__tsan_read8");
-        assert!(count >= 1, "__tsan_read8 should be called at least once, got {count}");
+        assert!(
+            count >= 1,
+            "__tsan_read8 should be called at least once, got {count}"
+        );
     }
 
     #[test]
@@ -599,7 +600,10 @@ mod tests {
         let mut pass = TsanPass;
         pass.run_on_module(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__tsan_write8");
-        assert!(count >= 1, "__tsan_write8 should be called at least once, got {count}");
+        assert!(
+            count >= 1,
+            "__tsan_write8 should be called at least once, got {count}"
+        );
     }
 
     #[test]
@@ -633,7 +637,10 @@ mod tests {
         let entry_count = count_calls_to(&module, 0, "__tsan_func_entry");
         let exit_count = count_calls_to(&module, 0, "__tsan_func_exit");
         assert!(entry_count >= 1, "__tsan_func_entry must be inserted");
-        assert!(exit_count >= 1, "__tsan_func_exit must be inserted before ret");
+        assert!(
+            exit_count >= 1,
+            "__tsan_func_exit must be inserted before ret"
+        );
     }
 
     #[test]

--- a/src/llvm-transforms/src/ubsan.rs
+++ b/src/llvm-transforms/src/ubsan.rs
@@ -67,11 +67,7 @@ impl crate::pass::ModulePass for UbsanModulePass {
         "ubsan-module"
     }
 
-    fn run_on_module(
-        &mut self,
-        ctx: &mut llvm_ir::Context,
-        module: &mut llvm_ir::Module,
-    ) -> bool {
+    fn run_on_module(&mut self, ctx: &mut llvm_ir::Context, module: &mut llvm_ir::Module) -> bool {
         ensure_declarations(ctx, module);
 
         let num_funcs = module.functions.len();
@@ -330,7 +326,11 @@ fn instrument_div_by_zero(ctx: &mut Context, func: &mut Function) -> bool {
     };
 
     // Process in reverse block/pos order.
-    sites.sort_by(|a, b| b.block_idx.cmp(&a.block_idx).then(b.body_pos.cmp(&a.body_pos)));
+    sites.sort_by(|a, b| {
+        b.block_idx
+            .cmp(&a.block_idx)
+            .then(b.body_pos.cmp(&a.body_pos))
+    });
 
     for site in sites {
         let DivSite {
@@ -635,10 +635,7 @@ fn is_integer_type(ctx: &Context, ty: llvm_ir::TypeId) -> bool {
     matches!(ctx.get_type(ty), llvm_ir::TypeData::Integer(_))
 }
 
-fn is_provably_non_null(
-    ptr: ValueRef,
-    alloca_ids: &std::collections::HashSet<InstrId>,
-) -> bool {
+fn is_provably_non_null(ptr: ValueRef, alloca_ids: &std::collections::HashSet<InstrId>) -> bool {
     match ptr {
         // Alloca: always non-null (stack pointer).
         ValueRef::Instruction(iid) => alloca_ids.contains(&iid),
@@ -886,7 +883,10 @@ mod tests {
         let (mut ctx, mut module) = make_add_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_add_overflow");
-        assert!(count >= 1, "__ubsan_handle_add_overflow should be inserted for non-nsw add, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_add_overflow should be inserted for non-nsw add, got {count}"
+        );
     }
 
     #[test]
@@ -902,7 +902,10 @@ mod tests {
         let (mut ctx, mut module) = make_div_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_divrem_overflow");
-        assert!(count >= 1, "__ubsan_handle_divrem_overflow should be inserted for sdiv, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_divrem_overflow should be inserted for sdiv, got {count}"
+        );
     }
 
     #[test]
@@ -910,7 +913,10 @@ mod tests {
         let (mut ctx, mut module) = make_rem_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_divrem_overflow");
-        assert!(count >= 1, "__ubsan_handle_divrem_overflow should be inserted for srem, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_divrem_overflow should be inserted for srem, got {count}"
+        );
     }
 
     #[test]
@@ -918,7 +924,10 @@ mod tests {
         let (mut ctx, mut module) = make_load_ptr_arg_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_null_ptr_deref");
-        assert!(count >= 1, "__ubsan_handle_null_ptr_deref should be inserted for load from arg ptr, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_null_ptr_deref should be inserted for load from arg ptr, got {count}"
+        );
     }
 
     #[test]
@@ -926,7 +935,10 @@ mod tests {
         let (mut ctx, mut module) = make_store_ptr_arg_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_null_ptr_deref");
-        assert!(count >= 1, "__ubsan_handle_null_ptr_deref should be inserted for store to arg ptr, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_null_ptr_deref should be inserted for store to arg ptr, got {count}"
+        );
     }
 
     #[test]
@@ -934,7 +946,10 @@ mod tests {
         let (mut ctx, mut module) = make_alloca_load_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_null_ptr_deref");
-        assert_eq!(count, 0, "loads from alloca must NOT get null check, got {count}");
+        assert_eq!(
+            count, 0,
+            "loads from alloca must NOT get null check, got {count}"
+        );
     }
 
     #[test]
@@ -943,13 +958,12 @@ mod tests {
         run_ubsan(&mut ctx, &mut module);
         // function index 1 (function 0 is... wait, globals are separate from functions)
         // The function is the last added function — after the global.
-        let func_idx = module
-            .functions
-            .iter()
-            .position(|f| f.name == "f")
-            .unwrap();
+        let func_idx = module.functions.iter().position(|f| f.name == "f").unwrap();
         let count = count_calls_to(&module, func_idx, "__ubsan_handle_null_ptr_deref");
-        assert_eq!(count, 0, "loads from globals must NOT get null check, got {count}");
+        assert_eq!(
+            count, 0,
+            "loads from globals must NOT get null check, got {count}"
+        );
     }
 
     #[test]
@@ -957,14 +971,20 @@ mod tests {
         let (mut ctx, mut module) = make_unreachable_module();
         run_ubsan(&mut ctx, &mut module);
         let count = count_calls_to(&module, 0, "__ubsan_handle_builtin_unreachable");
-        assert!(count >= 1, "__ubsan_handle_builtin_unreachable should be inserted, got {count}");
+        assert!(
+            count >= 1,
+            "__ubsan_handle_builtin_unreachable should be inserted, got {count}"
+        );
         // Unreachable terminator must still be present.
         let still_unreachable = module.functions[0]
             .blocks
             .iter()
             .filter_map(|bb| bb.terminator)
             .any(|tid| matches!(module.functions[0].instr(tid).kind, InstrKind::Unreachable));
-        assert!(still_unreachable, "unreachable terminator must still be present after instrumentation");
+        assert!(
+            still_unreachable,
+            "unreachable terminator must still be present after instrumentation"
+        );
     }
 
     #[test]

--- a/src/llvm-transforms/tests/mem2reg_property.rs
+++ b/src/llvm-transforms/tests/mem2reg_property.rs
@@ -125,7 +125,14 @@ fn compile_and_run_ours_exit_code(src: &str) -> Option<i32> {
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let mut emitter = X86Emitter::new(obj_format);

--- a/src/llvm-transforms/tests/reassoc.rs
+++ b/src/llvm-transforms/tests/reassoc.rs
@@ -2,14 +2,10 @@
 //! FMF-exploiting FP constant folding (`try_fold_fp`).
 
 use llvm_ir::{
-    ArgId, Builder, ConstantData, Context, FastMathFlags, InstrId, InstrKind, Instruction,
-    Linkage, Module, TypeId, ValueRef,
+    ArgId, Builder, ConstantData, Context, FastMathFlags, InstrId, InstrKind, Instruction, Linkage,
+    Module, TypeId, ValueRef,
 };
-use llvm_transforms::{
-    constant_fold::try_fold_fp,
-    pass::FunctionPass,
-    reassoc::ReassocPass,
-};
+use llvm_transforms::{constant_fold::try_fold_fp, pass::FunctionPass, reassoc::ReassocPass};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -43,7 +39,13 @@ fn body_len(module: &Module) -> usize {
 }
 
 /// Helper: append an instruction to block 0 of function 0, return its InstrId.
-fn push_instr(ctx: &Context, module: &mut Module, name: &str, ty: TypeId, kind: InstrKind) -> ValueRef {
+fn push_instr(
+    ctx: &Context,
+    module: &mut Module,
+    name: &str,
+    ty: TypeId,
+    kind: InstrKind,
+) -> ValueRef {
     let f = &mut module.functions[0];
     let iid = f.alloc_instr(Instruction::new(Some(name.into()), ty, kind));
     f.blocks[0].body.push(iid);
@@ -63,22 +65,42 @@ fn set_ret(ctx: &Context, module: &mut Module, val: ValueRef) {
 }
 
 fn flags_nsz() -> FastMathFlags {
-    FastMathFlags { nsz: true, ..Default::default() }
+    FastMathFlags {
+        nsz: true,
+        ..Default::default()
+    }
 }
 fn flags_nnan() -> FastMathFlags {
-    FastMathFlags { nnan: true, ..Default::default() }
+    FastMathFlags {
+        nnan: true,
+        ..Default::default()
+    }
 }
 fn flags_nnan_ninf() -> FastMathFlags {
-    FastMathFlags { nnan: true, ninf: true, ..Default::default() }
+    FastMathFlags {
+        nnan: true,
+        ninf: true,
+        ..Default::default()
+    }
 }
 fn flags_arcp() -> FastMathFlags {
-    FastMathFlags { arcp: true, ..Default::default() }
+    FastMathFlags {
+        arcp: true,
+        ..Default::default()
+    }
 }
 fn flags_reassoc() -> FastMathFlags {
-    FastMathFlags { reassoc: true, nnan: true, ..Default::default() }
+    FastMathFlags {
+        reassoc: true,
+        nnan: true,
+        ..Default::default()
+    }
 }
 fn flags_fast() -> FastMathFlags {
-    FastMathFlags { fast: true, ..Default::default() }
+    FastMathFlags {
+        fast: true,
+        ..Default::default()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +117,11 @@ fn nsz_fadd_zero_elim() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FAdd { flags: flags_nsz(), lhs: x, rhs: zero },
+        InstrKind::FAdd {
+            flags: flags_nsz(),
+            lhs: x,
+            rhs: zero,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -129,7 +155,11 @@ fn nsz_fsub_zero_elim() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FSub { flags: flags_nsz(), lhs: x, rhs: zero },
+        InstrKind::FSub {
+            flags: flags_nsz(),
+            lhs: x,
+            rhs: zero,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -153,7 +183,11 @@ fn nnan_fmul_one_elim() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FMul { flags: flags_nnan(), lhs: x, rhs: one },
+        InstrKind::FMul {
+            flags: flags_nnan(),
+            lhs: x,
+            rhs: one,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -202,7 +236,11 @@ fn nnan_ninf_fmul_zero() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FMul { flags: flags_nnan_ninf(), lhs: x, rhs: zero },
+        InstrKind::FMul {
+            flags: flags_nnan_ninf(),
+            lhs: x,
+            rhs: zero,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -244,7 +282,11 @@ fn reassoc_const_chain() {
         &mut module,
         "inner",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: x, rhs: c1 },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: x,
+            rhs: c1,
+        },
     );
 
     // outer = fadd reassoc double %inner, 2.0
@@ -253,7 +295,11 @@ fn reassoc_const_chain() {
         &mut module,
         "outer",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: inner, rhs: c2 },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: inner,
+            rhs: c2,
+        },
     );
 
     set_ret(&ctx, &mut module, outer);
@@ -351,7 +397,11 @@ fn fast_flag_enables_all() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FAdd { flags: flags_fast(), lhs: x, rhs: zero },
+        InstrKind::FAdd {
+            flags: flags_fast(),
+            lhs: x,
+            rhs: zero,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -375,7 +425,11 @@ fn fdiv_one_elim() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FDiv { flags: flags_nnan(), lhs: x, rhs: one },
+        InstrKind::FDiv {
+            flags: flags_nnan(),
+            lhs: x,
+            rhs: one,
+        },
     );
     set_ret(&ctx, &mut module, r);
 
@@ -418,7 +472,10 @@ fn fold_fp_nnan_suppresses_nan() {
     let f64_ty = ctx.f64_ty;
     let zero = ValueRef::Constant(ctx.const_float(f64_ty, 0f64.to_bits()));
     let kind = InstrKind::FDiv {
-        flags: FastMathFlags { nnan: true, ..Default::default() },
+        flags: FastMathFlags {
+            nnan: true,
+            ..Default::default()
+        },
         lhs: zero,
         rhs: zero,
     };
@@ -440,7 +497,11 @@ fn nsz_fadd_zero_lhs_elim() {
         &mut module,
         "r",
         f64_ty,
-        InstrKind::FAdd { flags: flags_nsz(), lhs: zero, rhs: x },
+        InstrKind::FAdd {
+            flags: flags_nsz(),
+            lhs: zero,
+            rhs: x,
+        },
     );
     set_ret(&ctx, &mut module, r);
 

--- a/src/llvm-transforms/tests/strict_fp.rs
+++ b/src/llvm-transforms/tests/strict_fp.rs
@@ -2,14 +2,10 @@
 //! constant folding, plus `strictfp` function attribute round-trip.
 
 use llvm_ir::{
-    ArgId, BlockId, Builder, Context, FastMathFlags, InstrKind, Instruction, Linkage,
-    Module, TypeId, ValueRef,
+    ArgId, BlockId, Builder, Context, FastMathFlags, InstrKind, Instruction, Linkage, Module,
+    TypeId, ValueRef,
 };
-use llvm_transforms::{
-    gvn::Gvn,
-    licm::Licm,
-    pass::FunctionPass,
-};
+use llvm_transforms::{gvn::Gvn, licm::Licm, pass::FunctionPass};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -65,7 +61,10 @@ fn flags_none() -> FastMathFlags {
 }
 
 fn flags_reassoc() -> FastMathFlags {
-    FastMathFlags { reassoc: true, ..Default::default() }
+    FastMathFlags {
+        reassoc: true,
+        ..Default::default()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -84,14 +83,22 @@ fn gvn_does_not_cse_strict_fadd() {
         &mut module,
         "x1",
         f64_ty,
-        InstrKind::FAdd { flags: flags_none(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_none(),
+            lhs: a,
+            rhs: b,
+        },
     );
     // %x2 = fadd double %a, %b    (identical, no flags)
     let x2 = push_instr(
         &mut module,
         "x2",
         f64_ty,
-        InstrKind::FAdd { flags: flags_none(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_none(),
+            lhs: a,
+            rhs: b,
+        },
     );
     set_ret(&ctx, &mut module, x2);
 
@@ -102,10 +109,7 @@ fn gvn_does_not_cse_strict_fadd() {
     let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
 
     // GVN must NOT fire: strict FP forbids CSE.
-    assert!(
-        !changed,
-        "GVN must not CSE strict (no-FMF) fadds"
-    );
+    assert!(!changed, "GVN must not CSE strict (no-FMF) fadds");
     assert_eq!(
         body_len(&module, BlockId(0)),
         2,
@@ -129,14 +133,22 @@ fn gvn_cse_fadd_with_reassoc() {
         &mut module,
         "x1",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: a,
+            rhs: b,
+        },
     );
     // %x2 = fadd reassoc double %a, %b  (identical)
     let x2 = push_instr(
         &mut module,
         "x2",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: a,
+            rhs: b,
+        },
     );
     set_ret(&ctx, &mut module, x2);
 
@@ -226,8 +238,9 @@ fn build_fp_invariant_loop(flags: FastMathFlags) -> (Context, Module, BlockId) {
     // Overwrite the fadd flags to the desired value.
     {
         let fp_inv_iid = module.functions[0].value_names["fp_inv"];
-        if let InstrKind::FAdd { flags: ref mut f, .. } =
-            &mut module.functions[0].instructions[fp_inv_iid.0 as usize].kind
+        if let InstrKind::FAdd {
+            flags: ref mut f, ..
+        } = &mut module.functions[0].instructions[fp_inv_iid.0 as usize].kind
         {
             *f = flags;
         }
@@ -253,7 +266,9 @@ fn licm_does_not_hoist_strict_fadd() {
     // fp_inv must NOT be hoisted: no FMF flags → strict FP semantics.
     let fp_inv_id = module.functions[0].value_names["fp_inv"];
     assert!(
-        module.functions[0].blocks[body.0 as usize].body.contains(&fp_inv_id),
+        module.functions[0].blocks[body.0 as usize]
+            .body
+            .contains(&fp_inv_id),
         "%fp_inv must NOT be hoisted out of the loop (no fast-math flags)"
     );
 }
@@ -269,12 +284,17 @@ fn licm_hoists_fadd_with_reassoc() {
     let mut pass = Licm;
     let changed = pass.run_on_function(&mut ctx, &mut module.functions[0]);
 
-    assert!(changed, "LICM must report a change when hoisting reassoc fadd");
+    assert!(
+        changed,
+        "LICM must report a change when hoisting reassoc fadd"
+    );
 
     // fp_inv must be hoisted out of the body.
     let fp_inv_id = module.functions[0].value_names["fp_inv"];
     assert!(
-        !module.functions[0].blocks[body.0 as usize].body.contains(&fp_inv_id),
+        !module.functions[0].blocks[body.0 as usize]
+            .body
+            .contains(&fp_inv_id),
         "%fp_inv must be hoisted out of the loop when reassoc is set"
     );
 }
@@ -344,13 +364,21 @@ fn strictfp_blocks_fp_cse_entirely() {
         &mut module,
         "x1",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: a,
+            rhs: b,
+        },
     );
     let x2 = push_instr(
         &mut module,
         "x2",
         f64_ty,
-        InstrKind::FAdd { flags: flags_reassoc(), lhs: a, rhs: b },
+        InstrKind::FAdd {
+            flags: flags_reassoc(),
+            lhs: a,
+            rhs: b,
+        },
     );
     set_ret(&ctx, &mut module, x2);
 

--- a/src/llvm/src/bin/codegen-quality.rs
+++ b/src/llvm/src/bin/codegen-quality.rs
@@ -91,7 +91,8 @@ fn count_opcode(mf: &MachineFunction, opcode: MOpcode) -> usize {
 
 fn compile_kernel(path: &Path, emit_dir: &Path) -> Result<KernelMetrics, String> {
     let source = fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
-    let (mut ctx, mut module) = parse(&source).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    let (mut ctx, mut module) =
+        parse(&source).map_err(|e| format!("parse {}: {e}", path.display()))?;
     let func_idx = module
         .functions
         .iter()
@@ -112,7 +113,14 @@ fn compile_kernel(path: &Path, emit_dir: &Path) -> Result<KernelMetrics, String>
         &mf.allocatable_fp_pregs,
         RegAllocStrategy::LinearScan,
     );
-    insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM);
+    insert_spill_reloads(
+        &mut mf,
+        &mut result,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+        MOV_LOAD_MR,
+        MOV_STORE_RM,
+    );
     apply_allocation(&mut mf, &result);
 
     let machine_instructions: usize = mf.blocks.iter().map(|b| b.instrs.len()).sum();

--- a/src/llvm/src/bin/large-program-bench.rs
+++ b/src/llvm/src/bin/large-program-bench.rs
@@ -95,7 +95,13 @@ fn load_baselines(path: &Path) -> std::collections::HashMap<String, BaselineEntr
             if let (Some(name), Some(tb), Some(cm)) =
                 (current_name.take(), text_bytes.take(), compile_ms.take())
             {
-                map.insert(name, BaselineEntry { text_bytes: tb, compile_ms: cm });
+                map.insert(
+                    name,
+                    BaselineEntry {
+                        text_bytes: tb,
+                        compile_ms: cm,
+                    },
+                );
             }
         }
     }
@@ -110,10 +116,7 @@ fn extract_u64_field(line: &str, field: &str) -> Option<u64> {
     rest.parse::<u64>().ok()
 }
 
-fn save_baselines(
-    path: &Path,
-    entries: &[(String, BenchResult)],
-) -> Result<(), String> {
+fn save_baselines(path: &Path, entries: &[(String, BenchResult)]) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("create dir {}: {e}", parent.display()))?;
     }
@@ -135,14 +138,14 @@ fn save_baselines(
 
 #[derive(Debug, Clone)]
 struct BenchResult {
-    fixture:          String,
-    input_bytes:      usize,
-    text_bytes:       usize,
+    fixture: String,
+    input_bytes: usize,
+    text_bytes: usize,
     /// text_bytes / 4 — rough instruction count (each x86 instr encoded ≥4 B on average)
-    instr_estimate:   usize,
-    compile_ms:       u64,
+    instr_estimate: usize,
+    compile_ms: u64,
     /// Compiler-visible RSS estimate: 2× input bytes rule satisfied?
-    rss_ok:           bool,
+    rss_ok: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +166,11 @@ fn bench_fixture(path: &Path, fmt: ObjectFormat) -> Result<BenchResult, String> 
     // We use the whole object size as an upper bound; the real text section
     // is extracted separately via a simple scan for the .text content length.
     let text_bytes = estimate_text_bytes(&obj_bytes, fmt);
-    let instr_estimate = if text_bytes >= 4 { text_bytes / 4 } else { text_bytes };
+    let instr_estimate = if text_bytes >= 4 {
+        text_bytes / 4
+    } else {
+        text_bytes
+    };
 
     // RSS rule: object output must be <= 2× input IR size (memory efficiency check).
     // We approximate peak RSS as the output object size (worst-case allocator).
@@ -175,7 +182,7 @@ fn bench_fixture(path: &Path, fmt: ObjectFormat) -> Result<BenchResult, String> 
         .ok_or_else(|| format!("invalid filename: {}", path.display()))?;
 
     Ok(BenchResult {
-        fixture:        stem.to_string(),
+        fixture: stem.to_string(),
         input_bytes,
         text_bytes,
         instr_estimate,
@@ -197,29 +204,41 @@ fn estimate_text_bytes(obj: &[u8], fmt: ObjectFormat) -> usize {
 
 /// Read ELF-64 section header table and find .text section size.
 fn elf_text_size(obj: &[u8]) -> Option<usize> {
-    if obj.len() < 64 { return None; }
-    if obj[0..4] != [0x7f, b'E', b'L', b'F'] { return None; }
+    if obj.len() < 64 {
+        return None;
+    }
+    if obj[0..4] != [0x7f, b'E', b'L', b'F'] {
+        return None;
+    }
     // ELF64 header offsets (all little-endian)
-    let e_shoff     = u64::from_le_bytes(obj.get(40..48)?.try_into().ok()?) as usize;
+    let e_shoff = u64::from_le_bytes(obj.get(40..48)?.try_into().ok()?) as usize;
     let e_shentsize = u16::from_le_bytes(obj.get(58..60)?.try_into().ok()?) as usize;
-    let e_shnum     = u16::from_le_bytes(obj.get(60..62)?.try_into().ok()?) as usize;
-    let e_shstrndx  = u16::from_le_bytes(obj.get(62..64)?.try_into().ok()?) as usize;
+    let e_shnum = u16::from_le_bytes(obj.get(60..62)?.try_into().ok()?) as usize;
+    let e_shstrndx = u16::from_le_bytes(obj.get(62..64)?.try_into().ok()?) as usize;
 
-    if e_shoff == 0 || e_shentsize < 64 || e_shnum == 0 { return None; }
+    if e_shoff == 0 || e_shentsize < 64 || e_shnum == 0 {
+        return None;
+    }
 
     // Section name string table
     let shstrtab_start = e_shoff + e_shstrndx * e_shentsize;
-    if shstrtab_start + e_shentsize > obj.len() { return None; }
-    let shstr_off  = u64::from_le_bytes(
-        obj.get(shstrtab_start + 24..shstrtab_start + 32)?.try_into().ok()?,
+    if shstrtab_start + e_shentsize > obj.len() {
+        return None;
+    }
+    let shstr_off = u64::from_le_bytes(
+        obj.get(shstrtab_start + 24..shstrtab_start + 32)?
+            .try_into()
+            .ok()?,
     ) as usize;
 
     // Walk section headers looking for ".text"
     for i in 0..e_shnum {
         let sh = e_shoff + i * e_shentsize;
-        if sh + e_shentsize > obj.len() { break; }
-        let sh_name  = u32::from_le_bytes(obj.get(sh..sh + 4)?.try_into().ok()?) as usize;
-        let sh_size  = u64::from_le_bytes(obj.get(sh + 32..sh + 40)?.try_into().ok()?) as usize;
+        if sh + e_shentsize > obj.len() {
+            break;
+        }
+        let sh_name = u32::from_le_bytes(obj.get(sh..sh + 4)?.try_into().ok()?) as usize;
+        let sh_size = u64::from_le_bytes(obj.get(sh + 32..sh + 40)?.try_into().ok()?) as usize;
         let name_off = shstr_off + sh_name;
         if obj.get(name_off..)?.starts_with(b".text\0") {
             return Some(sh_size);
@@ -230,38 +249,43 @@ fn elf_text_size(obj: &[u8]) -> Option<usize> {
 
 /// Read Mach-O 64-bit section table and find __text section size.
 fn macho_text_size(obj: &[u8]) -> Option<usize> {
-    if obj.len() < 32 { return None; }
+    if obj.len() < 32 {
+        return None;
+    }
     // magic: 0xFEEDFACF (LE) = CF FA ED FE
-    if obj[0..4] != [0xCF, 0xFA, 0xED, 0xFE] { return None; }
-    let ncmds    = u32::from_le_bytes(obj.get(16..20)?.try_into().ok()?) as usize;
+    if obj[0..4] != [0xCF, 0xFA, 0xED, 0xFE] {
+        return None;
+    }
+    let ncmds = u32::from_le_bytes(obj.get(16..20)?.try_into().ok()?) as usize;
     let mut off = 32usize; // mach_header_64 is 32 bytes
     for _ in 0..ncmds {
-        if off + 8 > obj.len() { break; }
-        let cmd     = u32::from_le_bytes(obj.get(off..off + 4)?.try_into().ok()?);
+        if off + 8 > obj.len() {
+            break;
+        }
+        let cmd = u32::from_le_bytes(obj.get(off..off + 4)?.try_into().ok()?);
         let cmdsize = u32::from_le_bytes(obj.get(off + 4..off + 8)?.try_into().ok()?) as usize;
         if cmd == 0x19 {
             // LC_SEGMENT_64: segname at +8 (16 bytes), nsects at +64
-            let nsects = u32::from_le_bytes(
-                obj.get(off + 64..off + 68)?.try_into().ok()?,
-            ) as usize;
+            let nsects = u32::from_le_bytes(obj.get(off + 64..off + 68)?.try_into().ok()?) as usize;
             let sec_base = off + 72; // first section_64
             for s in 0..nsects {
                 let sec = sec_base + s * 80; // sizeof(section_64) = 80
-                if sec + 80 > obj.len() { break; }
+                if sec + 80 > obj.len() {
+                    break;
+                }
                 // sectname at sec+0 (16 bytes), segname at sec+16 (16 bytes)
                 let sectname = &obj[sec..sec + 16];
-                let segname  = &obj[sec + 16..sec + 32];
-                if segname.starts_with(b"__TEXT\0")
-                    && sectname.starts_with(b"__text\0")
-                {
-                    let size = u64::from_le_bytes(
-                        obj.get(sec + 40..sec + 48)?.try_into().ok()?,
-                    ) as usize;
+                let segname = &obj[sec + 16..sec + 32];
+                if segname.starts_with(b"__TEXT\0") && sectname.starts_with(b"__text\0") {
+                    let size =
+                        u64::from_le_bytes(obj.get(sec + 40..sec + 48)?.try_into().ok()?) as usize;
                     return Some(size);
                 }
             }
         }
-        if cmdsize == 0 { break; }
+        if cmdsize == 0 {
+            break;
+        }
         off += cmdsize;
     }
     None
@@ -292,7 +316,10 @@ fn main() -> ExitCode {
             .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("ll"))
             .collect(),
         Err(e) => {
-            eprintln!("error: cannot read fixture dir {}: {e}", fixture_dir.display());
+            eprintln!(
+                "error: cannot read fixture dir {}: {e}",
+                fixture_dir.display()
+            );
             return ExitCode::FAILURE;
         }
     };
@@ -356,11 +383,15 @@ fn main() -> ExitCode {
     // --- compare to baselines ---
     let mut regression = false;
     if !update_baselines && !baselines.is_empty() {
-        println!("Baseline comparison (threshold: ±{:.0}%):", threshold * 100.0);
+        println!(
+            "Baseline comparison (threshold: ±{:.0}%):",
+            threshold * 100.0
+        );
         println!("{}", "-".repeat(80));
         for r in &results {
             if let Some(bl) = baselines.get(&r.fixture) {
-                let delta = (r.text_bytes as f64 - bl.text_bytes as f64) / bl.text_bytes.max(1) as f64;
+                let delta =
+                    (r.text_bytes as f64 - bl.text_bytes as f64) / bl.text_bytes.max(1) as f64;
                 let flag = if delta > threshold {
                     regression = true;
                     "  !! REGRESSION"
@@ -371,10 +402,16 @@ fn main() -> ExitCode {
                 };
                 println!(
                     "  {:<22}  text_bytes: {:>6} vs baseline {:>6}  ({:+.1}%){flag}",
-                    r.fixture, r.text_bytes, bl.text_bytes, delta * 100.0
+                    r.fixture,
+                    r.text_bytes,
+                    bl.text_bytes,
+                    delta * 100.0
                 );
             } else {
-                println!("  {:<22}  (no baseline — run with --update-baselines)", r.fixture);
+                println!(
+                    "  {:<22}  (no baseline — run with --update-baselines)",
+                    r.fixture
+                );
             }
         }
         println!();
@@ -409,7 +446,10 @@ fn main() -> ExitCode {
     }
 
     if regression {
-        eprintln!("FAIL: instruction count regression detected (>{:.0}% above baseline)", threshold * 100.0);
+        eprintln!(
+            "FAIL: instruction count regression detected (>{:.0}% above baseline)",
+            threshold * 100.0
+        );
         return ExitCode::FAILURE;
     }
 

--- a/src/llvm/src/bin/llvm-compile.rs
+++ b/src/llvm/src/bin/llvm-compile.rs
@@ -51,7 +51,9 @@ fn main() -> ExitCode {
                     .next()
                     .unwrap_or_else(|| die("--target requires an argument"));
                 if target != "x86_64" {
-                    eprintln!("warning: only x86_64 target is supported; ignoring --target {target}");
+                    eprintln!(
+                        "warning: only x86_64 target is supported; ignoring --target {target}"
+                    );
                 }
             }
             s if s.starts_with("-O") => {

--- a/src/llvm/src/bin/llvm-ir-min.rs
+++ b/src/llvm/src/bin/llvm-ir-min.rs
@@ -114,7 +114,8 @@ fn minimize_lines(
                 continue;
             }
             stats.attempts += 1;
-            fs::write(work_file, &trial_text).map_err(|e| format!("write trial file failed: {e}"))?;
+            fs::write(work_file, &trial_text)
+                .map_err(|e| format!("write trial file failed: {e}"))?;
             if run_predicate(predicate, work_file)? {
                 log.push(format!("remove line {i}: {removed}"));
                 lines = trial;
@@ -130,12 +131,18 @@ fn minimize_lines(
     Ok((format!("{}\n", lines.join("\n")), stats))
 }
 
-fn write_evidence_package(config: &Config, original: &str, minimized: &str, log_text: &str) -> Result<(), String> {
+fn write_evidence_package(
+    config: &Config,
+    original: &str,
+    minimized: &str,
+    log_text: &str,
+) -> Result<(), String> {
     let Some(dir) = &config.evidence_dir else {
         return Ok(());
     };
 
-    fs::create_dir_all(dir).map_err(|e| format!("failed to create evidence dir {}: {e}", dir.display()))?;
+    fs::create_dir_all(dir)
+        .map_err(|e| format!("failed to create evidence dir {}: {e}", dir.display()))?;
     fs::write(dir.join("original.ll"), original)
         .map_err(|e| format!("failed to write original.ll: {e}"))?;
     fs::write(dir.join("minimized.ll"), minimized)
@@ -144,10 +151,16 @@ fn write_evidence_package(config: &Config, original: &str, minimized: &str, log_
         .map_err(|e| format!("failed to write reducer.log: {e}"))?;
     fs::write(
         dir.join("repro.sh"),
-        format!("#!/usr/bin/env sh\nset -eu\n{}\n", config.predicate.replace("{{input}}", "${1:-minimized.ll}")),
+        format!(
+            "#!/usr/bin/env sh\nset -eu\n{}\n",
+            config.predicate.replace("{{input}}", "${1:-minimized.ll}")
+        ),
     )
     .map_err(|e| format!("failed to write repro.sh: {e}"))?;
-    let _ = Command::new("chmod").arg("+x").arg(dir.join("repro.sh")).status();
+    let _ = Command::new("chmod")
+        .arg("+x")
+        .arg(dir.join("repro.sh"))
+        .status();
 
     let manifest = format!(
         "input={}\noutput={}\nbucket_signature={}\noriginal_bytes={}\nminimized_bytes={}\n",

--- a/src/llvm/src/bin/llvm-ir-reduce.rs
+++ b/src/llvm/src/bin/llvm-ir-reduce.rs
@@ -55,7 +55,8 @@ fn main() -> ExitCode {
             }
             "--predicate" => {
                 predicate = Some(
-                    args.next().unwrap_or_else(|| die("--predicate requires an argument")),
+                    args.next()
+                        .unwrap_or_else(|| die("--predicate requires an argument")),
                 );
             }
             s if s.starts_with("--predicate=") => {

--- a/src/llvm/src/bin/llvm-test-suite-compat.rs
+++ b/src/llvm/src/bin/llvm-test-suite-compat.rs
@@ -41,7 +41,9 @@ fn main() {
                 )
             }
             "--help" | "-h" => {
-                eprintln!("usage: llvm-test-suite-compat [--suite-dir DIR] [--report PATH] [--limit N]");
+                eprintln!(
+                    "usage: llvm-test-suite-compat [--suite-dir DIR] [--report PATH] [--limit N]"
+                );
                 return;
             }
             other => panic!("unknown argument: {other}"),
@@ -82,7 +84,9 @@ fn main() {
                 continue;
             }
             Err(_) => {
-                stats.failures.push((rel, "parse-panic".into(), "panic".into()));
+                stats
+                    .failures
+                    .push((rel, "parse-panic".into(), "panic".into()));
                 continue;
             }
         };
@@ -95,7 +99,9 @@ fn main() {
             pm.run(&mut ctx, &mut module);
         }));
         if optimized.is_err() {
-            stats.failures.push((rel, "optimize-panic".into(), "panic".into()));
+            stats
+                .failures
+                .push((rel, "optimize-panic".into(), "panic".into()));
             continue;
         }
         stats.optimized += 1;
@@ -109,7 +115,9 @@ fn main() {
             }
         }));
         if codegen.is_err() {
-            stats.failures.push((rel, "codegen-panic".into(), "panic".into()));
+            stats
+                .failures
+                .push((rel, "codegen-panic".into(), "panic".into()));
             continue;
         }
         stats.codegen += 1;
@@ -153,9 +161,21 @@ fn write_report(path: &Path, suite_dir: &Path, stats: &Stats) -> std::io::Result
     body.push_str(&format!("Suite dir: `{}`\n\n", suite_dir.display()));
     body.push_str("| Stage | Count | Rate |\n|---|---:|---:|\n");
     body.push_str(&format!("| Total `.ll` files | {} | 100% |\n", stats.total));
-    body.push_str(&format!("| Parsed | {} | {:.1}% |\n", stats.parsed, pct(stats.parsed, stats.total)));
-    body.push_str(&format!("| Optimized | {} | {:.1}% |\n", stats.optimized, pct(stats.optimized, stats.total)));
-    body.push_str(&format!("| x86 codegen lowered | {} | {:.1}% |\n\n", stats.codegen, pct(stats.codegen, stats.total)));
+    body.push_str(&format!(
+        "| Parsed | {} | {:.1}% |\n",
+        stats.parsed,
+        pct(stats.parsed, stats.total)
+    ));
+    body.push_str(&format!(
+        "| Optimized | {} | {:.1}% |\n",
+        stats.optimized,
+        pct(stats.optimized, stats.total)
+    ));
+    body.push_str(&format!(
+        "| x86 codegen lowered | {} | {:.1}% |\n\n",
+        stats.codegen,
+        pct(stats.codegen, stats.total)
+    ));
 
     body.push_str("## First failures by file\n\n");
     for (file, stage, err) in stats.failures.iter().take(50) {

--- a/src/llvm/src/compile.rs
+++ b/src/llvm/src/compile.rs
@@ -17,7 +17,7 @@ use llvm_codegen::{
 };
 use llvm_ir_parser::parser::parse;
 use llvm_target_x86::{
-    instructions::{MOV_LOAD_MR, MOV_STORE_RM, MOVSD_LOAD_MR, MOVSD_STORE_RM},
+    instructions::{MOVSD_LOAD_MR, MOVSD_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM},
     X86Backend, X86Emitter,
 };
 use llvm_transforms::{build_pipeline, OptLevel};
@@ -36,8 +36,7 @@ pub fn compile_ir_to_object(
     opt_level: OptLevel,
     fmt: ObjectFormat,
 ) -> Result<Vec<u8>, String> {
-    let (mut ctx, mut module) =
-        parse(src).map_err(|e| format!("parse error: {e}"))?;
+    let (mut ctx, mut module) = parse(src).map_err(|e| format!("parse error: {e}"))?;
 
     let mut pm = build_pipeline(opt_level);
     pm.run_until_fixed_point(&mut ctx, &mut module, 8);
@@ -75,7 +74,14 @@ pub fn compile_ir_to_object(
             &mf.allocatable_fp_pregs,
             strategy,
         );
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM, MOVSD_LOAD_MR, MOVSD_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOVSD_LOAD_MR,
+            MOVSD_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
 
         let mut emitter = X86Emitter::new(fmt);

--- a/src/llvm/src/lto.rs
+++ b/src/llvm/src/lto.rs
@@ -46,11 +46,15 @@ pub fn extract_lto_payload(obj: &ObjectFile) -> Option<&[u8]> {
 }
 
 /// Merge all embedded IR payloads from `objects`, then run LTO passes.
-pub fn run_lto_from_objects(objects: &[ObjectFile], level: OptLevel) -> Result<(Context, Module), String> {
+pub fn run_lto_from_objects(
+    objects: &[ObjectFile],
+    level: OptLevel,
+) -> Result<(Context, Module), String> {
     let mut modules = Vec::new();
     for obj in objects {
         if let Some(bytes) = extract_lto_payload(obj) {
-            let decoded = read_bitcode(bytes).map_err(|e| format!("failed to decode LTO payload: {e:?}"))?;
+            let decoded =
+                read_bitcode(bytes).map_err(|e| format!("failed to decode LTO payload: {e:?}"))?;
             modules.push(decoded);
         }
     }
@@ -68,7 +72,12 @@ pub fn run_lto_from_objects(objects: &[ObjectFile], level: OptLevel) -> Result<(
     Ok((merged_ctx, merged_mod))
 }
 
-fn merge_module_into(dst_ctx: &mut Context, dst: &mut Module, src_ctx: Context, mut src: Module) -> Result<(), String> {
+fn merge_module_into(
+    dst_ctx: &mut Context,
+    dst: &mut Module,
+    src_ctx: Context,
+    mut src: Module,
+) -> Result<(), String> {
     // Merge globals (naive name-based policy).
     for gv in src.globals.drain(..) {
         if dst.get_global_id(&gv.name).is_none() {
@@ -87,7 +96,10 @@ fn merge_module_into(dst_ctx: &mut Context, dst: &mut Module, src_ctx: Context, 
                 if existing_is_decl && !f.is_declaration {
                     dst.functions[fid.0 as usize] = f;
                 } else if !existing_is_decl && !f.is_declaration {
-                    return Err(format!("duplicate function definition during LTO merge: {}", dst.function(fid).name));
+                    return Err(format!(
+                        "duplicate function definition during LTO merge: {}",
+                        dst.function(fid).name
+                    ));
                 }
             }
         }
@@ -185,7 +197,12 @@ mod tests {
         embed_lto_payload(&mut o2, &ctx_b, &m_b);
 
         let (_ctx_m, merged) = run_lto_from_objects(&[o1, o2], OptLevel::O2).expect("run lto");
-        let (_, callee) = merged.get_function("callee").expect("callee in merged module");
-        assert!(!callee.is_declaration, "callee definition should be available after merge");
+        let (_, callee) = merged
+            .get_function("callee")
+            .expect("callee in merged module");
+        assert!(
+            !callee.is_declaration,
+            "callee definition should be available after merge"
+        );
     }
 }

--- a/src/llvm/tests/compile_pipeline.rs
+++ b/src/llvm/tests/compile_pipeline.rs
@@ -3,8 +3,8 @@
 //! These tests call the compile logic directly without subprocesses so they
 //! run on every platform in the standard `cargo test` suite.
 
-use llvm::compile::{compile_ir_to_object, host_object_format, regalloc_strategy_for};
 use llvm::codegen::regalloc::RegAllocStrategy;
+use llvm::compile::{compile_ir_to_object, host_object_format, regalloc_strategy_for};
 use llvm_transforms::OptLevel;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -38,8 +38,7 @@ entry:
 }
 "#;
     let fmt = host_object_format();
-    let bytes = compile_ir_to_object(src, OptLevel::O0, fmt)
-        .expect("compile failed");
+    let bytes = compile_ir_to_object(src, OptLevel::O0, fmt).expect("compile failed");
     assert!(!bytes.is_empty(), "expected non-empty object");
     assert!(
         looks_like_object(&bytes),
@@ -64,15 +63,12 @@ entry:
 }
 "#;
     let fmt = host_object_format();
-    let bytes = compile_ir_to_object(src, OptLevel::O0, fmt)
-        .expect("compile failed");
+    let bytes = compile_ir_to_object(src, OptLevel::O0, fmt).expect("compile failed");
     assert!(!bytes.is_empty());
     // The object bytes should contain the symbol names somewhere as strings.
     let _text = std::str::from_utf8(&bytes).unwrap_or("");
     // ELF/Mach-O/COFF all store symbol names as ASCII in a string table.
-    let raw_contains = |needle: &[u8]| {
-        bytes.windows(needle.len()).any(|w| w == needle)
-    };
+    let raw_contains = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
     assert!(raw_contains(b"main"), "missing 'main' symbol in object");
     assert!(raw_contains(b"helper"), "missing 'helper' symbol in object");
 }
@@ -216,7 +212,10 @@ entry:
 "#;
     let fmt = host_object_format();
     let bytes = compile_ir_to_object(src, OptLevel::O2, fmt).expect("O2 compile failed");
-    assert!(looks_like_object(&bytes), "O2 output must be a valid object file");
+    assert!(
+        looks_like_object(&bytes),
+        "O2 output must be a valid object file"
+    );
 }
 
 #[test]
@@ -230,7 +229,10 @@ entry:
 "#;
     let fmt = host_object_format();
     let bytes = compile_ir_to_object(src, OptLevel::O3, fmt).expect("O3 compile failed");
-    assert!(looks_like_object(&bytes), "O3 output must be a valid object file");
+    assert!(
+        looks_like_object(&bytes),
+        "O3 output must be a valid object file"
+    );
 }
 
 #[test]
@@ -246,8 +248,8 @@ entry:
 }
 "#;
     let fmt = host_object_format();
-    let bytes = compile_ir_to_object(src, OptLevel::O2, fmt)
-        .expect("pressure-free O2 compile failed");
+    let bytes =
+        compile_ir_to_object(src, OptLevel::O2, fmt).expect("pressure-free O2 compile failed");
     assert!(
         looks_like_object(&bytes),
         "graph-coloring O2 output must be a valid object file"

--- a/src/llvm/tests/lto_multi_tu.rs
+++ b/src/llvm/tests/lto_multi_tu.rs
@@ -64,8 +64,7 @@ fn lto_merge_three_modules_finds_all_functions() {
          define i32 @main() { entry: %a = call i32 @add(i32 3, i32 4)  ret i32 %a }",
     );
 
-    let (_, merged) = run_lto_from_objects(&[o1, o2, o3], OptLevel::O0)
-        .expect("LTO merge failed");
+    let (_, merged) = run_lto_from_objects(&[o1, o2, o3], OptLevel::O0).expect("LTO merge failed");
 
     assert!(
         merged.get_function_id("add").is_some(),
@@ -95,8 +94,8 @@ fn lto_cross_module_merge_and_optimize_succeeds() {
          define i32 @main() { entry: %r = call i32 @add(i32 3, i32 4)  ret i32 %r }",
     );
 
-    let (_, merged) = run_lto_from_objects(&[math, main_mod], OptLevel::O2)
-        .expect("LTO O2 merge must not fail");
+    let (_, merged) =
+        run_lto_from_objects(&[math, main_mod], OptLevel::O2).expect("LTO O2 merge must not fail");
 
     assert!(
         merged.get_function_id("add").is_some(),
@@ -109,7 +108,10 @@ fn lto_cross_module_merge_and_optimize_succeeds() {
 
     // The @add definition should no longer be a declaration after merge.
     let (_, add_fn) = merged.get_function("add").expect("@add not found");
-    assert!(!add_fn.is_declaration, "@add should be a definition after cross-module merge");
+    assert!(
+        !add_fn.is_declaration,
+        "@add should be a definition after cross-module merge"
+    );
 
     // The @main function must still have its instructions intact.
     let (_, main_fn) = merged.get_function("main").expect("@main not found");
@@ -137,8 +139,7 @@ fn lto_dead_stripping_removes_unused_function() {
 
     let (_, merged_o0) =
         run_lto_from_objects(&[with_dead.clone()], OptLevel::O0).expect("O0 failed");
-    let (_, merged_o2) =
-        run_lto_from_objects(&[with_dead], OptLevel::O2).expect("O2 failed");
+    let (_, merged_o2) = run_lto_from_objects(&[with_dead], OptLevel::O2).expect("O2 failed");
 
     // At O0, @dead should still be present (no DCE).
     assert!(
@@ -180,14 +181,30 @@ fn lto_lrir_round_trip_preserves_functions() {
     let payload = extract_lto_payload(&obj).expect("no payload");
     let (ctx2, m2) = read_bitcode(payload).expect("read_bitcode failed");
 
-    assert!(m2.get_function_id("foo").is_some(), "@foo missing after round-trip");
-    assert!(m2.get_function_id("main").is_some(), "@main missing after round-trip");
+    assert!(
+        m2.get_function_id("foo").is_some(),
+        "@foo missing after round-trip"
+    );
+    assert!(
+        m2.get_function_id("main").is_some(),
+        "@main missing after round-trip"
+    );
 
     // Re-optimize at O1 — must not panic.
-    let mut obj2 = ObjectFile { format: ObjectFormat::Elf, elf_machine: 62, coff_machine: 0, sections: vec![], symbols: vec![] };
+    let mut obj2 = ObjectFile {
+        format: ObjectFormat::Elf,
+        elf_machine: 62,
+        coff_machine: 0,
+        sections: vec![],
+        symbols: vec![],
+    };
     embed_lto_payload(&mut obj2, &ctx2, &m2);
-    let (_, re_optimized) = run_lto_from_objects(&[obj2], OptLevel::O1).expect("re-optimize failed");
-    assert!(re_optimized.get_function_id("main").is_some(), "@main must survive re-optimization");
+    let (_, re_optimized) =
+        run_lto_from_objects(&[obj2], OptLevel::O1).expect("re-optimize failed");
+    assert!(
+        re_optimized.get_function_id("main").is_some(),
+        "@main must survive re-optimization"
+    );
 }
 
 #[test]
@@ -229,5 +246,8 @@ fn lto_no_payload_returns_error() {
         symbols: vec![],
     };
     let result = run_lto_from_objects(&[empty_obj], OptLevel::O0);
-    assert!(result.is_err(), "expected error for object with no LTO payload");
+    assert!(
+        result.is_err(),
+        "expected error for object with no LTO payload"
+    );
 }


### PR DESCRIPTION
Refs #381

## Summary

Second Milestone V (#381) PR — the formatting quality gate.

- Ran `cargo +stable fmt` across all workspace crates. Purely mechanical (whitespace/wrapping); no behavior change. Was **910** `fmt --check` diffs, now **0**.
- Added `.github/workflows/quality-gates.yml` with a `cargo fmt --all -- --check` job on the pinned stable toolchain, so formatting is enforced on every push/PR and can't regress.

There was previously **no fmt or clippy CI gate at all** — this establishes the workflow file that the clippy gate will extend next.

## Why this is its own PR

Per the agent-workflow directive (one issue → focused PRs), the formatting change is isolated from the clippy fixes (next PR) so the large mechanical fmt diff stays reviewable on its own and doesn't entangle with behavioral lint fixes.

## Test plan

- [x] `cargo +stable fmt --check` → clean (0 diffs)
- [x] `cargo +stable build --workspace` → green (fmt is non-semantic)
- [x] New workflow mirrors existing gate workflow conventions (checkout pinned ref, minimal stable toolchain)

## Milestone V remaining (separate PRs)

- clippy `--locked --all-targets -D warnings` fixes (~120 warnings) + add clippy job to `quality-gates.yml`
- AGENTS.md recurring-workflow doc update + roadmap #93 status update with green-run links

🤖 Generated with [Claude Code](https://claude.com/claude-code)