### PR TITLE
fix(parser): reject stray token after terminated implicit entry block

### DIFF
--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -776,7 +776,10 @@ impl<'src> Parser<'src> {
         // Strategy: consume the ident/intlit, then consume the next token.
         // If the next token is `:`, we have a label. Otherwise push both tokens
         // back via unget (the second first, then the first).
-        let bb_name = match self.lex.peek()? {
+        // `explicit_label` records whether we consumed a real `name:` label.
+        // When it is false we fell back to the implicit `entry` block, which is
+        // only legitimate for the very first block of a function.
+        let (bb_name, explicit_label) = match self.lex.peek()? {
             Token::LocalIdent(_) => {
                 // Consume the ident.
                 let n = self.lex.expect_local_ident()?;
@@ -784,12 +787,12 @@ impl<'src> Parser<'src> {
                 let next = self.lex.next()?;
                 if matches!(next, Token::Colon) {
                     // Confirmed label.
-                    n
+                    (n, true)
                 } else {
                     // Not a label — push both tokens back (second first, then first).
                     self.lex.unget(next);
                     self.lex.unget(Token::LocalIdent(n));
-                    "entry".to_string()
+                    ("entry".to_string(), false)
                 }
             }
             Token::IntLit(n) => {
@@ -798,19 +801,35 @@ impl<'src> Parser<'src> {
                 self.lex.next()?;
                 let next = self.lex.next()?;
                 if matches!(next, Token::Colon) {
-                    s
+                    (s, true)
                 } else {
                     self.lex.unget(next);
                     self.lex.unget(Token::IntLit(n));
-                    "entry".to_string()
+                    ("entry".to_string(), false)
                 }
             }
-            _ => "entry".to_string(),
+            _ => ("entry".to_string(), false),
         };
 
         let fid = self
             .current_func
             .ok_or_else(|| self.err("block outside function"))?;
+
+        // Guard against a no-progress loop. parse_block only returns (other than
+        // at `}`) once the block it parsed is terminated, so on re-entry an
+        // implicitly-selected block that already exists and is complete means the
+        // lookahead is stray content after a terminated block (e.g. a bare `%x`
+        // or a malformed token that is not a `label:`). Without this guard we
+        // would unget the token, re-select the complete `entry` block, break
+        // immediately, and return having consumed nothing — and parse_function
+        // would call parse_block forever. Reject with a structured error instead.
+        if !explicit_label {
+            if let Some(&existing) = self.pending_blocks.get(&bb_name) {
+                if self.block_is_complete(existing) {
+                    return Err(self.err("expected block label after terminated block"));
+                }
+            }
+        }
 
         // Reuse pre-allocated BlockId if this block was forward-referenced.
         let bid = if let Some(&existing) = self.pending_blocks.get(&bb_name) {

--- a/src/llvm-ir-parser/tests/negative_inputs.rs
+++ b/src/llvm-ir-parser/tests/negative_inputs.rs
@@ -318,6 +318,43 @@ entry:
     assert_parse_err_contains(src, "expected ");
 }
 
+// ───────── 6. Parser termination (no-progress loops) ──────────────────────
+
+/// Regression for a fuzz-found infinite loop (Milestone Z burn-in, llvm-stress
+/// timeout bucket `567c0234…`). After an implicit `entry` block is terminated,
+/// a stray instruction-shaped token that is *not* a `label:` used to make
+/// `parse_block` re-select the already-complete `entry` block, break without
+/// consuming the token, and return — so `parse_function` called it forever
+/// (libFuzzer killed it on a 60s timeout). The parser must now reject such
+/// stray content with a structured error instead of looping.
+#[test]
+fn stray_token_after_terminated_implicit_entry_is_rejected() {
+    // `unreachable` terminates the implicit entry block; the bare `%x` that
+    // follows has no `=` and no `:`, so it is neither an instruction result nor
+    // a block label. This is the distilled minimum of the fuzz timeout input.
+    let src = "define void @f() {\nunreachable\n%x\n}\n";
+    assert_parse_err_contains(src, "expected block label after terminated block");
+}
+
+/// The same shape with a numeric stray token (`5` is not `5:` and has no `=`)
+/// after a terminated implicit entry must also terminate with an error rather
+/// than spin — the integer-literal label path has the identical hazard.
+#[test]
+fn stray_int_token_after_terminated_implicit_entry_is_rejected() {
+    let src = "define void @f() {\nret void\n5\n}\n";
+    assert_parse_err_contains(src, "expected block label after terminated block");
+}
+
+/// Guardrail: the fix must not reject the legitimate case it sits next to — a
+/// single-block function whose entry block is implicit (no `entry:` label) and
+/// is the only block must still parse cleanly.
+#[test]
+fn implicit_entry_single_block_still_parses() {
+    let src = "define i32 @g() {\n  ret i32 0\n}\n";
+    let (_ctx, module) = parse(src).expect("implicit single-block entry must parse");
+    assert_eq!(module.functions.len(), 1);
+}
+
 // ───────── Smoke: depth-checked round-trip ─────────────────────────────────
 
 /// Negative tests above all assert *rejection*; this one pins the positive


### PR DESCRIPTION
## Problem

Fuzz-discovered infinite loop in the LLVM IR text parser, surfaced during **Milestone Z (#385)** burn-in by the hardened fuzz-evidence pipeline from #400 (llvm-stress timeout bucket `567c0234…`).

Distilled minimum repro — `parse(...)` never returns:

```llvm
define void @f() {
unreachable
%x
}
```

## Root cause

In `parse_block`, after the implicit `entry` block is terminated, a stray instruction-shaped token that is **not** a `label:` (the bare `%x` — no `=`, no `:`) is ungotten, the already-complete `entry` block is re-selected implicitly, the instruction loop breaks immediately (block complete), and `parse_block` returns **without consuming any token**. `parse_function` then re-invokes `parse_block` on the same token forever. No instruction/block is ever allocated, so the `ParseLimits` counters never advance and resource limits cannot break the loop.

## Fix

Thread an `explicit_label` flag through the label-detection match: `true` for a confirmed `name:`, `false` for the implicit `entry` fallback. When an **implicitly**-selected block already exists and is already complete, the lookahead must be stray content after a terminated block — return a structured `ParseError` (`"expected block label after terminated block"`) instead of spinning. Explicit labels and the legitimate first/implicit entry block are untouched.

## Tests

New section 6 in `negative_inputs.rs` (3 tests):
- `stray_token_after_terminated_implicit_entry_is_rejected` — the bare-ident repro now errors.
- `stray_int_token_after_terminated_implicit_entry_is_rejected` — the integer-literal label path has the identical hazard; also covered.
- `implicit_entry_single_block_still_parses` — guardrail that the fix does not reject the legitimate implicit single-block entry.

## Validation (local, `cargo +stable`)

- Both the distilled minimum **and the original 196-byte fuzz artifact** now return a clean error instead of hanging (verified with a hard external timeout).
- Full parser crate green: lib 23, catch_pads 8, **differential 74** (LLVM-19 round-trips — no valid-input regression), negative_inputs 17, parse_basic 27, smoke 12.
- `fmt --check`, `clippy -p llvm-in-rust-ir-parser -D warnings`, and `git diff --check` all clean.

Closes #401
Refs #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)