### PR TITLE
[codex] Harden fuzz crash evidence uploads

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,21 +52,40 @@ jobs:
         continue-on-error: ${{ github.event_name == 'schedule' }}
         run: cargo +nightly fuzz run parser_with_limits -- -max_total_time=120 -max_len=131072
 
+      - name: Upload raw fuzz artifacts before reduction
+        if: ${{ failure() || steps.llvm_stress_fuzz.outcome == 'failure' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvm-stress-raw-fuzz-artifacts-${{ github.run_id }}
+          path: |
+            fuzz/artifacts/**
+            fuzz/corpus/**
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Package reducible fuzz crash evidence
         if: ${{ failure() || steps.llvm_stress_fuzz.outcome == 'failure' }}
         continue-on-error: true
         run: |
           mkdir -p ci-failures/llvm-stress
           shopt -s nullglob
+          reduce_timeout="${LLVM_STRESS_REDUCE_TIMEOUT:-10m}"
           for artifact in fuzz/artifacts/parser/crash-* fuzz/artifacts/parser/timeout-*; do
             if grep -q '^define ' "$artifact"; then
               name=$(basename "$artifact")
-              scripts/reduce_ci_failure.sh \
+              set +e
+              timeout "$reduce_timeout" scripts/reduce_ci_failure.sh \
                 --input "$artifact" \
                 --predicate 'cargo +nightly fuzz run parser {{input}} -- -runs=1' \
                 --evidence-dir "ci-failures/llvm-stress/$name" \
                 --component llvm-ir-parser \
                 --failure-kind fuzz
+              reduce_status=$?
+              set -e
+              if [[ "$reduce_status" -ne 0 ]]; then
+                echo "::warning title=Fuzz reduction incomplete::reducer exited $reduce_status for $artifact; raw artifact was uploaded before reduction"
+              fi
             fi
           done
 


### PR DESCRIPTION
## Summary

- Upload raw LLVM-Stress fuzz artifacts before attempting crash reduction.
- Bound each reducer invocation with `LLVM_STRESS_REDUCE_TIMEOUT` (default `10m`) and emit a warning instead of letting reduction consume the job timeout.

## Root Cause

The replacement Z fuzz evidence run `26996985817` for #385 found an LLVM-Stress fuzz failure, then entered `Package reducible fuzz crash evidence`. That reducer step ran until the job hit the 45 minute timeout, so the later artifact upload step never ran and GitHub retained zero artifacts for triage.

## Milestone Link

Refs #385 and roadmap #93. This is required before rerunning the Milestone Z fuzz evidence on `main`, because the evidence lane must preserve crash inputs even when minimization is slow.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/fuzz.yml')"`
- `git diff --check`

Draft until CI finishes and the review loop is satisfied.