### PR TITLE
docs: add RC evidence bundle tooling — Milestone Z

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -3,6 +3,14 @@ name: Performance Budget Gate
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Baseline ref/SHA to compare against"
+        required: true
+      head_ref:
+        description: "Candidate ref/SHA to evaluate"
+        required: true
 
 jobs:
   performance_budget:
@@ -14,13 +22,13 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.event.pull_request.base.sha }}
           path: base
 
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event.pull_request.head.sha }}
           path: head
 
       - name: Install Rust stable toolchain
@@ -40,7 +48,7 @@ jobs:
       - name: Compare against performance budget
         working-directory: head
         env:
-          ALLOW_REGRESSION: ${{ contains(github.event.pull_request.labels.*.name, 'perf-regression-accepted') }}
+          ALLOW_REGRESSION: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'perf-regression-accepted') }}
         run: |
           args=()
           if [[ "$ALLOW_REGRESSION" == "true" ]]; then

--- a/docs/release_candidate_protocol.md
+++ b/docs/release_candidate_protocol.md
@@ -62,6 +62,32 @@ Create one tracking issue per candidate and paste this template:
 Decision notes:
 ```
 
+For Milestone Z evidence bundles, generate the checklist comment with:
+
+```bash
+scripts/rc_evidence_bundle.sh \
+  --version 0.1.0 \
+  --rc 1 \
+  --commit <candidate-sha> \
+  --release-owner @<handle> \
+  --artifact-run <url> \
+  --quality-run <url> \
+  --platform-run <url> \
+  --interoperability-run <url> \
+  --differential-run <url> \
+  --golden-run <url> \
+  --sanitizer-run <url-or-waiver:reason> \
+  --fuzz-run <url-or-waiver:reason> \
+  --fuzz-differential-run <url-or-waiver:reason> \
+  --performance-run <url-or-waiver:reason> \
+  --docs-run <url> \
+  --pilot-summary <url-or-waiver:reason>
+```
+
+Every URL should point at the exact candidate commit.  When a lane cannot run
+for that commit, use a `waiver:<reason>` value and explain the follow-up in the
+RC issue before any `GO` decision.
+
 ## Rollback triggers
 
 Rollback or yank the release if any of these occur inside the rollback window:

--- a/scripts/rc_evidence_bundle.sh
+++ b/scripts/rc_evidence_bundle.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/rc_evidence_bundle.sh --version VERSION --rc N --commit SHA --release-owner @handle [options]
+
+Required options:
+  --version VERSION                  Candidate version, for example 0.1.0
+  --rc N                             RC number, for example 1
+  --commit SHA                       Exact candidate commit
+  --release-owner @handle            Release owner to record in the checklist
+
+Evidence options, each must be a GitHub URL or waiver:<reason>:
+  --artifact-run VALUE               Release Artifact Provenance run
+  --quality-run VALUE                Quality Gates run
+  --platform-run VALUE               Platform Matrix Gate run
+  --interoperability-run VALUE       Interoperability Conformance Gate run
+  --differential-run VALUE           Differential Tests (LLVM 19) run
+  --golden-run VALUE                 Golden Codegen Gate run
+  --sanitizer-run VALUE              Sanitizer and UB hardening run
+  --fuzz-run VALUE                   Fuzzing (LLVM-Stress + CSmith) run
+  --fuzz-differential-run VALUE      fuzz-differential run
+  --performance-run VALUE            Performance Budget Gate run
+  --docs-run VALUE                   Production Operations Docs run
+  --pilot-summary VALUE              Pilot workload summary or waiver:<reason>
+
+Optional:
+  --burn-in-start YYYY-MM-DD         Burn-in start date (UTC)
+  --burn-in-end YYYY-MM-DD           Burn-in target/end date (UTC)
+  --provenance-checksum SHA256       Provenance bundle checksum
+  --output FILE                      Write markdown to FILE instead of stdout
+
+The generated markdown is intended for the Milestone Z (#385) issue and the
+roadmap #93 go/no-go comment.
+USAGE
+}
+
+VERSION=""
+RC=""
+COMMIT=""
+RELEASE_OWNER=""
+ARTIFACT_RUN=""
+QUALITY_RUN=""
+PLATFORM_RUN=""
+INTEROP_RUN=""
+DIFFERENTIAL_RUN=""
+GOLDEN_RUN=""
+SANITIZER_RUN=""
+FUZZ_RUN=""
+FUZZ_DIFFERENTIAL_RUN=""
+PERFORMANCE_RUN=""
+DOCS_RUN=""
+PILOT_SUMMARY=""
+BURN_IN_START=""
+BURN_IN_END=""
+PROVENANCE_CHECKSUM=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="${2:?--version requires a value}"; shift 2 ;;
+    --rc) RC="${2:?--rc requires a value}"; shift 2 ;;
+    --commit) COMMIT="${2:?--commit requires a value}"; shift 2 ;;
+    --release-owner) RELEASE_OWNER="${2:?--release-owner requires a value}"; shift 2 ;;
+    --artifact-run) ARTIFACT_RUN="${2:?--artifact-run requires a value}"; shift 2 ;;
+    --quality-run) QUALITY_RUN="${2:?--quality-run requires a value}"; shift 2 ;;
+    --platform-run) PLATFORM_RUN="${2:?--platform-run requires a value}"; shift 2 ;;
+    --interoperability-run) INTEROP_RUN="${2:?--interoperability-run requires a value}"; shift 2 ;;
+    --differential-run) DIFFERENTIAL_RUN="${2:?--differential-run requires a value}"; shift 2 ;;
+    --golden-run) GOLDEN_RUN="${2:?--golden-run requires a value}"; shift 2 ;;
+    --sanitizer-run) SANITIZER_RUN="${2:?--sanitizer-run requires a value}"; shift 2 ;;
+    --fuzz-run) FUZZ_RUN="${2:?--fuzz-run requires a value}"; shift 2 ;;
+    --fuzz-differential-run) FUZZ_DIFFERENTIAL_RUN="${2:?--fuzz-differential-run requires a value}"; shift 2 ;;
+    --performance-run) PERFORMANCE_RUN="${2:?--performance-run requires a value}"; shift 2 ;;
+    --docs-run) DOCS_RUN="${2:?--docs-run requires a value}"; shift 2 ;;
+    --pilot-summary) PILOT_SUMMARY="${2:?--pilot-summary requires a value}"; shift 2 ;;
+    --burn-in-start) BURN_IN_START="${2:?--burn-in-start requires a value}"; shift 2 ;;
+    --burn-in-end) BURN_IN_END="${2:?--burn-in-end requires a value}"; shift 2 ;;
+    --provenance-checksum) PROVENANCE_CHECKSUM="${2:?--provenance-checksum requires a value}"; shift 2 ;;
+    --output) OUTPUT="${2:?--output requires a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+require_non_empty() {
+  local name="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    echo "missing required option: $name" >&2
+    exit 2
+  fi
+}
+
+require_evidence() {
+  local name="$1"
+  local value="$2"
+  require_non_empty "$name" "$value"
+  if [[ "$value" != https://github.com/* && "$value" != waiver:* ]]; then
+    echo "$name must be a GitHub URL or waiver:<reason>" >&2
+    exit 2
+  fi
+}
+
+require_date() {
+  local name="$1"
+  local value="$2"
+  [[ -z "$value" || "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || {
+    echo "$name must use YYYY-MM-DD" >&2
+    exit 2
+  }
+}
+
+require_non_empty "--version" "$VERSION"
+require_non_empty "--rc" "$RC"
+require_non_empty "--commit" "$COMMIT"
+require_non_empty "--release-owner" "$RELEASE_OWNER"
+[[ "$COMMIT" =~ ^[0-9a-fA-F]{7,40}$ ]] || {
+  echo "--commit must be a 7-40 character hex SHA" >&2
+  exit 2
+}
+[[ "$RC" =~ ^[0-9]+$ ]] || {
+  echo "--rc must be numeric" >&2
+  exit 2
+}
+[[ "$RELEASE_OWNER" == @* ]] || {
+  echo "--release-owner must be a Slock/GitHub-style @handle" >&2
+  exit 2
+}
+
+require_evidence "--artifact-run" "$ARTIFACT_RUN"
+require_evidence "--quality-run" "$QUALITY_RUN"
+require_evidence "--platform-run" "$PLATFORM_RUN"
+require_evidence "--interoperability-run" "$INTEROP_RUN"
+require_evidence "--differential-run" "$DIFFERENTIAL_RUN"
+require_evidence "--golden-run" "$GOLDEN_RUN"
+require_evidence "--sanitizer-run" "$SANITIZER_RUN"
+require_evidence "--fuzz-run" "$FUZZ_RUN"
+require_evidence "--fuzz-differential-run" "$FUZZ_DIFFERENTIAL_RUN"
+require_evidence "--performance-run" "$PERFORMANCE_RUN"
+require_evidence "--docs-run" "$DOCS_RUN"
+require_evidence "--pilot-summary" "$PILOT_SUMMARY"
+require_date "--burn-in-start" "$BURN_IN_START"
+require_date "--burn-in-end" "$BURN_IN_END"
+
+DRY_RUN_DATE="$(date -u +%F)"
+RC_TAG="rc-${VERSION}-${RC}"
+PROVENANCE_CHECKSUM="${PROVENANCE_CHECKSUM:-pending}"
+BURN_IN_START="${BURN_IN_START:-pending}"
+BURN_IN_END="${BURN_IN_END:-pending}"
+
+render() {
+  cat <<MD
+# Milestone Z RC evidence: ${VERSION} RC${RC}
+
+- RC tag: \`${RC_TAG}\`
+- Candidate commit: \`${COMMIT}\`
+- Release owner: ${RELEASE_OWNER}
+- Artifact workflow run: ${ARTIFACT_RUN}
+- Provenance bundle checksum: \`${PROVENANCE_CHECKSUM}\`
+- Dry-run date: ${DRY_RUN_DATE}
+- Burn-in window: ${BURN_IN_START} to ${BURN_IN_END}
+
+## Required gates
+
+- [ ] Release artifact dry-run passed for the candidate commit: ${ARTIFACT_RUN}
+- [ ] Quality gates passed for the candidate commit: ${QUALITY_RUN}
+- [ ] Tier-1 host/target platform matrix passed: ${PLATFORM_RUN}
+- [ ] Interoperability conformance passed: ${INTEROP_RUN}
+- [ ] Differential tests against LLVM 19 passed: ${DIFFERENTIAL_RUN}
+- [ ] Golden codegen gate passed or approved baseline update linked: ${GOLDEN_RUN}
+- [ ] Sanitizer/UB gates passed or waiver linked: ${SANITIZER_RUN}
+- [ ] LLVM-Stress/CSmith fuzzing passed or waiver linked: ${FUZZ_RUN}
+- [ ] Differential fuzzing passed or waiver linked: ${FUZZ_DIFFERENTIAL_RUN}
+- [ ] Performance budget passed or accepted-regression rationale linked: ${PERFORMANCE_RUN}
+- [ ] Production operations/docs validation passed: ${DOCS_RUN}
+- [ ] Production pilot completed with upstream LLVM fallback and comparison: ${PILOT_SUMMARY}
+- [ ] No unresolved release-blocking issues remain
+- [ ] Rollback playbook dry-run completed
+
+## Decision
+
+- [ ] GO — promote this candidate to \`v${VERSION}\`
+- [ ] NO-GO — do not promote; reason and next action below
+
+Decision notes:
+MD
+}
+
+if [[ -n "$OUTPUT" ]]; then
+  render > "$OUTPUT"
+else
+  render
+fi

--- a/scripts/release_candidate_protocol.sh
+++ b/scripts/release_candidate_protocol.sh
@@ -26,5 +26,32 @@ require "NO-GO — do not promote"
 require "Release Artifact Provenance"
 require "rollback advisory"
 require 'Stable tags require an explicit `GO` decision'
+require "scripts/rc_evidence_bundle.sh"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+"$ROOT/scripts/rc_evidence_bundle.sh" \
+  --version 0.1.0 \
+  --rc 1 \
+  --commit 0123456789abcdef \
+  --release-owner @release-owner \
+  --artifact-run https://github.com/example/repo/actions/runs/1 \
+  --quality-run https://github.com/example/repo/actions/runs/2 \
+  --platform-run https://github.com/example/repo/actions/runs/3 \
+  --interoperability-run https://github.com/example/repo/actions/runs/4 \
+  --differential-run https://github.com/example/repo/actions/runs/5 \
+  --golden-run https://github.com/example/repo/actions/runs/6 \
+  --sanitizer-run https://github.com/example/repo/actions/runs/7 \
+  --fuzz-run https://github.com/example/repo/actions/runs/8 \
+  --fuzz-differential-run https://github.com/example/repo/actions/runs/9 \
+  --performance-run https://github.com/example/repo/actions/runs/10 \
+  --docs-run https://github.com/example/repo/actions/runs/11 \
+  --pilot-summary waiver:example-pilot-not-run \
+  --burn-in-start 2026-06-03 \
+  --burn-in-end 2026-06-05 \
+  --output "$TMP"
+
+grep -Fq "Milestone Z RC evidence" "$TMP"
+grep -Fq "Production pilot completed" "$TMP"
 
 echo "release candidate protocol is complete"


### PR DESCRIPTION
Refs #385, refs #93

## Summary

Adds the first Milestone Z support PR: exact-commit RC evidence collection.

- Adds `scripts/rc_evidence_bundle.sh`, a validated checklist generator for #385/#93 go/no-go comments.
- Documents the Milestone Z evidence-bundle flow in `docs/release_candidate_protocol.md`.
- Extends `scripts/release_candidate_protocol.sh` so CI exercises the evidence generator.
- Adds `workflow_dispatch` inputs to `Performance Budget Gate` so RC burn-in can cite an exact candidate commit comparison instead of only PR-head evidence.

## Test plan

- [x] `scripts/release_candidate_protocol.sh`
- [x] `scripts/rc_evidence_bundle.sh --version 0.1.0 --rc 1 --commit c32cb5a837ee2e4d014f3bf6205ec6140eff421a --release-owner @Cindy --artifact-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085592 --quality-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085586 --platform-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085574 --interoperability-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085610 --differential-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085590 --golden-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085612 --sanitizer-run waiver:waiting-for-c32cb5a-scheduled-or-manual-run --fuzz-run waiver:waiting-for-c32cb5a-scheduled-or-manual-run --fuzz-differential-run waiver:waiting-for-c32cb5a-scheduled-or-manual-run --performance-run waiver:manual-dispatch-added-by-z-evidence-pr --docs-run https://github.com/yudongusa/LLVM-in-Rust/actions/runs/26920085628 --pilot-summary waiver:pilot-not-started-yet --burn-in-start 2026-06-03 --burn-in-end 2026-06-05`
- [x] `bash -n scripts/rc_evidence_bundle.sh`
- [x] `bash -n scripts/release_candidate_protocol.sh`
- [x] `git diff --check`

## Milestone Z status

After this lands, the next Z step is to generate the initial #385 evidence comment for candidate commit `c32cb5a`, trigger/capture the remaining scheduled/manual lanes, and keep a burn-in reminder through the target window before final go/no-go sign-off.