### PR TITLE
docs(X): error-handling audit for runtime-facing crates

### DIFF
--- a/docs/error_handling_audit.md
+++ b/docs/error_handling_audit.md
@@ -33,11 +33,11 @@ the three real panicking forms:
 | `llvm-ir-parser` | 2 | 15 |
 | `llvm-bitcode` | 1 | 37 |
 | `llvm-target-riscv` | 1 | 17 |
-| `llvm-target-x86` | 0 | 7 |
-| `llvm-target-arm` | 0 | 0 |
-| `llvm-jit` | 0 | 11 |
 | `llvm-analysis` | 0 | 4 |
 | `llvm-bench` | 0 | 1 |
+| `llvm-jit` | 0 | 11 |
+| `llvm-target-arm` | 0 | 0 |
+| `llvm-target-x86` | 0 | 7 |
 | **Total** | **113** | **233** |
 
 ## Classification of the 113 production sites

--- a/docs/error_handling_audit.md
+++ b/docs/error_handling_audit.md
@@ -1,0 +1,152 @@
+# Error-Handling Audit — Production Panic Sites
+
+Issue #383 (Milestone X) item 1: audit every non-test `panic!` / `unwrap()` /
+`expect()` call site in the runtime-facing crates and classify each as
+**test-only**, **invariant-checked**, or **production-facing**.
+
+Source-of-truth scan: `scripts/audit_error_handling.py` (added in this PR).
+
+## Methodology
+
+The script walks every `.rs` file under `src/`, skipping `tests/`,
+`examples/`, and `benches/` directories, and skipping every region inside
+`#[cfg(test)] mod tests { … }` (tracked by `{` / `}` brace counting after the
+`#[cfg(test)]` attribute).  Inside the remaining "production" lines it counts
+the three real panicking forms:
+
+| Pattern | Regex | Why this excludes false positives |
+|---|---|---|
+| `panic!` macro | `(?<![A-Za-z_])panic!\s*\(` | Word-boundary lookbehind avoids `expand_panic!`, `panicking::panic!`, etc. |
+| `.unwrap()` on Option/Result | `\.unwrap\s*\(\s*\)` | The empty parens distinguish std `unwrap` from `unwrap_or…`. |
+| `.expect("msg")` on Option/Result | `\.expect\s*\(\s*"` | The leading string literal distinguishes std `expect` from the parser's lexer-style `lex.expect(&Token::…)` method. |
+
+## Crate-level summary (2026-05-30)
+
+| Crate | Production panic sites | Tests-only |
+|---|---:|---:|
+| `llvm-ir` | 76 | 0 |
+| `llvm-transforms` | 14 | 75 |
+| `llvm` | 7 | 7 |
+| `llvm-target-wasm` | 5 | 11 |
+| `llvm-codegen` | 4 | 22 |
+| `llvm-rustc-backend` | 3 | 26 |
+| `llvm-ir-parser` | 2 | 15 |
+| `llvm-bitcode` | 1 | 37 |
+| `llvm-target-riscv` | 1 | 17 |
+| `llvm-target-x86` | 0 | 7 |
+| `llvm-target-arm` | 0 | 0 |
+| `llvm-jit` | 0 | 11 |
+| `llvm-analysis` | 0 | 4 |
+| `llvm-bench` | 0 | 1 |
+| **Total** | **113** | **233** |
+
+## Classification of the 113 production sites
+
+### A. Infallible writes (~70 sites — *not* user-reachable panics)
+
+Bulk of `llvm-ir/src/printer.rs` writes are
+`write!(out: &mut String, …).unwrap()`.  Writing to a `String` is infallible
+under `std::fmt::Write` — the underlying buffer cannot return an error.
+This is the standard Rust idiom for printer code.  These are not real panic
+sites: the `.unwrap()` is a static guarantee, not a runtime failure mode.
+
+**Action:** no change required.  Optional follow-up could use the
+`expect("write to String is infallible")` form to communicate intent, but
+this is purely cosmetic.
+
+### B. Internal-API invariants (~30 sites)
+
+Examples:
+
+- `let fid = self.current_function.expect("no current function");`
+  — `llvm-ir/src/builder.rs`: builder methods called outside a positioned
+  function.  This is API misuse by Rust callers, not user input.
+- `sections.iter().position(|s| s.name == rodata_name).unwrap()`
+  — `llvm-codegen/src/emit.rs`: the section is created earlier in the same
+  function; the lookup cannot fail.
+- `panic!("max 2 successors")` in `cfg.rs` / `loops.rs` — match arms
+  documenting an invariant.  Reached only if the IR is internally
+  inconsistent.
+- `panic!("expected reloaded VReg operand")` in `regalloc.rs` — pre-condition
+  on the spill-reload helper.
+
+**Action:** no Result conversion needed; these are not reachable from
+adversarial input.  We may tighten the messages over time, but they
+correctly fail fast on a logic bug rather than silently producing wrong
+output.
+
+### C. Lexer post-peek invariants (2 sites in `llvm-ir-parser/src/lexer.rs`)
+
+- `self.peeked.as_ref().unwrap()` — guaranteed `Some` because the surrounding
+  code only enters this arm after `self.peek_some()` returned `true`.
+- `self.advance().unwrap()` — same pattern.
+
+Both are internal lookahead invariants, not user-input-driven panics on
+malformed IR.  The user-input-driven errors in the parser already return
+`Result<…, ParseError>`.
+
+**Action:** consider rewriting as `if let Some(t) = …` for cleanliness, but
+no Result API change.
+
+### D. Doc-comment examples (2 sites)
+
+`src/llvm-bitcode/src/lib.rs:20` and `src/llvm-codegen/src/thinlto.rs:24` —
+matches inside `//! …` doc comments showing example usage with `.unwrap()`
+for brevity.  Not real call sites.
+
+**Action:** none.
+
+### E. CLI argument parsing (~7 sites in `llvm-test-suite-compat.rs`)
+
+`args.next().expect("--suite-dir value")` and similar.  These are operator-
+facing CLI binaries used in CI; the `expect` message is the diagnostic.  Not
+a security boundary.
+
+**Action:** could be improved with proper `eprintln!` + non-zero exit, but
+this is QoL, not a hardening blocker.
+
+## Key finding
+
+**The external-input-facing surfaces are already structured-error clean:**
+
+| Surface | External input source | Error type today |
+|---|---|---|
+| `llvm-ir-parser::parser::parse(&str)` | Untrusted `.ll` text | `Result<_, ParseError>` |
+| `llvm-bitcode::read_bitcode(&[u8])` | Untrusted LRIR bytes | `Result<_, BitcodeError>` |
+| `llvm-bitcode::read_llvm_bc(&[u8])` | Untrusted LLVM `.bc` | `Result<_, BitcodeError>` |
+| `llvm-jit::SimpleJit::add_module(…)` | Trusted-IR `(Context, Module)` | `Result<_, JitError>` |
+
+The audit found **zero production panic sites that are reachable from a
+malformed external input** in the parser, bitcode readers, or JIT entry
+point.  Every panic in these paths is either a tests-only assertion, a
+post-peek/post-allocation lookahead invariant, or an API-misuse expect on a
+Rust caller's positioning.
+
+## Implications for the Milestone X follow-ups
+
+Because the structured-error story is already in place at the entry-point
+boundary, the remaining Milestone X work shifts from *"add structured error
+types"* to *"bound the resources those error paths can consume before
+failing"* and *"document the safety contract."*
+
+| Item | Original scope | Refined scope |
+|---|---|---|
+| Replace production-facing panics with structured errors | Convert remaining sites | No-op — already structured. Optional: classify each retained panic as invariant-only (`debug_assert!`-style) for future polish. |
+| Resource limits in parser/optimizer | New `ParseLimits` / `OptLimits` structs | Add with documented defaults; thread through `parse` / pass manager. |
+| CLI flags for limits | Surface on the CLI binaries | Add `--max-fn` / `--max-instr` etc. on `llvm-compile` / `llvm-ir-min` / `llvm-test-suite-compat`. |
+| Negative/fuzz tests | Oversized IR, deep nesting, malformed EH | Mostly new — add `tests/` cases that trigger each `ParseError`/`BitcodeError` variant and each new resource-limit error. |
+| Sandbox guidance doc | Non-sandbox security model | New doc page in `docs/`. |
+
+This audit will be referenced by subsequent Milestone X PRs as the
+classification of record.
+
+## Reproducing the audit
+
+```bash
+python3 scripts/audit_error_handling.py src --json
+```
+
+Writes `/tmp/audit_prod_sites.json` with every (file, line, kind) classified
+production site.
+
+Refs #93, refs #383.

--- a/scripts/audit_error_handling.py
+++ b/scripts/audit_error_handling.py
@@ -9,8 +9,9 @@ classification of the production sites.
 Usage:
     python3 scripts/audit_error_handling.py [path] [--json]
 
-Default `path` is `src/`.  With `--json`, dumps the full production-site
-list to `/tmp/audit_prod_sites.json`.
+Default `path` is `src/`.  The stdout table includes the per-crate
+production and in-test counts used by `docs/error_handling_audit.md`.  With
+`--json`, dumps the full production-site list to `/tmp/audit_prod_sites.json`.
 
 The script intentionally distinguishes std panicking forms from method names
 that happen to be called `expect` (e.g. the lexer's
@@ -74,39 +75,47 @@ def main() -> None:
     emit_json = "--json" in sys.argv
 
     prod_sites: list[dict] = []
-    by_crate: dict[str, list] = {}
-    test_count = 0
+    by_crate: dict[str, dict[str, list[dict]]] = {}
 
     for dirpath, _, files in os.walk(root):
         for fn in files:
             if not fn.endswith(".rs"):
                 continue
-            rel = os.path.relpath(os.path.join(dirpath, fn))
+            path = os.path.join(dirpath, fn)
+            rel = os.path.relpath(path)
+            root_rel = os.path.relpath(path, root)
             parts = rel.split(os.sep)
             if any(p in ("tests", "examples", "benches") for p in parts):
                 continue
-            crate = "/".join(parts[:2]) if len(parts) >= 2 else parts[0]
+            root_parts = root_rel.split(os.sep)
+            crate = root_parts[0] if root_parts and root_parts[0] != "." else parts[0]
+            bucket = by_crate.setdefault(crate, {"prod": [], "test": []})
             for line_no, kind, in_test, snippet in scan(rel):
+                record = {
+                    "crate": crate,
+                    "file": rel,
+                    "line": line_no,
+                    "kind": kind,
+                    "text": snippet,
+                }
                 if in_test:
-                    test_count += 1
+                    bucket["test"].append(record)
                 else:
-                    record = {
-                        "crate": crate,
-                        "file": rel,
-                        "line": line_no,
-                        "kind": kind,
-                        "text": snippet,
-                    }
                     prod_sites.append(record)
-                    by_crate.setdefault(crate, []).append(record)
+                    bucket["prod"].append(record)
 
-    print(f"{'crate':<40} {'prod':>6}")
-    print("-" * 50)
-    for crate in sorted(by_crate):
-        print(f"{crate:<40} {len(by_crate[crate]):>6}")
-    print("-" * 50)
+    print(f"{'crate':<40} {'prod':>6} {'tests':>6}")
+    print("-" * 57)
+    rows = sorted(
+        by_crate.items(),
+        key=lambda item: (-len(item[1]["prod"]), item[0]),
+    )
+    for crate, counts in rows:
+        print(f"{crate:<40} {len(counts['prod']):>6} {len(counts['test']):>6}")
+    print("-" * 57)
+    test_count = sum(len(counts["test"]) for counts in by_crate.values())
     print(f"{'TOTAL production sites':<40} {len(prod_sites):>6}")
-    print(f"(test sites excluded: {test_count})")
+    print(f"{'TOTAL test sites excluded':<40} {test_count:>6}")
 
     if emit_json:
         out_path = "/tmp/audit_prod_sites.json"

--- a/scripts/audit_error_handling.py
+++ b/scripts/audit_error_handling.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Audit production panicking sites in `src/` Rust code.
+
+For Milestone X / issue #383 — classifies every `panic!` / `unwrap()` /
+`expect("…")` call into production vs in-test buckets.  See
+`docs/error_handling_audit.md` for the methodology and the canonical
+classification of the production sites.
+
+Usage:
+    python3 scripts/audit_error_handling.py [path] [--json]
+
+Default `path` is `src/`.  With `--json`, dumps the full production-site
+list to `/tmp/audit_prod_sites.json`.
+
+The script intentionally distinguishes std panicking forms from method names
+that happen to be called `expect` (e.g. the lexer's
+`lex.expect(&Token::Foo)`).
+"""
+
+from __future__ import annotations
+import json
+import os
+import re
+import sys
+
+# `panic!(` macro call — word-boundary lookbehind avoids matching helpers
+# named `…_panic!`.
+RE_PANIC = re.compile(r"(?<![A-Za-z_])panic!\s*\(")
+# `.unwrap()` — empty parens distinguish std unwrap from `unwrap_or…`.
+RE_UNWRAP = re.compile(r"\.unwrap\s*\(\s*\)")
+# `.expect("…")` — leading string literal distinguishes std expect from the
+# parser's lexer-style `expect(&Token::Foo)` method.
+RE_EXPECT = re.compile(r'\.expect\s*\(\s*"')
+# Lines that introduce a #[cfg(test)] item — the next `mod NAME {` opens a
+# test-only region tracked via brace depth.
+RE_CFG_TEST = re.compile(r"#\[cfg\(\s*test\s*\)\]")
+
+
+def scan(path: str) -> list[tuple[int, str, bool, str]]:
+    """Return (line_no, kind, in_test, snippet) for each panicking site."""
+    try:
+        with open(path, errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return []
+    in_test = False
+    test_depth = 0
+    cfg_test_pending = False
+    out: list[tuple[int, str, bool, str]] = []
+    for i, line in enumerate(lines, start=1):
+        if not in_test and RE_CFG_TEST.search(line):
+            cfg_test_pending = True
+        if cfg_test_pending and "mod " in line and "{" in line:
+            in_test = True
+            test_depth = line.count("{") - line.count("}")
+            cfg_test_pending = False
+            continue
+        if in_test:
+            test_depth += line.count("{") - line.count("}")
+            if test_depth <= 0:
+                in_test = False
+        snippet = line.strip()[:120]
+        if RE_PANIC.search(line):
+            out.append((i, "panic", in_test, snippet))
+        if RE_UNWRAP.search(line):
+            out.append((i, "unwrap", in_test, snippet))
+        if RE_EXPECT.search(line):
+            out.append((i, "expect", in_test, snippet))
+    return out
+
+
+def main() -> None:
+    root = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith("--") else "src"
+    emit_json = "--json" in sys.argv
+
+    prod_sites: list[dict] = []
+    by_crate: dict[str, list] = {}
+    test_count = 0
+
+    for dirpath, _, files in os.walk(root):
+        for fn in files:
+            if not fn.endswith(".rs"):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, fn))
+            parts = rel.split(os.sep)
+            if any(p in ("tests", "examples", "benches") for p in parts):
+                continue
+            crate = "/".join(parts[:2]) if len(parts) >= 2 else parts[0]
+            for line_no, kind, in_test, snippet in scan(rel):
+                if in_test:
+                    test_count += 1
+                else:
+                    record = {
+                        "crate": crate,
+                        "file": rel,
+                        "line": line_no,
+                        "kind": kind,
+                        "text": snippet,
+                    }
+                    prod_sites.append(record)
+                    by_crate.setdefault(crate, []).append(record)
+
+    print(f"{'crate':<40} {'prod':>6}")
+    print("-" * 50)
+    for crate in sorted(by_crate):
+        print(f"{crate:<40} {len(by_crate[crate]):>6}")
+    print("-" * 50)
+    print(f"{'TOTAL production sites':<40} {len(prod_sites):>6}")
+    print(f"(test sites excluded: {test_count})")
+
+    if emit_json:
+        out_path = "/tmp/audit_prod_sites.json"
+        with open(out_path, "w") as fh:
+            json.dump(prod_sites, fh, indent=2)
+        print(f"wrote {out_path} ({len(prod_sites)} sites)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #383

## Summary

First **Milestone X (#383)** deliverable — the non-test `panic!`/`unwrap()`/`expect()` audit (checklist item 1).

- Adds `scripts/audit_error_handling.py`: a reproducible scanner that walks `src/`, excludes `#[cfg(test)] mod tests { … }` regions via brace counting, and classifies each panicking site into production vs in-test buckets. The regexes distinguish std panicking calls from method names (so the parser's `lex.expect(&Token::…)` is not double-counted as a panic).
- Adds `docs/error_handling_audit.md`: the classification of record.

## Key finding

The external-input-facing surfaces are already structured-error clean:

| Surface | Input | Error type |
|---|---|---|
| `llvm-ir-parser::parser::parse(&str)` | untrusted `.ll` text | `Result<_, ParseError>` |
| `llvm-bitcode::read_bitcode(&[u8])` | untrusted LRIR | `Result<_, BitcodeError>` |
| `llvm-bitcode::read_llvm_bc(&[u8])` | untrusted LLVM `.bc` | `Result<_, BitcodeError>` |
| `llvm-jit::SimpleJit::add_module(…)` | trusted-IR `(Context, Module)` | `Result<_, JitError>` |

Of the 113 production-site totals, the breakdown is:
- **~70** infallible `write!(String, …).unwrap()` printer idioms
- **~30** internal-API invariants (Builder pre-conditions, post-allocation lookups, "enum can't appear here" match arms)
- **2** lexer post-peek lookahead invariants
- **2** doc-comment examples
- **~7** operator-facing CLI argument-parsing `expect`s

Zero production panics are reachable from a malformed external input on the four boundary surfaces above.

## Why this matters for the rest of Milestone X

The original checklist included "replace production-facing panics with structured error types" — this audit shows that's effectively a no-op because the structured-error story is already in place at the boundaries. The doc adopts a **revised plan** for X-2…X-6: shift the work from "add error types" to *"bound the resources those error paths can consume before failing"* (parser/optimizer resource limits, CLI flag surfaces) and *"document the safety contract"* (sandbox-deployment doc, negative/fuzz tests). Subsequent X PRs will reference this audit as the classification of record.

## Test plan

- [x] `python3 scripts/audit_error_handling.py src` reproduces the table in the doc (113 production, 233 in-test).
- [x] `cargo +stable fmt --check` and `cargo +stable clippy --locked --all-targets -- -D warnings` unchanged (PR only adds docs + a Python script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)