### PR TITLE
Fix parser rejection of negative type lengths

### DIFF
--- a/src/llvm-ir-parser/src/lexer.rs
+++ b/src/llvm-ir-parser/src/lexer.rs
@@ -593,6 +593,18 @@ impl<'src> Lexer<'src> {
         }
     }
 
+    /// Public API for unsigned grammar positions that do not accept a leading '-'.
+    pub fn expect_nonnegative_uint_lit(&mut self) -> Result<u64, LexError> {
+        match self.next()? {
+            Token::IntLit(n) if n >= 0 => Ok(n as u64),
+            Token::IntLit(n) => {
+                Err(self.make_err(format!("expected unsigned integer literal, got {}", n)))
+            }
+            Token::UIntLit(n) => Ok(n),
+            t => Err(self.make_err(format!("expected integer literal, got {:?}", t))),
+        }
+    }
+
     /// Public API for `expect_string_lit`.
     pub fn expect_string_lit(&mut self) -> Result<String, LexError> {
         match self.next()? {

--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -581,7 +581,7 @@ impl<'src> Parser<'src> {
 
     fn parse_array_type(&mut self) -> Result<TypeId, ParseError> {
         self.lex.expect(&Token::LBracket)?;
-        let len = self.lex.expect_uint_lit()?;
+        let len = self.lex.expect_nonnegative_uint_lit()?;
         self.lex.expect_kw(&Keyword::X)?;
         let elem = self.parse_type()?;
         self.lex.expect(&Token::RBracket)?;
@@ -595,7 +595,8 @@ impl<'src> Parser<'src> {
         if scalable {
             self.lex.expect_kw(&Keyword::X)?;
         }
-        let len = self.lex.expect_uint_lit()? as u32;
+        let raw_len = self.lex.expect_nonnegative_uint_lit()?;
+        let len = u32::try_from(raw_len).map_err(|_| self.err("vector length too large"))?;
         self.lex.expect_kw(&Keyword::X)?;
         let elem = self.parse_type()?;
         self.lex.expect(&Token::RAngle)?;

--- a/src/llvm-ir-parser/tests/negative_inputs.rs
+++ b/src/llvm-ir-parser/tests/negative_inputs.rs
@@ -355,6 +355,39 @@ fn implicit_entry_single_block_still_parses() {
     assert_eq!(module.functions.len(), 1);
 }
 
+// ───────── 7. Unsigned size literals ────────────────────────────────────────
+
+/// Regression for a Milestone Z fuzz crash after the parser-timeout fix. A
+/// malformed vector length such as `<-4 x i16>` used to be accepted by
+/// `expect_uint_lit` via `as u64`, producing a huge vector type and later
+/// overflowing codegen frame-size arithmetic. The parser must reject it at the
+/// source boundary instead.
+#[test]
+fn negative_vector_length_is_rejected() {
+    let src = r#"
+define void @f() {
+entry:
+  %a = alloca <-4 x i16>, align 8
+  ret void
+}
+"#;
+    assert_parse_err_contains(src, "expected unsigned integer literal");
+}
+
+/// Array lengths use the same unsigned literal helper and must reject negative
+/// syntax for the same reason.
+#[test]
+fn negative_array_length_is_rejected() {
+    let src = r#"
+define void @f() {
+entry:
+  %a = alloca [-1 x i8], align 1
+  ret void
+}
+"#;
+    assert_parse_err_contains(src, "expected unsigned integer literal");
+}
+
 // ───────── Smoke: depth-checked round-trip ─────────────────────────────────
 
 /// Negative tests above all assert *rejection*; this one pins the positive


### PR DESCRIPTION
## Summary

- Add a parser lexer helper for unsigned grammar positions that rejects signed negative integer tokens.
- Use it for array and vector type lengths, with an explicit `u32` bounds check for vector lengths.
- Add negative parser regressions for malformed vector and array lengths from the Milestone Z fuzz crash.

## Root Cause

Milestone Z rerun 27376979535 found a new LLVM-Stress crash after the parser no-progress fix. The minimized input used `alloca <-4 x i16>`. The parser accepted `Token::IntLit(-4)` through `expect_uint_lit` via `as u64`, then `parse_vector_type` truncated the value to `u32`; codegen later overflowed while sizing the alloca frame.

## Validation

- `cargo test -p llvm-in-rust-ir-parser --test negative_inputs`
- `cargo fmt --check -p llvm-in-rust-ir-parser`
- `cargo clippy -p llvm-in-rust-ir-parser -- -D warnings`
- `cargo +nightly fuzz run parser artifacts/LLVM-in-Rust/z-fuzz-27376979535/reduced/ci-failures/llvm-stress/crash-b5a92aa151611a01333f609f4ec4cb787e27a906/minimized.ll -- -runs=1`
- `cargo +nightly fuzz run parser artifacts/LLVM-in-Rust/z-fuzz-27376979535/raw/artifacts/parser/crash-b5a92aa151611a01333f609f4ec4cb787e27a906 -- -runs=1`
- `cargo test -p llvm-in-rust-ir-parser`

Closes #403.
Refs #385 and #93.