### PR TITLE
fix: restore fuzz parser regalloc build

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -71,18 +71,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "llvm-analysis"
+name = "llvm-in-rust-analysis"
 version = "0.1.0"
 dependencies = [
- "llvm-ir",
+ "llvm-in-rust-ir",
 ]
 
 [[package]]
-name = "llvm-codegen"
+name = "llvm-in-rust-bitcode"
 version = "0.1.0"
 dependencies = [
- "llvm-analysis",
- "llvm-ir",
+ "llvm-in-rust-ir",
+]
+
+[[package]]
+name = "llvm-in-rust-codegen"
+version = "0.1.0"
+dependencies = [
+ "llvm-in-rust-analysis",
+ "llvm-in-rust-bitcode",
+ "llvm-in-rust-ir",
 ]
 
 [[package]]
@@ -90,38 +98,38 @@ name = "llvm-in-rust-fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
- "llvm-codegen",
- "llvm-ir",
- "llvm-ir-parser",
- "llvm-target-x86",
- "llvm-transforms",
+ "llvm-in-rust-codegen",
+ "llvm-in-rust-ir",
+ "llvm-in-rust-ir-parser",
+ "llvm-in-rust-target-x86",
+ "llvm-in-rust-transforms",
 ]
 
 [[package]]
-name = "llvm-ir"
+name = "llvm-in-rust-ir"
 version = "0.1.0"
 
 [[package]]
-name = "llvm-ir-parser"
+name = "llvm-in-rust-ir-parser"
 version = "0.1.0"
 dependencies = [
- "llvm-ir",
+ "llvm-in-rust-ir",
 ]
 
 [[package]]
-name = "llvm-target-x86"
+name = "llvm-in-rust-target-x86"
 version = "0.1.0"
 dependencies = [
- "llvm-codegen",
- "llvm-ir",
+ "llvm-in-rust-codegen",
+ "llvm-in-rust-ir",
 ]
 
 [[package]]
-name = "llvm-transforms"
+name = "llvm-in-rust-transforms"
 version = "0.1.0"
 dependencies = [
- "llvm-analysis",
- "llvm-ir",
+ "llvm-in-rust-analysis",
+ "llvm-in-rust-ir",
 ]
 
 [[package]]

--- a/fuzz/fuzz_targets/parser.rs
+++ b/fuzz/fuzz_targets/parser.rs
@@ -44,9 +44,17 @@ fn run_codegen(module: &Module, ctx: &llvm_ir::Context) {
         let mut result = allocate_registers(
             &intervals,
             &mf.allocatable_pregs,
+            &mf.allocatable_fp_pregs,
             RegAllocStrategy::LinearScan,
         );
-        insert_spill_reloads(&mut mf, &mut result, MOV_LOAD_MR, MOV_STORE_RM);
+        insert_spill_reloads(
+            &mut mf,
+            &mut result,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+            MOV_LOAD_MR,
+            MOV_STORE_RM,
+        );
         apply_allocation(&mut mf, &result);
         let mut emitter = X86Emitter::new(obj_format);
         let _ = emit_object(&mf, &mut emitter).to_bytes();


### PR DESCRIPTION
## Summary
- update the parser fuzz target for the current register-allocation API
- pass the FP register pool and spill/reload opcodes through the direct codegen path
- refresh the fuzz lockfile to the current `llvm-in-rust-*` package names

## Validation
- `cargo +nightly check --manifest-path fuzz/Cargo.toml --bin parser`
- `cargo +nightly check --manifest-path fuzz/Cargo.toml --bin parser_with_limits`
- `cargo +nightly check --locked --manifest-path fuzz/Cargo.toml --bin parser`
- `cargo fmt --check --manifest-path fuzz/Cargo.toml`
- `git diff --check`

Refs #385.