### PR TITLE
style: clear clippy -D warnings workspace-wide + clippy CI gate — Milestone V

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,8 +1,8 @@
 name: Quality Gates
 
-# Release-blocking source-quality gates (roadmap Milestone V / issue #381).
-# Formatting is enforced here; clippy `-D warnings` is added in a follow-up
-# once the existing warnings are cleared.
+# Release-blocking source-quality gates (roadmap Milestone V / issue #381):
+# workspace formatting (`cargo fmt --check`) and lint cleanliness
+# (`cargo clippy --locked --all-targets -- -D warnings`).
 
 on:
   push:
@@ -31,3 +31,21 @@ jobs:
 
       - name: Check workspace formatting
         run: cargo +stable fmt --all -- --check
+
+  clippy:
+    name: cargo clippy -D warnings
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Rust stable toolchain with clippy
+        run: |
+          rustup set profile minimal
+          rustup toolchain install stable --component clippy
+          rustup default stable
+
+      - name: Lint workspace (deny warnings)
+        run: cargo +stable clippy --locked --all-targets -- -D warnings
+

--- a/src/llvm-analysis/src/dominators.rs
+++ b/src/llvm-analysis/src/dominators.rs
@@ -294,8 +294,8 @@ mod tests {
             df.get(&BlockId(2)).map(|v| v.as_slice()),
             Some(&[BlockId(3)][..])
         );
-        assert!(df.get(&BlockId(0)).map_or(true, |v| v.is_empty()));
-        assert!(df.get(&BlockId(3)).map_or(true, |v| v.is_empty()));
+        assert!(df.get(&BlockId(0)).is_none_or(|v| v.is_empty()));
+        assert!(df.get(&BlockId(3)).is_none_or(|v| v.is_empty()));
     }
 
     #[test]
@@ -308,9 +308,7 @@ mod tests {
         let cfg = Cfg::compute(&func);
         let dom = DomTree::compute(&func, &cfg);
         let df = dom.dominance_frontier(&cfg);
-        assert!(df
-            .get(&BlockId(2))
-            .map_or(false, |v| v.contains(&BlockId(1))));
+        assert!(df.get(&BlockId(2)).is_some_and(|v| v.contains(&BlockId(1))));
     }
 
     #[test]
@@ -326,12 +324,12 @@ mod tests {
         let df = dom.dominance_frontier(&cfg);
         // No reachable block exists, so the dominance frontier must be empty.
         assert!(
-            df.get(&BlockId(1)).map_or(true, |v| v.is_empty()),
+            df.get(&BlockId(1)).is_none_or(|v| v.is_empty()),
             "spurious DF entry for unreachable block 1: {:?}",
             df.get(&BlockId(1))
         );
         assert!(
-            df.get(&BlockId(2)).map_or(true, |v| v.is_empty()),
+            df.get(&BlockId(2)).is_none_or(|v| v.is_empty()),
             "spurious DF entry for unreachable block 2: {:?}",
             df.get(&BlockId(2))
         );

--- a/src/llvm-analysis/src/loops.rs
+++ b/src/llvm-analysis/src/loops.rs
@@ -76,7 +76,7 @@ impl LoopInfo {
             .collect();
 
         // Sort largest-body first so parent search is straightforward.
-        loops.sort_by(|a, b| b.body.len().cmp(&a.body.len()));
+        loops.sort_by_key(|loop_info| std::cmp::Reverse(loop_info.body.len()));
 
         // Assign parent: the innermost (smallest body) loop that contains
         // this loop's header, excluding itself.

--- a/src/llvm-bitcode/src/llvm_reader.rs
+++ b/src/llvm-bitcode/src/llvm_reader.rs
@@ -2199,7 +2199,7 @@ mod tests {
                 self.pending = 0;
                 self.pending_bits = 0;
             }
-            while self.buf.len() % 4 != 0 {
+            while !self.buf.len().is_multiple_of(4) {
                 self.buf.push(0);
             }
         }
@@ -2253,7 +2253,7 @@ mod tests {
                 self.buf.push(self.pending as u8);
             }
             // Pad to 4 bytes.
-            while self.buf.len() % 4 != 0 {
+            while !self.buf.len().is_multiple_of(4) {
                 self.buf.push(0);
             }
             self.buf

--- a/src/llvm-codegen/src/cfi.rs
+++ b/src/llvm-codegen/src/cfi.rs
@@ -146,7 +146,7 @@ impl CfiWriter {
 
         // Pad to 8-byte boundary (length field + body must be 8-byte aligned).
         // The total record = 4 (length) + body.len(); pad body so total is multiple of 8.
-        while (4 + body.len()) % 8 != 0 {
+        while !(4 + body.len()).is_multiple_of(8) {
             body.extend(CfiInstr::Nop.encode());
         }
 
@@ -190,7 +190,7 @@ impl CfiWriter {
         }
 
         // Pad to 4-byte boundary.
-        while (4 + body.len()) % 4 != 0 {
+        while !(4 + body.len()).is_multiple_of(4) {
             body.extend(CfiInstr::Nop.encode());
         }
 

--- a/src/llvm-codegen/src/emit.rs
+++ b/src/llvm-codegen/src/emit.rs
@@ -888,7 +888,7 @@ fn build_eh_frame(text_size: u64, frame_size: u32, used_callee_saved: &[PReg]) -
         // Record callee-saved register saves (each push is 1 or 2 bytes).
         // CFA offset at this point = 16 + n_callee*8; factored = (16 + (idx+1)*8) / 8 = 2 + idx+1.
         for (idx, pr) in used_callee_saved.iter().enumerate() {
-            let reg = pr.0 as u8;
+            let reg = pr.0;
             // Push instruction: 1 byte for RAX-RDI (no REX), 2 bytes for R8-R15 (REX.B prefix).
             let push_len: u8 = if pr.0 >= 8 { 2 } else { 1 };
             // DWARF register numbers for x86-64 (System V ABI Table 3.18).
@@ -1509,6 +1509,458 @@ fn push_str(table: &mut Vec<u8>, s: &[u8]) -> u32 {
     table.extend_from_slice(s);
     table.push(0);
     off
+}
+
+// ── Global-variable data section emission ─────────────────────────────────
+
+use llvm_ir::{
+    context::ConstId, ConstExprOp, ConstantData, Context, FloatKind, Linkage, Module, TypeData,
+};
+use std::collections::HashMap;
+
+/// Byte size of an IR type under the System V / AAPCS64 ABI model.
+///
+/// Pointers are always 8 bytes; integer types round up to the nearest byte;
+/// aggregates include natural padding.  Void / label / metadata / function
+/// types have size 0.
+pub fn sizeof_ty(ctx: &Context, ty: llvm_ir::context::TypeId) -> u64 {
+    match ctx.get_type(ty) {
+        TypeData::Integer(bits) => (*bits as u64).div_ceil(8),
+        TypeData::Float(k) => match k {
+            FloatKind::Half | FloatKind::BFloat => 2,
+            FloatKind::Single => 4,
+            FloatKind::Double => 8,
+            FloatKind::Fp128 => 16,
+            FloatKind::X86Fp80 => 16,
+        },
+        TypeData::Pointer => 8,
+        TypeData::Array { element, len } => {
+            let esz = sizeof_ty(ctx, *element);
+            esz * len
+        }
+        TypeData::Vector { element, len, .. } => {
+            let esz = sizeof_ty(ctx, *element);
+            esz * (*len as u64)
+        }
+        TypeData::Struct(st) => struct_total_size(ctx, &st.fields.clone(), st.packed),
+        TypeData::Void | TypeData::Label | TypeData::Metadata | TypeData::Function(_) => 0,
+    }
+}
+
+fn align_of_ty(ctx: &Context, ty: llvm_ir::context::TypeId) -> u64 {
+    sizeof_ty(ctx, ty).clamp(1, 8)
+}
+
+fn struct_total_size(ctx: &Context, fields: &[llvm_ir::context::TypeId], packed: bool) -> u64 {
+    let mut offset = 0u64;
+    let mut max_align = 1u64;
+    for &f in fields {
+        let fsz = sizeof_ty(ctx, f);
+        let al = if packed { 1 } else { align_of_ty(ctx, f) };
+        if al > max_align {
+            max_align = al;
+        }
+        offset = (offset + al - 1) & !(al - 1);
+        offset += fsz;
+    }
+    if !packed && max_align > 1 {
+        offset = (offset + max_align - 1) & !(max_align - 1);
+    }
+    offset
+}
+
+fn struct_field_byte_offset(
+    ctx: &Context,
+    fields: &[llvm_ir::context::TypeId],
+    field_idx: usize,
+    packed: bool,
+) -> u64 {
+    let mut offset = 0u64;
+    for (i, &f) in fields.iter().enumerate() {
+        let al = if packed { 1 } else { align_of_ty(ctx, f) };
+        offset = (offset + al - 1) & !(al - 1);
+        if i == field_idx {
+            return offset;
+        }
+        offset += sizeof_ty(ctx, f);
+    }
+    0
+}
+
+/// Compute the addend (in bytes) for a GEP constexpr.
+///
+/// `base_ty` is the aggregate/element type that the first GEP index scales
+/// over.  `indices` are the already-extracted integer index values.
+fn gep_byte_offset(ctx: &Context, base_ty: llvm_ir::context::TypeId, indices: &[i64]) -> i64 {
+    let mut offset: i64 = 0;
+    let mut cur_ty = base_ty;
+    for (depth, &idx) in indices.iter().enumerate() {
+        if depth == 0 {
+            offset += idx * sizeof_ty(ctx, cur_ty) as i64;
+        } else {
+            match ctx.get_type(cur_ty).clone() {
+                TypeData::Array { element, .. } => {
+                    offset += idx * sizeof_ty(ctx, element) as i64;
+                    cur_ty = element;
+                }
+                TypeData::Struct(st) => {
+                    let fi = idx as usize;
+                    let flds: Vec<_> = st.fields.clone();
+                    offset += struct_field_byte_offset(ctx, &flds, fi, st.packed) as i64;
+                    if fi < flds.len() {
+                        cur_ty = flds[fi];
+                    }
+                }
+                TypeData::Vector { element, .. } => {
+                    offset += idx * sizeof_ty(ctx, element) as i64;
+                    cur_ty = element;
+                }
+                _ => break,
+            }
+        }
+    }
+    offset
+}
+
+fn const_as_i64(ctx: &Context, cid: ConstId) -> i64 {
+    match ctx.get_const(cid) {
+        ConstantData::Int { val, .. } => *val as i64,
+        _ => 0,
+    }
+}
+
+/// Evaluate `cid` into raw bytes appended to `out`, recording any needed
+/// relocations in `relocs` with offsets relative to `sec_base` (the
+/// section-absolute byte offset at which `out` starts).
+fn eval_const_bytes(
+    ctx: &Context,
+    cid: ConstId,
+    sec_base: u64,
+    global_sym_map: &HashMap<String, usize>,
+    relocs: &mut Vec<Reloc>,
+    out: &mut Vec<u8>,
+) {
+    let cd = ctx.get_const(cid).clone();
+    match cd {
+        ConstantData::Int { ty, val } => {
+            let byte_count = (match ctx.get_type(ty) {
+                TypeData::Integer(b) => *b,
+                _ => 64,
+            } as u64)
+                .div_ceil(8);
+            for i in 0..byte_count {
+                out.push((val >> (i * 8)) as u8);
+            }
+        }
+        ConstantData::IntWide { ty, words } => {
+            let bits = match ctx.get_type(ty) {
+                TypeData::Integer(b) => *b as u64,
+                _ => 64 * words.len() as u64,
+            };
+            let byte_count = bits.div_ceil(8);
+            let raw: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+            let take = (byte_count as usize).min(raw.len());
+            out.extend_from_slice(&raw[..take]);
+        }
+        ConstantData::Float { ty, bits } => {
+            let sz = sizeof_ty(ctx, ty) as usize;
+            for i in 0..sz {
+                out.push((bits >> (i * 8)) as u8);
+            }
+        }
+        ConstantData::Null(ty) | ConstantData::Undef(ty) | ConstantData::Poison(ty) => {
+            let sz = sizeof_ty(ctx, ty) as usize;
+            out.extend(std::iter::repeat_n(0u8, sz));
+        }
+        ConstantData::ZeroInitializer(ty) => {
+            let sz = sizeof_ty(ctx, ty) as usize;
+            out.extend(std::iter::repeat_n(0u8, sz));
+        }
+        ConstantData::Array { elements, .. } | ConstantData::Vector { elements, .. } => {
+            for elem in elements {
+                eval_const_bytes(ctx, elem, sec_base, global_sym_map, relocs, out);
+            }
+        }
+        ConstantData::Struct { ty, fields } => {
+            let (field_tys, is_packed) = match ctx.get_type(ty) {
+                TypeData::Struct(st) => (st.fields.clone(), st.packed),
+                _ => (vec![], false),
+            };
+            let struct_start = out.len();
+            for (i, fld_cid) in fields.iter().enumerate() {
+                let fty = field_tys.get(i).copied().unwrap_or(ctx.i8_ty);
+                let al = if is_packed {
+                    1
+                } else {
+                    align_of_ty(ctx, fty) as usize
+                };
+                let local_pos = out.len() - struct_start;
+                let pad = if al > 0 {
+                    (al - local_pos % al) % al
+                } else {
+                    0
+                };
+                out.extend(std::iter::repeat_n(0u8, pad));
+                eval_const_bytes(ctx, *fld_cid, sec_base, global_sym_map, relocs, out);
+            }
+            // Trailing struct padding
+            let content = out.len() - struct_start;
+            let total = struct_total_size(ctx, &field_tys, is_packed) as usize;
+            if total > content {
+                out.extend(std::iter::repeat_n(0u8, total - content));
+            }
+        }
+        ConstantData::GlobalRef { name, .. } => {
+            push_ptr_reloc(sec_base, &name, 0, global_sym_map, relocs, out);
+        }
+        ConstantData::Expr { op, ty, operands } => {
+            match op {
+                ConstExprOp::BitCast | ConstExprOp::AddrSpaceCast => {
+                    if let Some(&base_cid) = operands.first() {
+                        eval_const_bytes(ctx, base_cid, sec_base, global_sym_map, relocs, out);
+                    } else {
+                        out.extend(std::iter::repeat_n(0u8, sizeof_ty(ctx, ty) as usize));
+                    }
+                }
+                ConstExprOp::GetElementPtr { base_ty, .. } => {
+                    let indices: Vec<i64> = operands[1..]
+                        .iter()
+                        .map(|&c| const_as_i64(ctx, c))
+                        .collect();
+                    let addend = gep_byte_offset(ctx, base_ty, &indices);
+                    match ctx.get_const(operands[0]).clone() {
+                        ConstantData::GlobalRef { name, .. } => {
+                            push_ptr_reloc(sec_base, &name, addend, global_sym_map, relocs, out);
+                        }
+                        _ => {
+                            eval_const_bytes(
+                                ctx,
+                                operands[0],
+                                sec_base,
+                                global_sym_map,
+                                relocs,
+                                out,
+                            );
+                        }
+                    }
+                }
+                ConstExprOp::IntToPtr => {
+                    // Absolute address — no relocation
+                    if let Some(&val_cid) = operands.first() {
+                        match ctx.get_const(val_cid) {
+                            ConstantData::Int { val, .. } => {
+                                out.extend_from_slice(&val.to_le_bytes());
+                            }
+                            _ => out.extend_from_slice(&0u64.to_le_bytes()),
+                        }
+                    } else {
+                        out.extend_from_slice(&0u64.to_le_bytes());
+                    }
+                }
+                ConstExprOp::PtrToInt => {
+                    let int_bits = match ctx.get_type(ty) {
+                        TypeData::Integer(b) => *b,
+                        _ => 64,
+                    };
+                    let byte_count = (int_bits as usize).div_ceil(8);
+                    if let Some(&base_cid) = operands.first() {
+                        if let ConstantData::GlobalRef { name, .. } =
+                            ctx.get_const(base_cid).clone()
+                        {
+                            push_ptr_reloc(sec_base, &name, 0, global_sym_map, relocs, out);
+                            // push_ptr_reloc always emits 8 bytes; truncate if int is narrower
+                            if byte_count < 8 {
+                                let extra = 8 - byte_count;
+                                let len = out.len();
+                                out.truncate(len - extra);
+                            }
+                            return;
+                        }
+                    }
+                    out.extend(std::iter::repeat_n(0u8, byte_count));
+                }
+                ConstExprOp::Trunc | ConstExprOp::ZExt | ConstExprOp::SExt => {
+                    let dst_bits = match ctx.get_type(ty) {
+                        TypeData::Integer(b) => *b as usize,
+                        _ => 64,
+                    };
+                    let dst_bytes = dst_bits.div_ceil(8);
+                    if let Some(&src_cid) = operands.first() {
+                        let mut src_buf = Vec::new();
+                        eval_const_bytes(
+                            ctx,
+                            src_cid,
+                            sec_base,
+                            global_sym_map,
+                            relocs,
+                            &mut src_buf,
+                        );
+                        let sign_extend = op == ConstExprOp::SExt;
+                        let fill = if sign_extend {
+                            src_buf
+                                .last()
+                                .map(|&b| if b & 0x80 != 0 { 0xFF } else { 0 })
+                                .unwrap_or(0)
+                        } else {
+                            0
+                        };
+                        src_buf.resize(dst_bytes, fill);
+                        out.extend_from_slice(&src_buf[..dst_bytes.min(src_buf.len())]);
+                    } else {
+                        out.extend(std::iter::repeat_n(0u8, dst_bytes));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn push_ptr_reloc(
+    sec_base: u64,
+    name: &str,
+    addend: i64,
+    global_sym_map: &HashMap<String, usize>,
+    relocs: &mut Vec<Reloc>,
+    out: &mut Vec<u8>,
+) {
+    let reloc_offset = sec_base + out.len() as u64;
+    if let Some(&sym_idx) = global_sym_map.get(name) {
+        relocs.push(Reloc {
+            offset: reloc_offset,
+            symbol: sym_idx,
+            kind: RelocKind::Abs64,
+            addend,
+            external_name: None,
+        });
+    } else {
+        relocs.push(Reloc {
+            offset: reloc_offset,
+            symbol: 0,
+            kind: RelocKind::Abs64,
+            addend,
+            external_name: Some(name.to_string()),
+        });
+    }
+    out.extend_from_slice(&0u64.to_le_bytes());
+}
+
+/// Emit all global variables in `module` as data sections with relocations.
+///
+/// Returns `(sections, symbols)` ready to be merged into an [`ObjectFile`].
+/// Symbol indices in the returned relocs are relative to the returned
+/// `symbols` vec; callers must adjust them if merging into a larger symbol
+/// table.
+///
+/// Returns `None` when the module contains no global variables.
+pub fn emit_globals(
+    ctx: &Context,
+    module: &Module,
+    format: ObjectFormat,
+) -> Option<(Vec<Section>, Vec<Symbol>)> {
+    if module.globals.is_empty() {
+        return None;
+    }
+
+    // Map global name → symbol index (within our local symbols vec).
+    let mut global_sym_map: HashMap<String, usize> = HashMap::new();
+    for (i, gv) in module.globals.iter().enumerate() {
+        global_sym_map.insert(gv.name.clone(), i);
+    }
+
+    let rodata_name = match format {
+        ObjectFormat::MachO => "__const",
+        _ => ".rodata",
+    };
+    let data_name = match format {
+        ObjectFormat::MachO => "__data",
+        _ => ".data",
+    };
+
+    // Build one section for read-only globals, one for mutable globals.
+    let has_readonly = module.globals.iter().any(|gv| gv.is_constant);
+    let has_rw = module.globals.iter().any(|gv| !gv.is_constant);
+
+    let mut sections: Vec<Section> = Vec::new();
+    if has_readonly {
+        sections.push(Section {
+            name: rodata_name.to_string(),
+            data: Vec::new(),
+            relocs: Vec::new(),
+            debug_rows: Vec::new(),
+        });
+    }
+    if has_rw {
+        sections.push(Section {
+            name: data_name.to_string(),
+            data: Vec::new(),
+            relocs: Vec::new(),
+            debug_rows: Vec::new(),
+        });
+    }
+
+    let mut symbols: Vec<Symbol> = Vec::new();
+
+    for gv in &module.globals {
+        let sec_idx = if gv.is_constant {
+            sections.iter().position(|s| s.name == rodata_name).unwrap()
+        } else {
+            sections.iter().position(|s| s.name == data_name).unwrap()
+        };
+        let sec = &mut sections[sec_idx];
+
+        // Natural alignment: min of sizeof(ty), 16.
+        let sz = sizeof_ty(ctx, gv.ty) as usize;
+        let al = (sz as u64).clamp(1, 16) as usize;
+        let pad = if al > 0 {
+            (al - sec.data.len() % al) % al
+        } else {
+            0
+        };
+        sec.data.extend(std::iter::repeat_n(0u8, pad));
+
+        let global_offset = sec.data.len() as u64;
+
+        if let Some(init_cid) = gv.initializer {
+            // sec_base = 0: `sec.data` is the full section buffer, so
+            // `out.len()` directly gives the section-absolute byte position.
+            eval_const_bytes(
+                ctx,
+                init_cid,
+                0,
+                &global_sym_map,
+                &mut sec.relocs,
+                &mut sec.data,
+            );
+        } else {
+            // Declaration only (extern) — emit zero bytes as placeholder.
+            sec.data.extend(std::iter::repeat_n(0u8, sz));
+        }
+
+        let emitted_size = sec.data.len() as u64 - global_offset;
+        let is_global_sym = !matches!(gv.linkage, Linkage::Private | Linkage::Internal);
+        symbols.push(Symbol {
+            name: gv.name.clone(),
+            section: sec_idx,
+            offset: global_offset,
+            size: emitted_size,
+            global: is_global_sym,
+            undefined: false,
+        });
+    }
+
+    // Resolve external_name relocs within our own global_sym_map.
+    // (Relocs referencing *other* globals outside this module are left as
+    // external_name for the caller to resolve after merging symbol tables.)
+    let sym_count = symbols.len();
+    for sec in &mut sections {
+        for reloc in &mut sec.relocs {
+            if reloc.external_name.is_none() && reloc.symbol >= sym_count {
+                // Symbol index is already correct (relative to our vec).
+            }
+        }
+    }
+
+    Some((sections, symbols))
 }
 
 // ── tests ──────────────────────────────────────────────────────────────────
@@ -2174,456 +2626,4 @@ mod tests {
         let operand = u16::from_le_bytes([xdata[6], xdata[7]]);
         assert_eq!(operand, 32, "ALLOC_LARGE operand must be alloc_size/8 = 32");
     }
-}
-
-// ── Global-variable data section emission ─────────────────────────────────
-
-use llvm_ir::{
-    context::ConstId, ConstExprOp, ConstantData, Context, FloatKind, Linkage, Module, TypeData,
-};
-use std::collections::HashMap;
-
-/// Byte size of an IR type under the System V / AAPCS64 ABI model.
-///
-/// Pointers are always 8 bytes; integer types round up to the nearest byte;
-/// aggregates include natural padding.  Void / label / metadata / function
-/// types have size 0.
-pub fn sizeof_ty(ctx: &Context, ty: llvm_ir::context::TypeId) -> u64 {
-    match ctx.get_type(ty) {
-        TypeData::Integer(bits) => (*bits as u64).div_ceil(8),
-        TypeData::Float(k) => match k {
-            FloatKind::Half | FloatKind::BFloat => 2,
-            FloatKind::Single => 4,
-            FloatKind::Double => 8,
-            FloatKind::Fp128 => 16,
-            FloatKind::X86Fp80 => 16,
-        },
-        TypeData::Pointer => 8,
-        TypeData::Array { element, len } => {
-            let esz = sizeof_ty(ctx, *element);
-            esz * len
-        }
-        TypeData::Vector { element, len, .. } => {
-            let esz = sizeof_ty(ctx, *element);
-            esz * (*len as u64)
-        }
-        TypeData::Struct(st) => struct_total_size(ctx, &st.fields.clone(), st.packed),
-        TypeData::Void | TypeData::Label | TypeData::Metadata | TypeData::Function(_) => 0,
-    }
-}
-
-fn align_of_ty(ctx: &Context, ty: llvm_ir::context::TypeId) -> u64 {
-    sizeof_ty(ctx, ty).clamp(1, 8)
-}
-
-fn struct_total_size(ctx: &Context, fields: &[llvm_ir::context::TypeId], packed: bool) -> u64 {
-    let mut offset = 0u64;
-    let mut max_align = 1u64;
-    for &f in fields {
-        let fsz = sizeof_ty(ctx, f);
-        let al = if packed { 1 } else { align_of_ty(ctx, f) };
-        if al > max_align {
-            max_align = al;
-        }
-        offset = (offset + al - 1) & !(al - 1);
-        offset += fsz;
-    }
-    if !packed && max_align > 1 {
-        offset = (offset + max_align - 1) & !(max_align - 1);
-    }
-    offset
-}
-
-fn struct_field_byte_offset(
-    ctx: &Context,
-    fields: &[llvm_ir::context::TypeId],
-    field_idx: usize,
-    packed: bool,
-) -> u64 {
-    let mut offset = 0u64;
-    for (i, &f) in fields.iter().enumerate() {
-        let al = if packed { 1 } else { align_of_ty(ctx, f) };
-        offset = (offset + al - 1) & !(al - 1);
-        if i == field_idx {
-            return offset;
-        }
-        offset += sizeof_ty(ctx, f);
-    }
-    0
-}
-
-/// Compute the addend (in bytes) for a GEP constexpr.
-///
-/// `base_ty` is the aggregate/element type that the first GEP index scales
-/// over.  `indices` are the already-extracted integer index values.
-fn gep_byte_offset(ctx: &Context, base_ty: llvm_ir::context::TypeId, indices: &[i64]) -> i64 {
-    let mut offset: i64 = 0;
-    let mut cur_ty = base_ty;
-    for (depth, &idx) in indices.iter().enumerate() {
-        if depth == 0 {
-            offset += idx * sizeof_ty(ctx, cur_ty) as i64;
-        } else {
-            match ctx.get_type(cur_ty).clone() {
-                TypeData::Array { element, .. } => {
-                    offset += idx * sizeof_ty(ctx, element) as i64;
-                    cur_ty = element;
-                }
-                TypeData::Struct(st) => {
-                    let fi = idx as usize;
-                    let flds: Vec<_> = st.fields.clone();
-                    offset += struct_field_byte_offset(ctx, &flds, fi, st.packed) as i64;
-                    if fi < flds.len() {
-                        cur_ty = flds[fi];
-                    }
-                }
-                TypeData::Vector { element, .. } => {
-                    offset += idx * sizeof_ty(ctx, element) as i64;
-                    cur_ty = element;
-                }
-                _ => break,
-            }
-        }
-    }
-    offset
-}
-
-fn const_as_i64(ctx: &Context, cid: ConstId) -> i64 {
-    match ctx.get_const(cid) {
-        ConstantData::Int { val, .. } => *val as i64,
-        _ => 0,
-    }
-}
-
-/// Evaluate `cid` into raw bytes appended to `out`, recording any needed
-/// relocations in `relocs` with offsets relative to `sec_base` (the
-/// section-absolute byte offset at which `out` starts).
-fn eval_const_bytes(
-    ctx: &Context,
-    cid: ConstId,
-    sec_base: u64,
-    global_sym_map: &HashMap<String, usize>,
-    relocs: &mut Vec<Reloc>,
-    out: &mut Vec<u8>,
-) {
-    let cd = ctx.get_const(cid).clone();
-    match cd {
-        ConstantData::Int { ty, val } => {
-            let byte_count = (match ctx.get_type(ty) {
-                TypeData::Integer(b) => *b,
-                _ => 64,
-            } as u64)
-                .div_ceil(8);
-            for i in 0..byte_count {
-                out.push((val >> (i * 8)) as u8);
-            }
-        }
-        ConstantData::IntWide { ty, words } => {
-            let bits = match ctx.get_type(ty) {
-                TypeData::Integer(b) => *b as u64,
-                _ => 64 * words.len() as u64,
-            };
-            let byte_count = bits.div_ceil(8);
-            let raw: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
-            let take = (byte_count as usize).min(raw.len());
-            out.extend_from_slice(&raw[..take]);
-        }
-        ConstantData::Float { ty, bits } => {
-            let sz = sizeof_ty(ctx, ty) as usize;
-            for i in 0..sz {
-                out.push((bits >> (i * 8)) as u8);
-            }
-        }
-        ConstantData::Null(ty) | ConstantData::Undef(ty) | ConstantData::Poison(ty) => {
-            let sz = sizeof_ty(ctx, ty) as usize;
-            out.extend(std::iter::repeat_n(0u8, sz));
-        }
-        ConstantData::ZeroInitializer(ty) => {
-            let sz = sizeof_ty(ctx, ty) as usize;
-            out.extend(std::iter::repeat_n(0u8, sz));
-        }
-        ConstantData::Array { elements, .. } | ConstantData::Vector { elements, .. } => {
-            for elem in elements {
-                eval_const_bytes(ctx, elem, sec_base, global_sym_map, relocs, out);
-            }
-        }
-        ConstantData::Struct { ty, fields } => {
-            let (field_tys, is_packed) = match ctx.get_type(ty) {
-                TypeData::Struct(st) => (st.fields.clone(), st.packed),
-                _ => (vec![], false),
-            };
-            let struct_start = out.len();
-            for (i, fld_cid) in fields.iter().enumerate() {
-                let fty = field_tys.get(i).copied().unwrap_or(ctx.i8_ty);
-                let al = if is_packed {
-                    1
-                } else {
-                    align_of_ty(ctx, fty) as usize
-                };
-                let local_pos = out.len() - struct_start;
-                let pad = if al > 0 {
-                    (al - local_pos % al) % al
-                } else {
-                    0
-                };
-                out.extend(std::iter::repeat_n(0u8, pad));
-                eval_const_bytes(ctx, *fld_cid, sec_base, global_sym_map, relocs, out);
-            }
-            // Trailing struct padding
-            let content = out.len() - struct_start;
-            let total = struct_total_size(ctx, &field_tys, is_packed) as usize;
-            if total > content {
-                out.extend(std::iter::repeat_n(0u8, total - content));
-            }
-        }
-        ConstantData::GlobalRef { name, .. } => {
-            push_ptr_reloc(sec_base, &name, 0, global_sym_map, relocs, out);
-        }
-        ConstantData::Expr { op, ty, operands } => {
-            match op {
-                ConstExprOp::BitCast | ConstExprOp::AddrSpaceCast => {
-                    if let Some(&base_cid) = operands.first() {
-                        eval_const_bytes(ctx, base_cid, sec_base, global_sym_map, relocs, out);
-                    } else {
-                        out.extend(std::iter::repeat_n(0u8, sizeof_ty(ctx, ty) as usize));
-                    }
-                }
-                ConstExprOp::GetElementPtr { base_ty, .. } => {
-                    let indices: Vec<i64> = operands[1..]
-                        .iter()
-                        .map(|&c| const_as_i64(ctx, c))
-                        .collect();
-                    let addend = gep_byte_offset(ctx, base_ty, &indices);
-                    match ctx.get_const(operands[0]).clone() {
-                        ConstantData::GlobalRef { name, .. } => {
-                            push_ptr_reloc(sec_base, &name, addend, global_sym_map, relocs, out);
-                        }
-                        _ => {
-                            eval_const_bytes(
-                                ctx,
-                                operands[0],
-                                sec_base,
-                                global_sym_map,
-                                relocs,
-                                out,
-                            );
-                        }
-                    }
-                }
-                ConstExprOp::IntToPtr => {
-                    // Absolute address — no relocation
-                    if let Some(&val_cid) = operands.first() {
-                        match ctx.get_const(val_cid) {
-                            ConstantData::Int { val, .. } => {
-                                out.extend_from_slice(&val.to_le_bytes());
-                            }
-                            _ => out.extend_from_slice(&0u64.to_le_bytes()),
-                        }
-                    } else {
-                        out.extend_from_slice(&0u64.to_le_bytes());
-                    }
-                }
-                ConstExprOp::PtrToInt => {
-                    let int_bits = match ctx.get_type(ty) {
-                        TypeData::Integer(b) => *b,
-                        _ => 64,
-                    };
-                    let byte_count = (int_bits as usize).div_ceil(8);
-                    if let Some(&base_cid) = operands.first() {
-                        if let ConstantData::GlobalRef { name, .. } =
-                            ctx.get_const(base_cid).clone()
-                        {
-                            push_ptr_reloc(sec_base, &name, 0, global_sym_map, relocs, out);
-                            // push_ptr_reloc always emits 8 bytes; truncate if int is narrower
-                            if byte_count < 8 {
-                                let extra = 8 - byte_count;
-                                let len = out.len();
-                                out.truncate(len - extra);
-                            }
-                            return;
-                        }
-                    }
-                    out.extend(std::iter::repeat_n(0u8, byte_count));
-                }
-                ConstExprOp::Trunc | ConstExprOp::ZExt | ConstExprOp::SExt => {
-                    let dst_bits = match ctx.get_type(ty) {
-                        TypeData::Integer(b) => *b as usize,
-                        _ => 64,
-                    };
-                    let dst_bytes = dst_bits.div_ceil(8);
-                    if let Some(&src_cid) = operands.first() {
-                        let mut src_buf = Vec::new();
-                        eval_const_bytes(
-                            ctx,
-                            src_cid,
-                            sec_base,
-                            global_sym_map,
-                            relocs,
-                            &mut src_buf,
-                        );
-                        let sign_extend = op == ConstExprOp::SExt;
-                        let fill = if sign_extend {
-                            src_buf
-                                .last()
-                                .map(|&b| if b & 0x80 != 0 { 0xFF } else { 0 })
-                                .unwrap_or(0)
-                        } else {
-                            0
-                        };
-                        src_buf.resize(dst_bytes, fill);
-                        out.extend_from_slice(&src_buf[..dst_bytes.min(src_buf.len())]);
-                    } else {
-                        out.extend(std::iter::repeat_n(0u8, dst_bytes));
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn push_ptr_reloc(
-    sec_base: u64,
-    name: &str,
-    addend: i64,
-    global_sym_map: &HashMap<String, usize>,
-    relocs: &mut Vec<Reloc>,
-    out: &mut Vec<u8>,
-) {
-    let reloc_offset = sec_base + out.len() as u64;
-    if let Some(&sym_idx) = global_sym_map.get(name) {
-        relocs.push(Reloc {
-            offset: reloc_offset,
-            symbol: sym_idx,
-            kind: RelocKind::Abs64,
-            addend,
-            external_name: None,
-        });
-    } else {
-        relocs.push(Reloc {
-            offset: reloc_offset,
-            symbol: 0,
-            kind: RelocKind::Abs64,
-            addend,
-            external_name: Some(name.to_string()),
-        });
-    }
-    out.extend_from_slice(&0u64.to_le_bytes());
-}
-
-/// Emit all global variables in `module` as data sections with relocations.
-///
-/// Returns `(sections, symbols)` ready to be merged into an [`ObjectFile`].
-/// Symbol indices in the returned relocs are relative to the returned
-/// `symbols` vec; callers must adjust them if merging into a larger symbol
-/// table.
-///
-/// Returns `None` when the module contains no global variables.
-pub fn emit_globals(
-    ctx: &Context,
-    module: &Module,
-    format: ObjectFormat,
-) -> Option<(Vec<Section>, Vec<Symbol>)> {
-    if module.globals.is_empty() {
-        return None;
-    }
-
-    // Map global name → symbol index (within our local symbols vec).
-    let mut global_sym_map: HashMap<String, usize> = HashMap::new();
-    for (i, gv) in module.globals.iter().enumerate() {
-        global_sym_map.insert(gv.name.clone(), i);
-    }
-
-    let rodata_name = match format {
-        ObjectFormat::MachO => "__const",
-        _ => ".rodata",
-    };
-    let data_name = match format {
-        ObjectFormat::MachO => "__data",
-        _ => ".data",
-    };
-
-    // Build one section for read-only globals, one for mutable globals.
-    let has_readonly = module.globals.iter().any(|gv| gv.is_constant);
-    let has_rw = module.globals.iter().any(|gv| !gv.is_constant);
-
-    let mut sections: Vec<Section> = Vec::new();
-    if has_readonly {
-        sections.push(Section {
-            name: rodata_name.to_string(),
-            data: Vec::new(),
-            relocs: Vec::new(),
-            debug_rows: Vec::new(),
-        });
-    }
-    if has_rw {
-        sections.push(Section {
-            name: data_name.to_string(),
-            data: Vec::new(),
-            relocs: Vec::new(),
-            debug_rows: Vec::new(),
-        });
-    }
-
-    let mut symbols: Vec<Symbol> = Vec::new();
-
-    for gv in &module.globals {
-        let sec_idx = if gv.is_constant {
-            sections.iter().position(|s| s.name == rodata_name).unwrap()
-        } else {
-            sections.iter().position(|s| s.name == data_name).unwrap()
-        };
-        let sec = &mut sections[sec_idx];
-
-        // Natural alignment: min of sizeof(ty), 16.
-        let sz = sizeof_ty(ctx, gv.ty) as usize;
-        let al = (sz as u64).clamp(1, 16) as usize;
-        let pad = if al > 0 {
-            (al - sec.data.len() % al) % al
-        } else {
-            0
-        };
-        sec.data.extend(std::iter::repeat_n(0u8, pad));
-
-        let global_offset = sec.data.len() as u64;
-
-        if let Some(init_cid) = gv.initializer {
-            // sec_base = 0: `sec.data` is the full section buffer, so
-            // `out.len()` directly gives the section-absolute byte position.
-            eval_const_bytes(
-                ctx,
-                init_cid,
-                0,
-                &global_sym_map,
-                &mut sec.relocs,
-                &mut sec.data,
-            );
-        } else {
-            // Declaration only (extern) — emit zero bytes as placeholder.
-            sec.data.extend(std::iter::repeat_n(0u8, sz));
-        }
-
-        let emitted_size = sec.data.len() as u64 - global_offset;
-        let is_global_sym = !matches!(gv.linkage, Linkage::Private | Linkage::Internal);
-        symbols.push(Symbol {
-            name: gv.name.clone(),
-            section: sec_idx,
-            offset: global_offset,
-            size: emitted_size,
-            global: is_global_sym,
-            undefined: false,
-        });
-    }
-
-    // Resolve external_name relocs within our own global_sym_map.
-    // (Relocs referencing *other* globals outside this module are left as
-    // external_name for the caller to resolve after merging symbol tables.)
-    let sym_count = symbols.len();
-    for sec in &mut sections {
-        for reloc in &mut sec.relocs {
-            if reloc.external_name.is_none() && reloc.symbol >= sym_count {
-                // Symbol index is already correct (relative to our vec).
-            }
-        }
-    }
-
-    Some((sections, symbols))
 }

--- a/src/llvm-codegen/src/schedule.rs
+++ b/src/llvm-codegen/src/schedule.rs
@@ -352,13 +352,7 @@ pub fn x86_latency(opcode: MOpcode) -> u32 {
     // Reference: Intel Skylake/Cascade Lake instruction tables.
     match opcode.0 {
         // ── data movement (1 cycle) ──
-        0x00 | // MOV_RR
-        0x01 | // MOV_RI
-        0x02 | // MOVSX_32
-        0x03 | // MOVSX_8
-        0x04 | // MOVZX_8
-        0x05 | // MOV_PR
-        0x06   // MOVSX_16
+        0x00..=0x06   // MOVSX_16
         => 1,
 
         // ── integer arithmetic ──
@@ -413,19 +407,14 @@ pub fn x86_latency(opcode: MOpcode) -> u32 {
         0x87   // MULPD_RR
         => 4,
         0x85 => 11,  // DIVPS_RR
-        0x88 | // MOVAPS_RR
-        0x89 | // MOVDQU_LOAD_MR
-        0x8A | // MOVDQU_STORE_RM
-        0x8B   // MOVAPS_LOAD_MR
+        0x88..=0x8B   // MOVAPS_LOAD_MR
         => 4,
 
         // ── atomics (conservative: fence-like latency) ──
         0x90..=0x96 | 0x9A => 20,
 
         // ── non-promotable frame access ──
-        0xA0 | // LEA_FRAME_MR
-        0xA1 | // MOV_LOAD_REG_MR
-        0xA2   // MOV_STORE_REG_RM
+        0xA0..=0xA2   // MOV_STORE_REG_RM
         => 4,
 
         // ── SSE2 double ──

--- a/src/llvm-codegen/tests/linker_compat.rs
+++ b/src/llvm-codegen/tests/linker_compat.rs
@@ -45,7 +45,6 @@ fn emit_host_obj(ll: &str, out: &Path) {
     #[cfg(target_arch = "x86_64")]
     {
         emit_host_obj_x86(&ctx, &module, func, obj_format, out);
-        return;
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/src/llvm-codegen/tests/linker_compat.rs
+++ b/src/llvm-codegen/tests/linker_compat.rs
@@ -51,7 +51,6 @@ fn emit_host_obj(ll: &str, out: &Path) {
     #[cfg(target_arch = "aarch64")]
     {
         emit_host_obj_aarch64(&ctx, &module, func, obj_format, out);
-        return;
     }
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]

--- a/src/llvm-codegen/tests/thinlto.rs
+++ b/src/llvm-codegen/tests/thinlto.rs
@@ -197,7 +197,7 @@ fn thinlto_roundtrip_function_count() {
     b.position_at_end(e2);
     let c2 = b.const_int(i32_ty, 2);
     b.build_ret(c2);
-    drop(b);
+    let _ = b;
 
     let mut obj = elf_obj();
     embed_bitcode(&mut obj, &ctx, &module, "").unwrap();

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -3186,15 +3186,6 @@ impl<'src> Parser<'src> {
             Keyword::Unwind => "unwind",
             Keyword::X => "x",
             Keyword::Vscale => "vscale",
-            Keyword::Catchpad => "catchpad",
-            Keyword::Cleanuppad => "cleanuppad",
-            Keyword::Catchswitch => "catchswitch",
-            Keyword::Catchret => "catchret",
-            Keyword::Cleanupret => "cleanupret",
-            Keyword::Within => "within",
-            Keyword::Caller => "caller",
-            Keyword::None => "none",
-            Keyword::From => "from",
         }
     }
 

--- a/src/llvm-ir-parser/tests/parse_basic.rs
+++ b/src/llvm-ir-parser/tests/parse_basic.rs
@@ -82,8 +82,8 @@ entry:
 }
 
 /// Parse `fence`, `cmpxchg`, and `atomicrmw` and confirm the IR structure
-/// + the result of the print → parse round-trip is stable.  Covers issue #205
-/// at the parser layer.
+/// and the print → parse round-trip are stable.  Covers issue #205 at the
+/// parser layer.
 #[test]
 fn parse_atomics_round_trip() {
     let src = r#"

--- a/src/llvm-ir/src/lib.rs
+++ b/src/llvm-ir/src/lib.rs
@@ -24,7 +24,7 @@
 //! let bv = b.get_arg(1);
 //! let sum = b.build_add("sum", a, bv);
 //! b.build_ret(sum);
-//! drop(b);
+//! let _ = b;
 //! assert_eq!(module.functions[0].blocks.len(), 1);
 //! ```
 

--- a/src/llvm-ir/src/reduce.rs
+++ b/src/llvm-ir/src/reduce.rs
@@ -841,7 +841,7 @@ where
             align,
         } => Alloca {
             alloc_ty: *alloc_ty,
-            num_elements: num_elements.map(|v| f(v)),
+            num_elements: num_elements.map(&mut f),
             align: *align,
         },
         Load {
@@ -984,7 +984,7 @@ where
             clauses,
         } => LandingPad {
             result_ty: *result_ty,
-            personality_fn: personality_fn.map(|v| f(v)),
+            personality_fn: personality_fn.map(&mut f),
             cleanup: *cleanup,
             clauses: clauses
                 .iter()
@@ -1051,7 +1051,7 @@ where
             volatile: *volatile,
         },
         Ret { val } => Ret {
-            val: val.map(|v| f(v)),
+            val: val.map(&mut f),
         },
         Br { dest } => Br { dest: *dest },
         CondBr {
@@ -1096,7 +1096,7 @@ where
             args: args.iter().map(|&a| f(a)).collect(),
         },
         CleanupPad { parent, args } => CleanupPad {
-            parent: parent.map(|v| f(v)),
+            parent: parent.map(&mut f),
             args: args.iter().map(|&a| f(a)).collect(),
         },
         CatchSwitch {
@@ -1104,7 +1104,7 @@ where
             handlers,
             default,
         } => CatchSwitch {
-            parent: parent.map(|v| f(v)),
+            parent: parent.map(&mut f),
             handlers: handlers.clone(),
             default: *default,
         },
@@ -1156,7 +1156,7 @@ fn substitute_value_in_kind(
 mod tests {
     use super::*;
     use crate::basic_block::BasicBlock;
-    use crate::context::{ArgId, Context, InstrId, ValueRef};
+    use crate::context::{ArgId, Context, ValueRef};
     use crate::function::Function;
     use crate::instruction::{InstrKind, Instruction, IntArithFlags};
     use crate::module::Module;

--- a/src/llvm-jit/src/lib.rs
+++ b/src/llvm-jit/src/lib.rs
@@ -424,9 +424,9 @@ loop_exit:
         let ptr = jit.get_function_ptr("fib").expect("symbol not found");
         // SAFETY: ptr points to compiled x86-64 code with signature `fn(i32) -> i32`.
         let f = unsafe { std::mem::transmute::<*const u8, fn(i32) -> i32>(ptr) };
-        assert_eq!(unsafe { f(10) }, 55);
-        assert_eq!(unsafe { f(0) }, 0);
-        assert_eq!(unsafe { f(1) }, 1);
+        assert_eq!(f(10), 55);
+        assert_eq!(f(0), 0);
+        assert_eq!(f(1), 1);
     }
 
     #[test]
@@ -453,8 +453,8 @@ entry:
         let double = unsafe { std::mem::transmute::<*const u8, fn(i32) -> i32>(p_double) };
         let triple = unsafe { std::mem::transmute::<*const u8, fn(i32) -> i32>(p_triple) };
 
-        assert_eq!(unsafe { double(5) }, 10);
-        assert_eq!(unsafe { triple(5) }, 15);
+        assert_eq!(double(5), 10);
+        assert_eq!(triple(5), 15);
     }
 
     #[test]

--- a/src/llvm-rustc-backend/src/driver.rs
+++ b/src/llvm-rustc-backend/src/driver.rs
@@ -118,11 +118,7 @@ pub fn codegen_module(
                 emit_object(&mf, &mut emitter)
             }
             TargetArch::AArch64 => {
-                let aarch64_fmt = match fmt {
-                    ObjectFormat::MachO => ObjectFormat::MachO,
-                    ObjectFormat::Coff => ObjectFormat::Coff,
-                    ObjectFormat::Elf => ObjectFormat::Elf,
-                };
+                let aarch64_fmt = fmt;
                 let mut backend = AArch64Backend::new(AArch64Features::lse());
                 let mf = backend.lower_function(ctx, module, func);
                 let mut emitter = AArch64Emitter::new(aarch64_fmt);

--- a/src/llvm-rustc-backend/tests/driver.rs
+++ b/src/llvm-rustc-backend/tests/driver.rs
@@ -50,7 +50,7 @@ fn make_decl_only() -> (Context, Module) {
     let ptr_ty = ctx.ptr_ty;
     let mut b = Builder::new(&mut ctx, &mut module);
     b.add_declaration("printf", void_ty, vec![ptr_ty], true);
-    drop(b);
+    let _ = b;
     (ctx, module)
 }
 
@@ -187,7 +187,7 @@ fn backend_pipeline_smoke_via_driver() {
     let x = b.get_arg(0);
     let r = b.build_mul("r", x, x);
     b.build_ret(r);
-    drop(b);
+    let _ = b;
 
     let opts = CodegenOptions {
         target: TargetArch::X86_64,

--- a/src/llvm-target-arm/src/abi.rs
+++ b/src/llvm-target-arm/src/abi.rs
@@ -142,7 +142,7 @@ fn field_hfa_kind(ctx: &Context, ty: TypeId) -> Option<(FloatKind, usize)> {
         TypeData::Float(_) => None, // half/bfloat/fp128/x86fp80 → not a valid HFA base
         TypeData::Struct(_) => {
             // Recursively check if this nested struct is itself an HFA.
-            detect_hfa(ctx, ty).map(|(k, n)| (k, n))
+            detect_hfa(ctx, ty)
         }
         _ => None,
     }

--- a/src/llvm-target-arm/src/encode.rs
+++ b/src/llvm-target-arm/src/encode.rs
@@ -1691,7 +1691,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // 0xC8E0FC00 | (1<<16) | (0<<5) | 2 = 0xC8F0FC02
-        let expected = 0xC8E0FC00u32 | (1 << 16) | (0 << 5) | 2;
+        let expected = (0xC8E0FC00u32 | (1 << 16)) | 2;
         assert_eq!(
             word, expected,
             "CASAL X1, X2, [X0] must encode as 0x{expected:08X}"
@@ -1720,7 +1720,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // 0xF8E00000 | (Rs=1 <<16) | (Rn=2 <<5) | Rt=0
-        let expected = 0xF8E00000u32 | (1 << 16) | (2 << 5) | 0;
+        let expected = 0xF8E00000u32 | (1 << 16) | (2 << 5);
         assert_eq!(
             word, expected,
             "LDADDAL X1, X0, [X2] must encode as 0x{expected:08X}"
@@ -1747,7 +1747,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0xC85F7C00u32 | (1 << 5) | 0;
+        let expected = 0xC85F7C00u32 | (1 << 5);
         assert_eq!(
             word, expected,
             "LDXR X0, [X1] must encode as 0x{expected:08X}"
@@ -1776,7 +1776,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // 0xC8007C00 | (Ws=0 <<16) | (Rn=1 <<5) | Rt=2
-        let expected = 0xC8007C00u32 | (0 << 16) | (1 << 5) | 2;
+        let expected = 0xC8007C00u32 | (1 << 5) | 2;
         assert_eq!(
             word, expected,
             "STXR W0, X2, [X1] must encode as 0x{expected:08X}"
@@ -1803,7 +1803,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0xF8E08000u32 | (1 << 16) | (2 << 5) | 0;
+        let expected = 0xF8E08000u32 | (1 << 16) | (2 << 5);
         assert_eq!(
             word, expected,
             "SWPAL X1, X0, [X2] must encode as 0x{expected:08X}"
@@ -1844,7 +1844,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E602800u32 | (2 << 16) | (1 << 5) | 0;
+        let expected = 0x1E602800u32 | (2 << 16) | (1 << 5);
         assert_eq!(
             word, expected,
             "FADD D0, D1, D2 should encode as 0x{expected:08X}"
@@ -1860,7 +1860,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E603800u32 | (2 << 16) | (1 << 5) | 0;
+        let expected = 0x1E603800u32 | (2 << 16) | (1 << 5);
         assert_eq!(
             word, expected,
             "FSUB D0, D1, D2 should encode as 0x{expected:08X}"
@@ -1876,7 +1876,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E600800u32 | (2 << 16) | (1 << 5) | 0;
+        let expected = 0x1E600800u32 | (2 << 16) | (1 << 5);
         assert_eq!(
             word, expected,
             "FMUL D0, D1, D2 should encode as 0x{expected:08X}"
@@ -1892,7 +1892,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E601800u32 | (2 << 16) | (1 << 5) | 0;
+        let expected = 0x1E601800u32 | (2 << 16) | (1 << 5);
         assert_eq!(
             word, expected,
             "FDIV D0, D1, D2 should encode as 0x{expected:08X}"
@@ -1908,7 +1908,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E614000u32 | (1 << 5) | 0;
+        let expected = 0x1E614000u32 | (1 << 5);
         assert_eq!(
             word, expected,
             "FNEG D0, D1 should encode as 0x{expected:08X}"
@@ -1924,7 +1924,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E61C000u32 | (1 << 5) | 0;
+        let expected = 0x1E61C000u32 | (1 << 5);
         assert_eq!(
             word, expected,
             "FSQRT D0, D1 should encode as 0x{expected:08X}"
@@ -1963,7 +1963,7 @@ mod tests {
         let mut e = AArch64Emitter::new(ObjectFormat::Elf);
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
-        let expected = 0x1E604000u32 | (1 << 5) | 0;
+        let expected = 0x1E604000u32 | (1 << 5);
         assert_eq!(
             word, expected,
             "FMOV D0, D1 should encode as 0x{expected:08X}"
@@ -1988,7 +1988,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // Rd = X0 = reg 0 (low 5 bits of X0.0 = 0); Rn = fp_enc(D0) = 0
-        let expected = 0x9E780000u32 | (0 << 5) | 0;
+        let expected = 0x9E780000u32;
         assert_eq!(
             word, expected,
             "FCVTZS X0, D0 should encode as 0x{expected:08X}"
@@ -2037,7 +2037,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // rd = dst.0 & 0x1F = 32 & 0x1F = 0; rn = reg_enc(X1) = 1
-        let expected = 0x9E620000u32 | (1 << 5) | 0;
+        let expected = 0x9E620000u32 | (1 << 5);
         assert_eq!(
             word, expected,
             "SCVTF D0, X1 should encode as 0x{expected:08X}"
@@ -2062,7 +2062,7 @@ mod tests {
         let sec = e.emit_function(&mf);
         let word = u32::from_le_bytes([sec.data[0], sec.data[1], sec.data[2], sec.data[3]]);
         // rt = D0.0 & 0x1F = 32 & 0x1F = 0; imm12 = 2 + 0 + 0 = 2
-        let expected = 0xFD400000u32 | (2 << 10) | (29 << 5) | 0;
+        let expected = 0xFD400000u32 | (2 << 10) | (29 << 5);
         assert_eq!(
             word, expected,
             "MOVSD_LOAD_MR D0, [x29, #16] should encode as 0x{expected:08X}"

--- a/src/llvm-target-riscv/src/encode.rs
+++ b/src/llvm-target-riscv/src/encode.rs
@@ -1120,7 +1120,7 @@ mod tests {
     fn enc_fneg_d_uses_fsgnjn_encoding() {
         // fneg.d is FSGNJN.D rd, rs, rs: funct7=0x21, funct3=0x1, rs2=rs1
         let mi = MInstr::new(FNEG_D)
-            .with_dst(VReg(32 + 0)) // fd=f0
+            .with_dst(VReg(32)) // fd=f0
             .with_preg(PReg(32 + 1)) // rs1=f1
             .with_preg(PReg(32 + 1)); // rs2=f1 (same)
         let word = encode_instr(&mi);
@@ -1140,7 +1140,7 @@ mod tests {
         // feq.d uses integer rd, FP rs1/rs2: funct7=0x51, funct3=0x2
         let mi = MInstr::new(FCMP_EQ_D)
             .with_dst(VReg(3)) // integer rd=x3
-            .with_preg(PReg(32 + 0)) // rs1=f0
+            .with_preg(PReg(32)) // rs1=f0
             .with_preg(PReg(32 + 1)); // rs2=f1
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x51, "feq.d funct7 must be 0x51");
@@ -1177,7 +1177,7 @@ mod tests {
         // fcvt.l.d: funct7=0x61, rs2=2 (L), rounding=RTZ=0x1
         let mi = MInstr::new(FCVT_L_D)
             .with_dst(VReg(1)) // integer rd
-            .with_preg(PReg(32 + 0)); // fp rs1
+            .with_preg(PReg(32)); // fp rs1
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x61, "fcvt.l.d funct7 must be 0x61");
         assert_eq!((word >> 20) & 0x1F, 2, "fcvt.l.d rs2 must be 2 (L)");
@@ -1199,7 +1199,7 @@ mod tests {
     fn enc_fcvt_d_l_funct7_and_rs2() {
         // fcvt.d.l: funct7=0x69, rs2=2
         let mi = MInstr::new(FCVT_D_L)
-            .with_dst(VReg(32 + 0)) // fp rd
+            .with_dst(VReg(32)) // fp rd
             .with_preg(PReg(1)); // int rs1
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x69, "fcvt.d.l funct7 must be 0x69");
@@ -1312,9 +1312,7 @@ mod tests {
     #[test]
     fn enc_fcvt_s_l_funct7_and_rs2() {
         // fcvt.s.l: funct7=0x68, rs2=2
-        let mi = MInstr::new(FCVT_S_L)
-            .with_dst(VReg(32 + 0))
-            .with_preg(PReg(1));
+        let mi = MInstr::new(FCVT_S_L).with_dst(VReg(32)).with_preg(PReg(1));
         let word = encode_instr(&mi);
         assert_eq!((word >> 25) & 0x7F, 0x68, "fcvt.s.l funct7 must be 0x68");
         assert_eq!((word >> 20) & 0x1F, 2, "fcvt.s.l rs2 must be 2");

--- a/src/llvm-target-riscv/tests/e2e_objdump.rs
+++ b/src/llvm-target-riscv/tests/e2e_objdump.rs
@@ -39,7 +39,7 @@ fn sample_ll_emits_riscv_elf_objdump_accepts() {
     pm.add_function_pass(DeadCodeElim);
     pm.run(&mut ctx, &mut module);
 
-    let mut backend = RiscVBackend::default();
+    let mut backend = RiscVBackend;
     for func in &module.functions {
         if func.is_declaration {
             continue;

--- a/src/llvm-target-wasm/src/reloop.rs
+++ b/src/llvm-target-wasm/src/reloop.rs
@@ -554,13 +554,11 @@ mod tests {
                     return true;
                 }
                 has_loop_header(body, header)
-                    || next
-                        .as_deref()
-                        .map_or(false, |n| has_loop_header(n, header))
+                    || next.as_deref().is_some_and(|n| has_loop_header(n, header))
             }
-            ControlNode::Simple { next, .. } => next
-                .as_deref()
-                .map_or(false, |n| has_loop_header(n, header)),
+            ControlNode::Simple { next, .. } => {
+                next.as_deref().is_some_and(|n| has_loop_header(n, header))
+            }
             ControlNode::Branch {
                 then_node,
                 else_node,
@@ -570,10 +568,8 @@ mod tests {
                 has_loop_header(then_node, header)
                     || else_node
                         .as_deref()
-                        .map_or(false, |n| has_loop_header(n, header))
-                    || next
-                        .as_deref()
-                        .map_or(false, |n| has_loop_header(n, header))
+                        .is_some_and(|n| has_loop_header(n, header))
+                    || next.as_deref().is_some_and(|n| has_loop_header(n, header))
             }
         }
     }
@@ -594,19 +590,19 @@ mod tests {
                 has_branch_at(then_node, cond_block)
                     || else_node
                         .as_deref()
-                        .map_or(false, |n| has_branch_at(n, cond_block))
+                        .is_some_and(|n| has_branch_at(n, cond_block))
                     || next
                         .as_deref()
-                        .map_or(false, |n| has_branch_at(n, cond_block))
+                        .is_some_and(|n| has_branch_at(n, cond_block))
             }
             ControlNode::Simple { next, .. } => next
                 .as_deref()
-                .map_or(false, |n| has_branch_at(n, cond_block)),
+                .is_some_and(|n| has_branch_at(n, cond_block)),
             ControlNode::Loop { body, next, .. } => {
                 has_branch_at(body, cond_block)
                     || next
                         .as_deref()
-                        .map_or(false, |n| has_branch_at(n, cond_block))
+                        .is_some_and(|n| has_branch_at(n, cond_block))
             }
         }
     }
@@ -698,10 +694,10 @@ mod tests {
                     if *id == BlockId(3) {
                         return true;
                     }
-                    next.as_deref().map_or(false, has_simple_3)
+                    next.as_deref().is_some_and(has_simple_3)
                 }
                 ControlNode::Loop { next, body, .. } => {
-                    has_simple_3(body) || next.as_deref().map_or(false, has_simple_3)
+                    has_simple_3(body) || next.as_deref().is_some_and(has_simple_3)
                 }
                 ControlNode::Branch {
                     then_node,
@@ -710,8 +706,8 @@ mod tests {
                     ..
                 } => {
                     has_simple_3(then_node)
-                        || else_node.as_deref().map_or(false, has_simple_3)
-                        || next.as_deref().map_or(false, has_simple_3)
+                        || else_node.as_deref().is_some_and(has_simple_3)
+                        || next.as_deref().is_some_and(has_simple_3)
                 }
             }
         }

--- a/src/llvm-target-x86/src/abi.rs
+++ b/src/llvm-target-x86/src/abi.rs
@@ -98,7 +98,7 @@ pub enum EightbyteClass {
 /// that force MEMORY classification (i128, vectors, etc.).
 fn type_size(ctx: &Context, ty: TypeId) -> Option<u64> {
     match ctx.get_type(ty) {
-        TypeData::Integer(bits) => Some((*bits as u64 + 7) / 8),
+        TypeData::Integer(bits) => Some((*bits as u64).div_ceil(8)),
         TypeData::Float(FloatKind::Single) => Some(4),
         TypeData::Float(FloatKind::Double) => Some(8),
         TypeData::Float(_) => None, // x87 / fp128 / bfloat → MEMORY
@@ -132,7 +132,7 @@ fn classify_field(ctx: &Context, ty: TypeId) -> EightbyteClass {
                 EightbyteClass::Memory
             } else {
                 // Nested struct: return INTEGER if any eightbyte is INTEGER.
-                if sub.iter().any(|c| *c == EightbyteClass::Integer) {
+                if sub.contains(&EightbyteClass::Integer) {
                     EightbyteClass::Integer
                 } else {
                     EightbyteClass::Sse

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -2744,7 +2744,7 @@ mod tests {
             false,
         );
         b.build_ret_void();
-        drop(b);
+        let _ = b;
 
         // Lower
         let mut be = X86Backend::new(TargetFeatures::baseline());

--- a/src/llvm-target-x86/src/lower.rs
+++ b/src/llvm-target-x86/src/lower.rs
@@ -1059,7 +1059,7 @@ fn lower_instr(
                 mf.push(mblock, MInstr::new(MOV_RR).with_dst(tmp).with_vreg(*src));
                 staged.push(tmp);
             }
-            for ((preg, _), tmp) in reg_moves.iter().zip(staged.into_iter()) {
+            for ((preg, _), tmp) in reg_moves.iter().zip(staged) {
                 emit_mov_to_preg(mf, mblock, *preg, tmp);
             }
 

--- a/src/llvm-transforms/src/lib.rs
+++ b/src/llvm-transforms/src/lib.rs
@@ -16,7 +16,7 @@
 //! b.position_at_end(entry);
 //! let c = b.const_int(i32_ty, 42);
 //! b.build_ret(c);
-//! drop(b);
+//! let _ = b;
 //! let mut pm = build_pipeline(OptLevel::O2);
 //! pm.run_until_fixed_point(&mut ctx, &mut module, 8);
 //! assert_eq!(module.functions.len(), 1);

--- a/src/llvm-transforms/src/licm.rs
+++ b/src/llvm-transforms/src/licm.rs
@@ -470,7 +470,7 @@ mod tests {
 
         b.position_at_end(exit_bb);
         b.build_ret(c0);
-        drop(b);
+        let _ = b;
 
         // Add back-edge to phi node.
         {
@@ -583,7 +583,7 @@ mod tests {
 
         b.position_at_end(exit_bb);
         b.build_ret_void();
-        drop(b);
+        let _ = b;
 
         {
             let i_phi_iid = module.functions[0].value_names["i"];
@@ -670,7 +670,7 @@ mod tests {
 
         b.position_at_end(exit_bb);
         b.build_ret(c0);
-        drop(b);
+        let _ = b;
 
         {
             let i_phi_iid = module.functions[1].value_names["i"];
@@ -812,7 +812,7 @@ mod tests {
 
         b.position_at_end(exit_bb);
         b.build_ret(c0);
-        drop(b);
+        let _ = b;
 
         // Add back-edge to inner phi.
         {

--- a/src/llvm-transforms/src/mem2reg.rs
+++ b/src/llvm-transforms/src/mem2reg.rs
@@ -350,19 +350,17 @@ fn rename_dfs(
                 ptr: ValueRef::Instruction(alloca_iid),
                 volatile: false,
                 ..
-            } => {
-                if stacks.contains_key(&alloca_iid) {
-                    // If the stored value is itself a replaced load, resolve it.
-                    let resolved = if let ValueRef::Instruction(vid) = val {
-                        subst.get(&vid).copied().unwrap_or(val)
-                    } else {
-                        val
-                    };
-                    let stack = stacks.get_mut(&alloca_iid).unwrap();
-                    saved.push((alloca_iid, stack.len()));
-                    stack.push(resolved);
-                    instrs_to_remove.insert(iid);
-                }
+            } if stacks.contains_key(&alloca_iid) => {
+                // If the stored value is itself a replaced load, resolve it.
+                let resolved = if let ValueRef::Instruction(vid) = val {
+                    subst.get(&vid).copied().unwrap_or(val)
+                } else {
+                    val
+                };
+                let stack = stacks.get_mut(&alloca_iid).unwrap();
+                saved.push((alloca_iid, stack.len()));
+                stack.push(resolved);
+                instrs_to_remove.insert(iid);
             }
             _ => {}
         }

--- a/src/llvm-transforms/src/reassoc.rs
+++ b/src/llvm-transforms/src/reassoc.rs
@@ -147,27 +147,26 @@ fn try_simplify_fp(
             if reassoc_or_fast {
                 if let Some(c2) = fp_constant_bits(ctx, *rhs) {
                     let inner_lhs = resolve(*lhs, subst);
-                    if let Some((inner_kind, _inner_lhs_id)) =
-                        get_instr_kind_by_ref(func, rewritten, inner_lhs)
-                    {
-                        if let InstrKind::FAdd {
+                    if let Some((
+                        InstrKind::FAdd {
                             flags: f2,
                             lhs: x,
                             rhs: rhs2,
-                        } = inner_kind
-                        {
-                            if f2.reassoc || f2.fast {
-                                if let Some(c1) = fp_constant_bits(ctx, *rhs2) {
-                                    let combined = f64::from_bits(c1) + f64::from_bits(c2);
-                                    if combined.is_finite() {
-                                        let new_c = ctx.const_float(ty, combined.to_bits());
-                                        let new_kind = InstrKind::FAdd {
-                                            flags: *flags,
-                                            lhs: *x,
-                                            rhs: ValueRef::Constant(new_c),
-                                        };
-                                        return Some(SimplifyResult::NewKind(new_kind));
-                                    }
+                        },
+                        _inner_lhs_id,
+                    )) = get_instr_kind_by_ref(func, rewritten, inner_lhs)
+                    {
+                        if f2.reassoc || f2.fast {
+                            if let Some(c1) = fp_constant_bits(ctx, *rhs2) {
+                                let combined = f64::from_bits(c1) + f64::from_bits(c2);
+                                if combined.is_finite() {
+                                    let new_c = ctx.const_float(ty, combined.to_bits());
+                                    let new_kind = InstrKind::FAdd {
+                                        flags: *flags,
+                                        lhs: *x,
+                                        rhs: ValueRef::Constant(new_c),
+                                    };
+                                    return Some(SimplifyResult::NewKind(new_kind));
                                 }
                             }
                         }
@@ -204,11 +203,9 @@ fn try_simplify_fp(
 
             // x * 0.0  →  0.0  (nnan + ninf, or fast)
             let nnan_ninf_or_fast = (flags.nnan && flags.ninf) || flags.fast;
-            if nnan_ninf_or_fast {
-                if is_fp_zero(ctx, *rhs) || is_fp_zero(ctx, *lhs) {
-                    let zero_cid = ctx.const_float(ty, 0f64.to_bits());
-                    return Some(SimplifyResult::Identity(ValueRef::Constant(zero_cid)));
-                }
+            if nnan_ninf_or_fast && (is_fp_zero(ctx, *rhs) || is_fp_zero(ctx, *lhs)) {
+                let zero_cid = ctx.const_float(ty, 0f64.to_bits());
+                return Some(SimplifyResult::Identity(ValueRef::Constant(zero_cid)));
             }
 
             None

--- a/src/llvm-transforms/src/slp.rs
+++ b/src/llvm-transforms/src/slp.rs
@@ -865,7 +865,7 @@ mod tests {
         let has_vec_fadd = func.blocks[0].body.iter().any(|&id| {
             let instr = &func.instructions[id.0 as usize];
             match &instr.kind {
-                InstrKind::FAdd { lhs, rhs, .. } => {
+                InstrKind::FAdd { lhs, rhs: _, .. } => {
                     let lhs_ty = match lhs {
                         ValueRef::Instruction(iid) => func.instructions[iid.0 as usize].ty,
                         _ => return false,

--- a/src/llvm-transforms/src/tsan.rs
+++ b/src/llvm-transforms/src/tsan.rs
@@ -456,7 +456,7 @@ fn is_alloca_derived(
 mod tests {
     use super::*;
     use crate::pass::ModulePass;
-    use llvm_ir::{Builder, Context, Function, InstrKind, Linkage, Module};
+    use llvm_ir::{Builder, Context, InstrKind, Linkage, Module};
 
     fn make_load_module_i64() -> (Context, Module) {
         let mut ctx = Context::new();

--- a/src/llvm-transforms/src/ubsan.rs
+++ b/src/llvm-transforms/src/ubsan.rs
@@ -165,7 +165,7 @@ fn ensure_declarations(ctx: &mut Context, module: &mut Module) {
 /// creating a *forward-declared stub* in the function's instruction pool —
 /// a Call with a special zero-arg void fn_ty and a GlobalId placeholder.
 /// The module pass resolves these placeholders to real declarations.
-
+///
 /// Index into UBSAN_RUNTIME_FNS by name.
 fn ubsan_fn_index(name: &str) -> Option<u32> {
     UBSAN_RUNTIME_FNS
@@ -187,14 +187,16 @@ fn placeholder_callee(fn_name: &str) -> Option<ValueRef> {
 fn apply_resolution_table(func: &mut Function, table: &[Option<u32>; 8]) {
     for iid in 0..func.instructions.len() {
         let iid = llvm_ir::InstrId(iid as u32);
-        if let InstrKind::Call { callee, .. } = &mut func.instr_mut(iid).kind {
-            if let ValueRef::Global(llvm_ir::GlobalId(gid)) = callee {
-                if *gid >= PLACEHOLDER_BASE {
-                    let fn_idx = (*gid - PLACEHOLDER_BASE) as usize;
-                    if fn_idx < table.len() {
-                        if let Some(real_gid) = table[fn_idx] {
-                            *gid = real_gid;
-                        }
+        if let InstrKind::Call {
+            callee: ValueRef::Global(llvm_ir::GlobalId(gid)),
+            ..
+        } = &mut func.instr_mut(iid).kind
+        {
+            if *gid >= PLACEHOLDER_BASE {
+                let fn_idx = (*gid - PLACEHOLDER_BASE) as usize;
+                if fn_idx < table.len() {
+                    if let Some(real_gid) = table[fn_idx] {
+                        *gid = real_gid;
                     }
                 }
             }
@@ -852,7 +854,7 @@ mod tests {
         b.position_at_end(entry);
         // Build a load of &G (the global value as a pointer).
         let fid = b.current_function().unwrap();
-        drop(b);
+        let _ = b;
         // Manually construct a load from the global.
         let func = module.function_mut(fid);
         let gid_ref = ValueRef::Global(llvm_ir::GlobalId(0));

--- a/src/llvm-transforms/tests/reassoc.rs
+++ b/src/llvm-transforms/tests/reassoc.rs
@@ -2,8 +2,8 @@
 //! FMF-exploiting FP constant folding (`try_fold_fp`).
 
 use llvm_ir::{
-    ArgId, Builder, ConstantData, Context, FastMathFlags, InstrId, InstrKind, Instruction, Linkage,
-    Module, TypeId, ValueRef,
+    ArgId, Builder, ConstantData, Context, FastMathFlags, InstrKind, Instruction, Linkage, Module,
+    TypeId, ValueRef,
 };
 use llvm_transforms::{constant_fold::try_fold_fp, pass::FunctionPass, reassoc::ReassocPass};
 
@@ -40,7 +40,7 @@ fn body_len(module: &Module) -> usize {
 
 /// Helper: append an instruction to block 0 of function 0, return its InstrId.
 fn push_instr(
-    ctx: &Context,
+    _ctx: &Context,
     module: &mut Module,
     name: &str,
     ty: TypeId,

--- a/src/llvm-transforms/tests/strict_fp.rs
+++ b/src/llvm-transforms/tests/strict_fp.rs
@@ -27,7 +27,7 @@ fn make_f64_two_arg_fn() -> (Context, Module) {
     );
     let entry = b.add_block("entry");
     b.position_at_end(entry);
-    drop(b);
+    let _ = b;
     (ctx, module)
 }
 
@@ -222,7 +222,7 @@ fn build_fp_invariant_loop(flags: FastMathFlags) -> (Context, Module, BlockId) {
 
     b.position_at_end(exit_bb);
     b.build_ret(c0);
-    drop(b);
+    let _ = b;
 
     // Patch back-edge into phi.
     {
@@ -340,7 +340,7 @@ fn strictfp_function_attr_round_trips() {
     );
 
     // Parse back.
-    let (ctx2, module2) = parse(&ll).expect("should re-parse successfully");
+    let (_ctx2, module2) = parse(&ll).expect("should re-parse successfully");
 
     assert!(
         module2.functions[0].strictfp,

--- a/src/llvm/examples/hello_world.rs
+++ b/src/llvm/examples/hello_world.rs
@@ -13,7 +13,7 @@ fn main() {
     b.position_at_end(entry);
     let c = b.const_int(i32_ty, 0);
     b.build_ret(c);
-    drop(b);
+    let _ = b;
 
     let mut pm = build_pipeline(OptLevel::O1);
     pm.run_until_fixed_point(&mut ctx, &mut module, 4);

--- a/src/llvm/examples/opt_pipeline.rs
+++ b/src/llvm/examples/opt_pipeline.rs
@@ -17,7 +17,7 @@ fn main() {
     let _dead = b.build_add("dead", c1, c2);
     let ret_val = b.const_int(i32_ty, 42);
     b.build_ret(ret_val);
-    drop(b);
+    let _ = b;
 
     let before = module.functions[0].blocks[0].body.len();
     let mut pm = build_pipeline(OptLevel::O2);

--- a/src/llvm/tests/lto_multi_tu.rs
+++ b/src/llvm/tests/lto_multi_tu.rs
@@ -138,7 +138,7 @@ fn lto_dead_stripping_removes_unused_function() {
     );
 
     let (_, merged_o0) =
-        run_lto_from_objects(&[with_dead.clone()], OptLevel::O0).expect("O0 failed");
+        run_lto_from_objects(std::slice::from_ref(&with_dead), OptLevel::O0).expect("O0 failed");
     let (_, merged_o2) = run_lto_from_objects(&[with_dead], OptLevel::O2).expect("O2 failed");
 
     // At O0, @dead should still be present (no DCE).


### PR DESCRIPTION
Refs #381

## Summary

Third Milestone V (#381) PR — the lint quality gate. `cargo +stable clippy --locked --all-targets -- -D warnings` now passes workspace-wide (was ~120 warnings), and the `Quality Gates` workflow (added in #389) gains a `clippy -D warnings` job.

### Auto-fixed (via `cargo clippy --fix`)
`map_or` → `is_some_and`, redundant closures, manual `is_multiple_of`/`div_ceil`, OR-patterns → ranges, unused imports/vars, etc.

### Manual fixes (needed judgment)
- **Parser `keyword_text`**: removed a duplicated 9-arm block (`Catchpad`..`From` were listed twice → unreachable arms). Benign — the duplicates produced identical output — but worth removing.
- **13 `drop(builder)`** calls used only to end a borrow → `let _ = builder;` (Builder doesn't impl `Drop`, so `drop()` was a no-op that only extended the borrow).
- **Collapsed nested `if let`s** in `reassoc.rs` and `ubsan.rs` by matching the inner enum/field pattern directly in the outer pattern — no let-chains, so it stays edition-2021 safe.
- `detect_hfa(...).map(|(k,n)| (k,n))` → `detect_hfa(...)` (identity map).
- `&[x.clone()]` → `std::slice::from_ref(&x)` in an LTO test.
- Doc-comment continuation / empty-line-after-doc fixes.

## Test plan

- [x] `cargo +stable clippy --locked --all-targets -- -D warnings` → exit 0 (clean)
- [x] `cargo +stable test -p llvm-in-rust-transforms -p llvm-in-rust-ir-parser -p llvm-in-rust-target-arm` → all green (verifies the parser-dedup / reassoc / ubsan refactors preserve behavior)
- [x] Rebased onto main after #389 (fmt) merged, so this diff is clippy-only

## Milestone V remaining (final PR)

- AGENTS.md recurring-agent-workflow doc update (per the directive, "so no need to repeat this") + roadmap #93 status update with green-run links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)