### PR TITLE
Add parser resource limits for untrusted IR

### DIFF
--- a/docs/sandbox_deployment.md
+++ b/docs/sandbox_deployment.md
@@ -41,9 +41,9 @@ untrusted.
 
 ## Resource Limits
 
-Apply host-level limits even after parser or optimizer limit knobs are wired
-into the API. In-process limits protect algorithmic code paths; OS/container
-limits protect the embedding application.
+Apply host-level limits even when using parser or optimizer limit knobs.
+In-process limits protect algorithmic code paths; OS/container limits protect
+the embedding application.
 
 | Resource | Guidance |
 |---|---|
@@ -53,7 +53,31 @@ limits protect the embedding application.
 | Output size | Cap object, assembly, log, reducer, and benchmark artifact sizes. Refuse to archive unbounded stdout/stderr. |
 | File descriptors and processes | Apply `RLIMIT_NOFILE` and `RLIMIT_NPROC`/container process limits. |
 | Temporary storage | Use a request-scoped temp directory with a quota. Never reuse temp paths across tenants. |
-| Recursion and nesting | Use the parser/resource-limit API when available; until then, rely on worker timeouts and memory caps. |
+| Recursion and nesting | Use `parse_with_limits` / `ParseLimits` or the `llvm-compile` parse-limit flags for source size, function count, block/instruction count, and type/constant nesting. Keep worker timeouts and memory caps as the outer guard. |
+
+Parser limits are opt-in so trusted existing callers keep historical behavior.
+For untrusted LLVM text IR, use the library API:
+
+```rust
+use llvm_ir_parser::parser::{parse_with_limits, ParseLimits};
+
+let limits = ParseLimits::production_defaults();
+let (_ctx, _module) = parse_with_limits(input, limits)?;
+```
+
+For the `llvm-compile` CLI, use the production preset or override individual
+limits:
+
+```bash
+llvm-compile input.ll -o output.o \
+  --production-parse-limits \
+  --max-input-bytes 16777216 \
+  --max-functions 10000 \
+  --max-blocks-per-function 100000 \
+  --max-instructions-per-function 1000000 \
+  --max-type-depth 128 \
+  --max-constant-depth 128
+```
 
 ## Platform Patterns
 

--- a/scripts/production_ops_docs.sh
+++ b/scripts/production_ops_docs.sh
@@ -86,6 +86,8 @@ require_in_file "$SANDBOX_DOC" "## Pilot Sign-Off Checklist"
 require_in_file "$SANDBOX_DOC" "seccomp"
 require_in_file "$SANDBOX_DOC" "sandbox-exec"
 require_in_file "$SANDBOX_DOC" "JIT is disabled"
+require_in_file "$SANDBOX_DOC" "parse_with_limits"
+require_in_file "$SANDBOX_DOC" "--production-parse-limits"
 
 reject_in_file "$README" "523 tests"
 reject_in_file "$README" "1,076 tests"

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -59,6 +59,53 @@ impl From<&LexError> for ParseError {
     }
 }
 
+/// Optional parser resource limits for untrusted LLVM IR input.
+///
+/// `None` means unlimited. The existing [`parse`] entry point uses
+/// [`ParseLimits::unlimited`] for compatibility; production callers should use
+/// [`parse_with_limits`] with limits appropriate for their sandbox budget.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ParseLimits {
+    /// Maximum source text size in bytes.
+    pub max_source_bytes: Option<usize>,
+    /// Maximum number of functions/declarations in one module.
+    pub max_functions: Option<usize>,
+    /// Maximum number of basic blocks in one function.
+    pub max_blocks_per_function: Option<usize>,
+    /// Maximum number of instructions, including terminators, in one function.
+    pub max_instructions_per_function: Option<usize>,
+    /// Maximum recursive nesting while parsing types.
+    pub max_type_depth: Option<usize>,
+    /// Maximum recursive nesting while parsing constant/value expressions.
+    pub max_constant_depth: Option<usize>,
+}
+
+impl ParseLimits {
+    /// No parser limits. This preserves the historical parser behavior.
+    pub const fn unlimited() -> Self {
+        Self {
+            max_source_bytes: None,
+            max_functions: None,
+            max_blocks_per_function: None,
+            max_instructions_per_function: None,
+            max_type_depth: None,
+            max_constant_depth: None,
+        }
+    }
+
+    /// Conservative defaults for process-isolated production pilots.
+    pub const fn production_defaults() -> Self {
+        Self {
+            max_source_bytes: Some(16 * 1024 * 1024),
+            max_functions: Some(10_000),
+            max_blocks_per_function: Some(100_000),
+            max_instructions_per_function: Some(1_000_000),
+            max_type_depth: Some(128),
+            max_constant_depth: Some(128),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Parser state
 // ---------------------------------------------------------------------------
@@ -67,6 +114,9 @@ struct Parser<'src> {
     lex: Lexer<'src>,
     ctx: Context,
     module: Module,
+    limits: ParseLimits,
+    type_depth: usize,
+    constant_depth: usize,
     /// Named block forward references: name → BlockId already allocated.
     pending_blocks: HashMap<String, BlockId>,
     /// Current function being parsed (None at module level).
@@ -89,11 +139,14 @@ struct Parser<'src> {
 }
 
 impl<'src> Parser<'src> {
-    fn new(src: &'src str) -> Self {
+    fn new_with_limits(src: &'src str, limits: ParseLimits) -> Self {
         Parser {
             lex: Lexer::new(src),
             ctx: Context::new(),
             module: Module::new(""),
+            limits,
+            type_depth: 0,
+            constant_depth: 0,
             pending_blocks: HashMap::new(),
             current_func: None,
             current_block: None,
@@ -102,6 +155,61 @@ impl<'src> Parser<'src> {
             pending_phi_patches: Vec::new(),
             staged_phi_patches: Vec::new(),
         }
+    }
+
+    fn limit_err(&self, what: &str, actual: usize, max: usize) -> ParseError {
+        self.err(format!(
+            "parse limit exceeded: {what} {actual} exceeds maximum {max}"
+        ))
+    }
+
+    fn check_limit(
+        &self,
+        limit: Option<usize>,
+        actual: usize,
+        what: &str,
+    ) -> Result<(), ParseError> {
+        if let Some(max) = limit {
+            if actual > max {
+                return Err(self.limit_err(what, actual, max));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_next_function(&self) -> Result<(), ParseError> {
+        self.check_limit(
+            self.limits.max_functions,
+            self.module.functions.len() + 1,
+            "function count",
+        )
+    }
+
+    fn check_next_block(&self, fid: usize) -> Result<(), ParseError> {
+        self.check_limit(
+            self.limits.max_blocks_per_function,
+            self.module.functions[fid].blocks.len() + 1,
+            "basic blocks per function",
+        )
+    }
+
+    fn alloc_block_limited(&mut self, fid: usize, name: &str) -> Result<BlockId, ParseError> {
+        self.check_next_block(fid)?;
+        let bb = BasicBlock::new(name);
+        Ok(self.module.functions[fid].add_block(bb))
+    }
+
+    fn alloc_instr_limited(
+        &mut self,
+        fid: usize,
+        instr: Instruction,
+    ) -> Result<InstrId, ParseError> {
+        self.check_limit(
+            self.limits.max_instructions_per_function,
+            self.module.functions[fid].instructions.len() + 1,
+            "instructions per function",
+        )?;
+        Ok(self.module.functions[fid].alloc_instr(instr))
     }
 
     fn err(&self, msg: impl Into<String>) -> ParseError {
@@ -389,6 +497,21 @@ impl<'src> Parser<'src> {
     // -----------------------------------------------------------------------
 
     fn parse_type(&mut self) -> Result<TypeId, ParseError> {
+        self.type_depth += 1;
+        let result = if let Some(max) = self.limits.max_type_depth {
+            if self.type_depth > max {
+                Err(self.limit_err("type nesting depth", self.type_depth, max))
+            } else {
+                self.parse_type_inner()
+            }
+        } else {
+            self.parse_type_inner()
+        };
+        self.type_depth -= 1;
+        result
+    }
+
+    fn parse_type_inner(&mut self) -> Result<TypeId, ParseError> {
         let base = match self.lex.peek()? {
             Token::Kw(Keyword::Void) => {
                 self.lex.next()?;
@@ -594,6 +717,7 @@ impl<'src> Parser<'src> {
         }
 
         if is_declaration {
+            self.check_next_function()?;
             let mut func = Function::new_declaration(&name, fn_ty, args, linkage);
             func.strictfp = has_strictfp;
             let idx = self.module.add_function(func);
@@ -602,6 +726,7 @@ impl<'src> Parser<'src> {
         }
 
         // Parse body.
+        self.check_next_function()?;
         let mut func = Function::new(&name, fn_ty, args, linkage);
         func.strictfp = has_strictfp;
         let idx = self.module.add_function(func);
@@ -686,14 +811,12 @@ impl<'src> Parser<'src> {
         let fid = self
             .current_func
             .ok_or_else(|| self.err("block outside function"))?;
-        let func = &mut self.module.functions[fid];
 
         // Reuse pre-allocated BlockId if this block was forward-referenced.
         let bid = if let Some(&existing) = self.pending_blocks.get(&bb_name) {
             existing
         } else {
-            let bb = BasicBlock::new(&bb_name);
-            let bid = func.add_block(bb);
+            let bid = self.alloc_block_limited(fid, &bb_name)?;
             self.pending_blocks.insert(bb_name.clone(), bid);
             bid
         };
@@ -778,7 +901,7 @@ impl<'src> Parser<'src> {
 
         let instr_name = result_name.clone();
         let instr = Instruction::new(instr_name, ty, kind);
-        let iid = self.module.functions[fid].alloc_instr(instr);
+        let iid = self.alloc_instr_limited(fid, instr)?;
 
         // If parse_instr_kind staged any phi forward-ref patches, bind them to iid now.
         if !self.staged_phi_patches.is_empty() {
@@ -1921,6 +2044,21 @@ impl<'src> Parser<'src> {
     }
 
     fn parse_value(&mut self, ty: TypeId) -> Result<ValueRef, ParseError> {
+        self.constant_depth += 1;
+        let result = if let Some(max) = self.limits.max_constant_depth {
+            if self.constant_depth > max {
+                Err(self.limit_err("constant nesting depth", self.constant_depth, max))
+            } else {
+                self.parse_value_inner(ty)
+            }
+        } else {
+            self.parse_value_inner(ty)
+        };
+        self.constant_depth -= 1;
+        result
+    }
+
+    fn parse_value_inner(&mut self, ty: TypeId) -> Result<ValueRef, ParseError> {
         match self.lex.peek()? {
             Token::LocalIdent(_) => {
                 let name = self.lex.expect_local_ident()?;
@@ -2143,8 +2281,7 @@ impl<'src> Parser<'src> {
                 ptr,
                 indices,
             };
-            let iid =
-                self.module.functions[fid].alloc_instr(Instruction::new(None, result_ty, kind));
+            let iid = self.alloc_instr_limited(fid, Instruction::new(None, result_ty, kind))?;
             self.module.functions[fid].block_mut(bid).append_instr(iid);
             Ok(ValueRef::Instruction(iid))
         } else {
@@ -2184,7 +2321,7 @@ impl<'src> Parser<'src> {
 
         if let (Some(fid), Some(bid)) = (self.current_func, self.current_block) {
             let kind = make_kind(val, dst_ty);
-            let iid = self.module.functions[fid].alloc_instr(Instruction::new(None, dst_ty, kind));
+            let iid = self.alloc_instr_limited(fid, Instruction::new(None, dst_ty, kind))?;
             self.module.functions[fid].block_mut(bid).append_instr(iid);
             Ok(ValueRef::Instruction(iid))
         } else {
@@ -2293,8 +2430,7 @@ impl<'src> Parser<'src> {
         if let Some(&bid) = self.pending_blocks.get(name) {
             return Ok(bid);
         }
-        let bb = BasicBlock::new(name);
-        let bid = self.module.functions[fid].add_block(bb);
+        let bid = self.alloc_block_limited(fid, name)?;
         self.pending_blocks.insert(name.to_string(), bid);
         Ok(bid)
     }
@@ -3201,7 +3337,25 @@ impl<'src> Parser<'src> {
 
 /// Public API for `parse`.
 pub fn parse(src: &str) -> Result<(Context, Module), ParseError> {
-    let mut parser = Parser::new(src);
+    parse_with_limits(src, ParseLimits::unlimited())
+}
+
+/// Parse LLVM IR with explicit resource limits.
+pub fn parse_with_limits(src: &str, limits: ParseLimits) -> Result<(Context, Module), ParseError> {
+    if let Some(max) = limits.max_source_bytes {
+        if src.len() > max {
+            return Err(ParseError {
+                line: 1,
+                col: 1,
+                message: format!(
+                    "parse limit exceeded: source bytes {} exceeds maximum {}",
+                    src.len(),
+                    max
+                ),
+            });
+        }
+    }
+    let mut parser = Parser::new_with_limits(src, limits);
     parser.parse_module()?;
     Ok((parser.ctx, parser.module))
 }
@@ -3270,6 +3424,91 @@ define void %3, i64@au";
             Err(err) => err,
         };
         assert!(err.message.contains("expected RParen"));
+    }
+
+    fn expect_limited(src: &str, limits: ParseLimits, needle: &str) {
+        let err = match parse_with_limits(src, limits) {
+            Ok(_) => panic!("input should hit parse limit"),
+            Err(err) => err,
+        };
+        assert!(
+            err.message.contains(needle),
+            "expected limit message containing {needle:?}, got {:?}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn parse_limits_reject_source_bytes() {
+        let src = "define void @f() { entry: ret void }";
+        let mut limits = ParseLimits::unlimited();
+        limits.max_source_bytes = Some(src.len() - 1);
+        expect_limited(src, limits, "source bytes");
+    }
+
+    #[test]
+    fn parse_limits_reject_function_count() {
+        let src = "\
+declare void @a()
+declare void @b()
+";
+        let mut limits = ParseLimits::unlimited();
+        limits.max_functions = Some(1);
+        expect_limited(src, limits, "function count");
+    }
+
+    #[test]
+    fn parse_limits_reject_blocks_per_function() {
+        let src = r#"
+define void @f(i1 %c) {
+entry:
+  br i1 %c, label %a, label %b
+a:
+  ret void
+b:
+  ret void
+}
+"#;
+        let mut limits = ParseLimits::unlimited();
+        limits.max_blocks_per_function = Some(2);
+        expect_limited(src, limits, "basic blocks per function");
+    }
+
+    #[test]
+    fn parse_limits_reject_instructions_per_function() {
+        let src = r#"
+define i32 @f(i32 %x) {
+entry:
+  %a = add i32 %x, 1
+  ret i32 %a
+}
+"#;
+        let mut limits = ParseLimits::unlimited();
+        limits.max_instructions_per_function = Some(1);
+        expect_limited(src, limits, "instructions per function");
+    }
+
+    #[test]
+    fn parse_limits_reject_type_depth() {
+        let src = "@g = global [1 x [1 x i32]] zeroinitializer";
+        let mut limits = ParseLimits::unlimited();
+        limits.max_type_depth = Some(2);
+        expect_limited(src, limits, "type nesting depth");
+    }
+
+    #[test]
+    fn parse_limits_reject_constant_depth() {
+        let src = "@g = constant [1 x i32] [i32 1]";
+        let mut limits = ParseLimits::unlimited();
+        limits.max_constant_depth = Some(1);
+        expect_limited(src, limits, "constant nesting depth");
+    }
+
+    #[test]
+    fn production_parse_limits_allow_small_module() {
+        let src = "define void @f() { entry: ret void }";
+        parse_with_limits(src, ParseLimits::production_defaults())
+            .expect("small module should fit production parser limits");
     }
 
     #[test]

--- a/src/llvm/src/bin/llvm-compile.rs
+++ b/src/llvm/src/bin/llvm-compile.rs
@@ -8,6 +8,17 @@
 //!   -o <output.o>       Output object file path (required)
 //!   -O <level>          Optimization level: 0, 1, 2, 3 (default: 2)
 //!   --target <arch>     Target architecture: x86_64 (default, only supported)
+//!   --production-parse-limits
+//!                       Use conservative parser limits for production pilots
+//!   --max-input-bytes N Maximum input size in bytes
+//!   --max-functions N  Maximum functions/declarations in the module
+//!   --max-blocks-per-function N
+//!                       Maximum basic blocks per function
+//!   --max-instructions-per-function N
+//!                       Maximum instructions per function
+//!   --max-type-depth N  Maximum recursive type nesting
+//!   --max-constant-depth N
+//!                       Maximum recursive constant nesting
 //!
 //! Examples:
 //!   llvm-compile foo.ll -o foo.o
@@ -16,11 +27,16 @@
 
 use std::{env, fs, process::ExitCode};
 
-use llvm::compile::{compile_ir_to_object, host_object_format};
+use llvm::compile::{compile_ir_to_object_with_limits, host_object_format};
+use llvm_ir_parser::parser::ParseLimits;
 use llvm_transforms::OptLevel;
 
 fn usage() -> String {
-    "usage: llvm-compile <input.ll> -o <output.o> [-O <level>] [--target <arch>]".to_string()
+    "usage: llvm-compile <input.ll> -o <output.o> [-O <level>] [--target <arch>] \
+     [--production-parse-limits] [--max-input-bytes N] [--max-functions N] \
+     [--max-blocks-per-function N] [--max-instructions-per-function N] \
+     [--max-type-depth N] [--max-constant-depth N]"
+        .to_string()
 }
 
 fn main() -> ExitCode {
@@ -29,6 +45,7 @@ fn main() -> ExitCode {
     let mut input: Option<String> = None;
     let mut output: Option<String> = None;
     let mut opt_level = OptLevel::O2;
+    let mut parse_limits = ParseLimits::unlimited();
 
     while let Some(arg) = args_iter.next() {
         match arg.as_str() {
@@ -56,6 +73,71 @@ fn main() -> ExitCode {
                     );
                 }
             }
+            "--production-parse-limits" => {
+                parse_limits = ParseLimits::production_defaults();
+            }
+            "--max-input-bytes" => {
+                parse_limits.max_source_bytes =
+                    Some(parse_limit_arg(&mut args_iter, "--max-input-bytes"));
+            }
+            "--max-functions" => {
+                parse_limits.max_functions =
+                    Some(parse_limit_arg(&mut args_iter, "--max-functions"));
+            }
+            "--max-blocks-per-function" => {
+                parse_limits.max_blocks_per_function =
+                    Some(parse_limit_arg(&mut args_iter, "--max-blocks-per-function"));
+            }
+            "--max-instructions-per-function" => {
+                parse_limits.max_instructions_per_function = Some(parse_limit_arg(
+                    &mut args_iter,
+                    "--max-instructions-per-function",
+                ));
+            }
+            "--max-type-depth" => {
+                parse_limits.max_type_depth =
+                    Some(parse_limit_arg(&mut args_iter, "--max-type-depth"));
+            }
+            "--max-constant-depth" => {
+                parse_limits.max_constant_depth =
+                    Some(parse_limit_arg(&mut args_iter, "--max-constant-depth"));
+            }
+            s if s.starts_with("--max-input-bytes=") => {
+                parse_limits.max_source_bytes = Some(parse_limit_value(
+                    &s["--max-input-bytes=".len()..],
+                    "--max-input-bytes",
+                ));
+            }
+            s if s.starts_with("--max-functions=") => {
+                parse_limits.max_functions = Some(parse_limit_value(
+                    &s["--max-functions=".len()..],
+                    "--max-functions",
+                ));
+            }
+            s if s.starts_with("--max-blocks-per-function=") => {
+                parse_limits.max_blocks_per_function = Some(parse_limit_value(
+                    &s["--max-blocks-per-function=".len()..],
+                    "--max-blocks-per-function",
+                ));
+            }
+            s if s.starts_with("--max-instructions-per-function=") => {
+                parse_limits.max_instructions_per_function = Some(parse_limit_value(
+                    &s["--max-instructions-per-function=".len()..],
+                    "--max-instructions-per-function",
+                ));
+            }
+            s if s.starts_with("--max-type-depth=") => {
+                parse_limits.max_type_depth = Some(parse_limit_value(
+                    &s["--max-type-depth=".len()..],
+                    "--max-type-depth",
+                ));
+            }
+            s if s.starts_with("--max-constant-depth=") => {
+                parse_limits.max_constant_depth = Some(parse_limit_value(
+                    &s["--max-constant-depth=".len()..],
+                    "--max-constant-depth",
+                ));
+            }
             s if s.starts_with("-O") => {
                 let level_str = &s[2..];
                 opt_level = OptLevel::parse(level_str)
@@ -82,13 +164,33 @@ fn main() -> ExitCode {
         Err(e) => die(&format!("cannot read {input}: {e}")),
     };
 
-    match compile_ir_to_object(&src, opt_level, fmt) {
+    match compile_ir_to_object_with_limits(&src, opt_level, fmt, parse_limits) {
         Ok(bytes) => match fs::write(&output, &bytes) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => die(&format!("cannot write {output}: {e}")),
         },
         Err(e) => die(&format!("compilation failed: {e}")),
     }
+}
+
+fn parse_limit_arg<I>(args: &mut std::iter::Peekable<I>, flag: &str) -> usize
+where
+    I: Iterator<Item = String>,
+{
+    let value = args
+        .next()
+        .unwrap_or_else(|| die(&format!("{flag} requires an argument")));
+    parse_limit_value(&value, flag)
+}
+
+fn parse_limit_value(value: &str, flag: &str) -> usize {
+    let parsed = value
+        .parse::<usize>()
+        .unwrap_or_else(|_| die(&format!("{flag} requires a positive integer")));
+    if parsed == 0 {
+        die(&format!("{flag} must be greater than zero"));
+    }
+    parsed
 }
 
 fn die(msg: &str) -> ! {

--- a/src/llvm/src/compile.rs
+++ b/src/llvm/src/compile.rs
@@ -15,7 +15,7 @@ use llvm_codegen::{
     },
     ObjectFile, ObjectFormat, Reloc, Section, Symbol,
 };
-use llvm_ir_parser::parser::parse;
+use llvm_ir_parser::parser::{parse_with_limits, ParseLimits};
 use llvm_target_x86::{
     instructions::{MOVSD_LOAD_MR, MOVSD_STORE_RM, MOV_LOAD_MR, MOV_STORE_RM},
     X86Backend, X86Emitter,
@@ -36,7 +36,23 @@ pub fn compile_ir_to_object(
     opt_level: OptLevel,
     fmt: ObjectFormat,
 ) -> Result<Vec<u8>, String> {
-    let (mut ctx, mut module) = parse(src).map_err(|e| format!("parse error: {e}"))?;
+    compile_ir_to_object_with_limits(src, opt_level, fmt, ParseLimits::unlimited())
+}
+
+/// Compile LLVM IR text into a native object file with explicit parser limits.
+///
+/// This is the production-facing entry point for callers that accept untrusted
+/// or size-unknown IR. Optimizer execution is still bounded by the pipeline's
+/// fixed-point iteration cap; process-level CPU/memory isolation should wrap
+/// this call for adversarial inputs.
+pub fn compile_ir_to_object_with_limits(
+    src: &str,
+    opt_level: OptLevel,
+    fmt: ObjectFormat,
+    limits: ParseLimits,
+) -> Result<Vec<u8>, String> {
+    let (mut ctx, mut module) =
+        parse_with_limits(src, limits).map_err(|e| format!("parse error: {e}"))?;
 
     let mut pm = build_pipeline(opt_level);
     pm.run_until_fixed_point(&mut ctx, &mut module, 8);


### PR DESCRIPTION
## Summary

Refs #383.

Adds opt-in parser resource limits for untrusted LLVM text IR:

- `ParseLimits` and `parse_with_limits` in `llvm-ir-parser`
- limits for source bytes, module function count, per-function basic blocks/instructions, type nesting, and constant/value nesting
- `compile_ir_to_object_with_limits` for library callers
- `llvm-compile` flags: `--production-parse-limits`, `--max-input-bytes`, `--max-functions`, `--max-blocks-per-function`, `--max-instructions-per-function`, `--max-type-depth`, `--max-constant-depth`
- sandbox guidance updated to document the API/CLI surfaces, with the production docs guard checking for them

Existing `parse()` behavior remains unlimited for compatibility.

## Validation

- `cargo +stable test -p llvm-in-rust-ir-parser parse_limits -- --nocapture`
- `cargo +stable check -p llvm-in-rust`
- `scripts/production_ops_docs.sh`
- `cargo +stable run -p llvm-in-rust --bin llvm-compile -- src/llvm-ir-parser/tests/fixtures/42_multi_function.ll -o /tmp/llvm-in-rust-limit-smoke.o --max-functions 1` (expected parse-limit failure)
- `cargo +stable test -p llvm-in-rust-ir-parser`
- `cargo +stable clippy --locked -p llvm-in-rust-ir-parser -p llvm-in-rust --all-targets -- -D warnings`
- `cargo +stable fmt --all -- --check`
- `git diff --check`
- `cargo +stable run -p llvm-in-rust --bin llvm-compile -- src/llvm-ir-parser/tests/fixtures/01_int_arith_flags.ll -o /tmp/llvm-in-rust-limit-positive.o -O0 --production-parse-limits`