### PR TITLE
docs(X): sandbox guidance for untrusted inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ source of truth for release-blocking quality status.
 
 See [`docs/production_support_boundaries.md`](docs/production_support_boundaries.md)
 for the public support contract, API stability matrix, and backend/platform
-boundaries.
+boundaries. See [`docs/sandbox_deployment.md`](docs/sandbox_deployment.md)
+before routing untrusted or tenant-controlled input through parser,
+optimization, codegen, object emission, or JIT paths.
 
 ---
 

--- a/docs/production_operations.md
+++ b/docs/production_operations.md
@@ -10,6 +10,9 @@ Issue #186 tracks the operator and contributor playbooks for running LLVM-in-Rus
 
 Before using this guide for a production pilot, review the scoped support
 contract in [`docs/production_support_boundaries.md`](production_support_boundaries.md).
+If the integration may receive untrusted or tenant-controlled input, also
+apply [`docs/sandbox_deployment.md`](sandbox_deployment.md) before exposing any
+parser, optimizer, codegen, object emission, or JIT path.
 
 ## Build and validation quick start
 
@@ -120,6 +123,7 @@ Minimize with `scripts/reduce_ci_failure.sh`, attach the evidence package, and s
 ## Runbook index
 
 - Production support boundaries: `docs/production_support_boundaries.md`
+- Sandbox deployment for untrusted inputs: `docs/sandbox_deployment.md`
 - Release artifacts: `docs/release_artifact_pipeline.md`
 - RC and rollback: `docs/release_candidate_protocol.md`
 - Crash and miscompilation triage: `docs/crash_triage_runbook.md`

--- a/docs/production_support_boundaries.md
+++ b/docs/production_support_boundaries.md
@@ -10,7 +10,7 @@ and from unsupported deployment modes.
 |---|---|---|
 | Constrained internal or pilot workload | Supported with controls | Trusted LLVM 15+ opaque-pointer IR; pinned LLVM-in-Rust commit or release; target/backend selected from the matrix below; release-blocking CI green on that commit; fallback to upstream LLVM documented by the embedding project. |
 | General drop-in replacement for LLVM | Not supported | LLVM IR, backend, runtime, and platform coverage are broad but not complete. Milestones V-Z in #93 must complete before a general production-ready declaration. |
-| Untrusted or adversarial IR/object input | Not supported without sandboxing | Run parser, optimizer, codegen, and JIT paths in a separate process/container with CPU, memory, file-system, and wall-clock limits. Disable JIT for hostile input unless the host already has a hardened executable-memory policy. |
+| Untrusted or adversarial IR/object input | Not supported without sandboxing | Run parser, optimizer, codegen, and JIT paths in a separate process/container with CPU, memory, file-system, and wall-clock limits. Disable JIT for hostile input unless the host already has a hardened executable-memory policy. See `docs/sandbox_deployment.md`. |
 | Research, benchmarking, and compiler experiments | Supported | APIs and behavior may change across `0.x` minor releases; pin revisions and record validation commands when publishing results. |
 
 ## Pre-1.0 API Stability Matrix
@@ -41,6 +41,14 @@ and from unsupported deployment modes.
 | Mach-O | Pilot-supported for object emission and selected debug/LTO paths. | Unwind parity is narrower than ELF/COFF, and platform execution coverage must be explicitly checked for each pilot. |
 | COFF | Pilot-supported for x86-64/Windows object emission, Win64 ABI hardening, CodeView/PDB milestones, `.pdata`/`.xdata`, and Windows CI paths. | Full SEH funclet runtime parity and non-x86 Windows targets remain outside the current production contract. |
 | Known unsupported cases | Unsupported unless a linked issue or known-issue entry says otherwise | LLVM <=14 typed-pointer IR, arbitrary unsupported intrinsics, unrestricted inline asm, hostile inputs without sandboxing, unsupported relocation/linker combinations, and production use of any matrix cell marked experimental. |
+
+## Untrusted Input Deployment
+
+The detailed sandboxing runbook is
+[`docs/sandbox_deployment.md`](sandbox_deployment.md). It covers process and
+container isolation, Linux seccomp/cgroups, macOS `sandbox-exec`, Windows job
+objects, resource limits, temporary-directory hygiene, and JIT disablement for
+hostile inputs.
 
 ## Documentation Truth Policy
 

--- a/docs/sandbox_deployment.md
+++ b/docs/sandbox_deployment.md
@@ -1,0 +1,176 @@
+# Sandbox Deployment Guidance
+
+Issue #383 (Milestone X) requires an explicit security model for deployments
+that may receive malformed or adversarial IR, LRIR, object, or source-derived
+inputs.
+
+## Security Model
+
+LLVM-in-Rust is a compiler toolchain, not a sandbox. The parser and bitcode
+readers return structured errors for malformed input, but callers must still
+bound CPU, memory, filesystem, and executable-memory exposure when inputs are
+not fully trusted.
+
+| Input source | Required posture |
+|---|---|
+| Build artifacts produced by a trusted internal compiler pipeline | May run in-process when pinned to a validated commit and covered by the production support boundaries. |
+| User-uploaded `.ll`, `.bc`, LRIR, object files, or source that is converted into IR | Run out-of-process with resource limits and filesystem isolation. |
+| Fuzzing, reducer, compatibility-suite, or benchmark inputs | Run in disposable workers with timeouts and artifact quotas. |
+| JIT execution from anything other than trusted IR | Disable JIT, or isolate it in a short-lived process/container with executable-memory policy controls. |
+
+## Minimum Isolation Contract
+
+Use a worker process boundary for untrusted inputs. The host service should:
+
+1. Spawn a fresh worker per request or per small batch.
+2. Pass inputs through a private temporary directory.
+3. Apply wall-clock, CPU, memory, file-size, process-count, and open-file
+   limits before invoking parser, optimizer, codegen, object emission, or JIT
+   paths.
+4. Deny network access unless the specific pipeline stage requires it.
+5. Mount the workspace read-only and write outputs only to a request-scoped
+   directory.
+6. Delete temporary directories after collecting the minimal diagnostic
+   bundle.
+7. Treat a timeout, signal, or resource-limit exit as an expected rejected
+   input, not as a host-service crash.
+
+The library APIs are suitable inside the worker process. Do not expose those
+APIs directly inside a long-lived control-plane process when the input is
+untrusted.
+
+## Resource Limits
+
+Apply host-level limits even after parser or optimizer limit knobs are wired
+into the API. In-process limits protect algorithmic code paths; OS/container
+limits protect the embedding application.
+
+| Resource | Guidance |
+|---|---|
+| Wall clock | Set a request timeout and kill the worker on expiry. Use tighter limits for parser-only validation and broader limits for full codegen or compatibility-suite runs. |
+| CPU | Use `RLIMIT_CPU`, cgroups, Kubernetes CPU limits, or the platform equivalent. Avoid unbounded optimizer fixed-point loops on user inputs. |
+| Memory | Use cgroup memory limits, container memory limits, or `ulimit -v`/`RLIMIT_AS` where available. Record OOM exits distinctly from parse errors. |
+| Output size | Cap object, assembly, log, reducer, and benchmark artifact sizes. Refuse to archive unbounded stdout/stderr. |
+| File descriptors and processes | Apply `RLIMIT_NOFILE` and `RLIMIT_NPROC`/container process limits. |
+| Temporary storage | Use a request-scoped temp directory with a quota. Never reuse temp paths across tenants. |
+| Recursion and nesting | Use the parser/resource-limit API when available; until then, rely on worker timeouts and memory caps. |
+
+## Platform Patterns
+
+### Linux
+
+Prefer containers or a service-level sandbox with cgroups and seccomp:
+
+```bash
+docker run --rm \
+  --network=none \
+  --memory=512m \
+  --cpus=1 \
+  --pids-limit=64 \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  -v "$PWD/input:/input:ro" \
+  -v "$PWD/out:/out:rw" \
+  llvm-in-rust-worker:latest \
+  llvm-ir-min /input/repro.ll --output /out/min.ll
+```
+
+For native services, combine cgroups with a seccomp profile that denies
+network, process-spawning, and filesystem mutation outside the worker
+directory. Keep the exact allowed syscalls tied to the worker binary and
+revalidate after dependency or runtime changes.
+
+### macOS
+
+Use a short-lived worker process and `sandbox-exec` or an equivalent managed
+sandbox profile when available:
+
+```bash
+sandbox-exec -p '(version 1)
+  (deny default)
+  (allow file-read* (subpath "/path/to/input"))
+  (allow file-write* (subpath "/path/to/out"))
+  (allow file-write* (subpath "/private/tmp/llvm-in-rust-worker"))
+  (allow process*)
+  (deny network*)' \
+  llvm-ir-min /path/to/input/repro.ll --output /path/to/out/min.ll
+```
+
+Also apply an outer timeout from the orchestrator, because `sandbox-exec` does
+not by itself bound CPU or memory.
+
+### Windows
+
+Run untrusted workloads in a constrained job object, container, or VM. Set job
+object limits for process count, working set/memory, CPU time, and active
+process lifetime. Write outputs to a request-scoped directory with inherited
+ACLs that exclude unrelated service data.
+
+## JIT-Specific Rules
+
+The JIT allocates executable memory. For hostile input, the safest default is
+to disable JIT entirely and use object emission plus external validation in a
+disposable worker.
+
+If a pilot must JIT untrusted or tenant-controlled IR:
+
+- run the JIT in a separate process/container with no ambient credentials;
+- enforce W^X / executable-memory policy where the host supports it;
+- disable network and restrict filesystem access;
+- cap the number and size of compiled modules;
+- terminate the worker after the JIT call completes;
+- never call JIT-produced function pointers in the control-plane process.
+
+## Temporary Directory Hygiene
+
+Use a fresh directory for each request:
+
+```text
+/var/tmp/llvm-in-rust/<request-id>/
+  input/
+  work/
+  output/
+  logs/
+```
+
+Requirements:
+
+- Generate request IDs with sufficient entropy; do not use user-provided file
+  names as directory names.
+- Open files with no-follow semantics where practical.
+- Normalize and reject paths that escape the request root.
+- Store the original input checksum and sanitized file name in metadata.
+- Delete the directory after success, or retain it only behind an explicit
+  incident-retention policy.
+
+## Operational Handling
+
+For every rejected or timed-out input, record:
+
+- commit SHA, crate/binary version, and Rust toolchain;
+- input checksum, producer, and size;
+- resource limits applied;
+- command/API surface invoked;
+- exit status, signal, timeout, stderr, and backtrace if available;
+- path to the minimized reproducer when one is created.
+
+Use `docs/crash_triage_runbook.md` for crash, timeout, and miscompilation
+triage. Use `docs/release_candidate_protocol.md` if a production pilot or RC
+run hits a release-blocking failure.
+
+## Pilot Sign-Off Checklist
+
+Before claiming support for an untrusted-input deployment:
+
+- [ ] Worker process/container boundary is mandatory for all untrusted inputs.
+- [ ] CPU, memory, wall-clock, process-count, file-size, and temp-storage
+      limits are enforced outside the Rust process.
+- [ ] Network access is disabled unless explicitly required.
+- [ ] JIT is disabled, or JIT runs only inside a disposable worker with
+      executable-memory policy controls.
+- [ ] Temp directories are request-scoped, non-shared, and cleaned up.
+- [ ] Error/timeout/OOM outcomes are observable and do not crash the host
+      service.
+- [ ] Fallback to upstream LLVM or a known-good artifact path is documented.
+
+Refs #93, refs #383.

--- a/scripts/production_ops_docs.sh
+++ b/scripts/production_ops_docs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOC="$ROOT/docs/production_operations.md"
 SUPPORT_DOC="$ROOT/docs/production_support_boundaries.md"
+SANDBOX_DOC="$ROOT/docs/sandbox_deployment.md"
 README="$ROOT/README.md"
 CHANGELOG="$ROOT/CHANGELOG.md"
 LICENSE_FILE="$ROOT/LICENSE"
@@ -45,6 +46,7 @@ reject_in_file() {
 
 [[ -f "$DOC" ]] || { echo "missing $DOC" >&2; exit 1; }
 [[ -f "$SUPPORT_DOC" ]] || { echo "missing $SUPPORT_DOC" >&2; exit 1; }
+[[ -f "$SANDBOX_DOC" ]] || { echo "missing $SANDBOX_DOC" >&2; exit 1; }
 
 require_in_doc "## Build and validation quick start"
 require_in_doc "## Observability checklist"
@@ -55,14 +57,17 @@ require_in_doc "## Runbook index"
 require_in_doc "scripts/reduce_ci_failure.sh"
 require_in_doc "scripts/release_artifacts.sh verify"
 require_in_doc "docs/production_support_boundaries.md"
+require_in_doc "docs/sandbox_deployment.md"
 require_in_doc "docs/release_candidate_protocol.md"
 require_in_doc "docs/crash_triage_runbook.md"
 require_in_readme "docs/production_operations.md"
 require_in_readme "docs/production_support_boundaries.md"
+require_in_readme "docs/sandbox_deployment.md"
 
 require_in_file "$SUPPORT_DOC" "## Production Scope"
 require_in_file "$SUPPORT_DOC" "## Pre-1.0 API Stability Matrix"
 require_in_file "$SUPPORT_DOC" "## Backend and Platform Boundaries"
+require_in_file "$SUPPORT_DOC" "## Untrusted Input Deployment"
 require_in_file "$SUPPORT_DOC" "| x86-64 native backend |"
 require_in_file "$SUPPORT_DOC" "| WebAssembly backend |"
 require_in_file "$SUPPORT_DOC" "| Known unsupported cases |"
@@ -71,6 +76,16 @@ require_in_file "$LICENSE_FILE" "APPENDIX: How to apply the Apache License to yo
 require_in_file "$MANIFEST" "[workspace.package]"
 require_in_file "$MANIFEST" 'license = "Apache-2.0"'
 require_in_file "$MANIFEST" 'repository = "https://github.com/yudongusa/LLVM-in-Rust"'
+require_in_file "$SANDBOX_DOC" "## Security Model"
+require_in_file "$SANDBOX_DOC" "## Minimum Isolation Contract"
+require_in_file "$SANDBOX_DOC" "## Resource Limits"
+require_in_file "$SANDBOX_DOC" "## Platform Patterns"
+require_in_file "$SANDBOX_DOC" "## JIT-Specific Rules"
+require_in_file "$SANDBOX_DOC" "## Temporary Directory Hygiene"
+require_in_file "$SANDBOX_DOC" "## Pilot Sign-Off Checklist"
+require_in_file "$SANDBOX_DOC" "seccomp"
+require_in_file "$SANDBOX_DOC" "sandbox-exec"
+require_in_file "$SANDBOX_DOC" "JIT is disabled"
 
 reject_in_file "$README" "523 tests"
 reject_in_file "$README" "1,076 tests"


### PR DESCRIPTION
Refs #383

## Summary

Milestone X sandbox-deployment guidance for the untrusted-input checklist item.

- Adds `docs/sandbox_deployment.md` as the canonical runbook for untrusted or tenant-controlled `.ll`, `.bc`, LRIR, object, source-derived, fuzz, reducer, and JIT inputs.
- Covers process/container isolation, Linux seccomp/cgroups, macOS `sandbox-exec`, Windows job objects, host-level CPU/memory/wall-clock/temp-storage limits, temp-dir hygiene, JIT disablement, and pilot sign-off checks.
- Links the runbook from README, `docs/production_support_boundaries.md`, and `docs/production_operations.md`.
- Extends `scripts/production_ops_docs.sh` so the sandbox guidance and links stay guarded in CI.

## Validation

- `scripts/production_ops_docs.sh`
- `cargo +stable fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check` before commit

## Notes

This PR is intentionally docs-only and should not conflict with the parser/resource-limit work on Milestone X.