### PR TITLE
docs: refresh agent skills for RC workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,11 @@ user prompts at each step:
 Plan → Implement → PR Review → Test → Issue+Fix Loop → Merge
 ```
 
-| Stage | Slash skill | Description |
-|-------|-------------|-------------|
-| Implement a phase | `/implement-phase` | Branch → code → targeted tests → commit → PR |
-| Review implementation PR | `/review-and-fix` | Review diff/tests → run full tests → post PR feedback |
-| Fix one issue | `/fix-issue <N>` | Read issue → fix in same PR branch → test → update PR |
+| Stage | Reusable workflow | Description |
+|-------|-------------------|-------------|
+| Implement a phase | issue-specific skill or this guide | Branch → code → targeted tests → commit → PR |
+| Review implementation PR | Mandatory PR Review/Test/Issue Loop below | Review diff/tests → run full tests → post PR feedback |
+| Fix one issue | issue-specific skill or this guide | Read issue → fix in same PR branch → test → update PR |
 
 ### Mandatory PR Review/Test/Issue Loop (for implementation PRs)
 
@@ -99,6 +99,24 @@ These rules prevent common mistakes in the multi-worktree setup:
 ---
 
 ## Agent Usage Guide
+
+### milestone-z-rc-burnin agent
+Use for the current open Milestone Z release-candidate burn-in/sign-off work.
+
+```
+Invoke: $milestone-z-rc-burnin
+When:   Clearing Z blockers, triaging fuzz/evidence reruns, collecting
+        exact-commit RC evidence, updating #385/#93, and coordinating the
+        final go/no-go bundle.
+Skill:  skills/milestone-z-rc-burnin/SKILL.md
+```
+
+### Completed-milestone skills
+
+The skills below are retained as implementation references for their original
+issues and for regressions in the same subsystem.  They are not the default
+entry point for current roadmap work unless their issue reopens or a new issue
+explicitly targets that subsystem.
 
 ### rust-stable-compat agent
 Use for issue #90 and any nightly-to-stable migration work.
@@ -265,9 +283,10 @@ at each step:
    e. Update #93 roadmap and report progress to the user.
 3. After all milestones are done, update `MEMORY.md` and post a final summary.
 
-**Auto-resume after interruption**: Use the `/loop` skill with a self-paced
-interval.  At each wakeup, check GitHub for open milestone sub-issues, pick
-the next one, and resume work.  Never wait for the user to restart.
+**Auto-resume after interruption**: Use agent memory plus Slock reminders or an
+agent-native self-paced loop.  At each wakeup, check GitHub for open milestone
+sub-issues, pick the next one, and resume work.  Never wait for the user to
+restart.
 
 **Progress reporting**: Post one short message per completed milestone:
 which PRs merged, issue numbers closed, and the updated roadmap link.

--- a/skills/milestone-z-rc-burnin/SKILL.md
+++ b/skills/milestone-z-rc-burnin/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: milestone-z-rc-burnin
+description: Execute Milestone Z release-candidate burn-in work for issue #385/#93: unblock parser/fuzz findings, collect exact-commit evidence, publish the go/no-go bundle, and update roadmap status.
+---
+
+# Milestone Z RC Burn-In
+
+Use this skill for the remaining production-readiness roadmap work in
+Milestone Z (#385) and parent roadmap #93.
+
+## When to Use
+
+- A fuzz, differential, sanitizer, platform, release-artifact, or performance
+  gate blocks Milestone Z.
+- An RC evidence PR, go/no-go bundle, or #93/#385 status update is needed.
+- A stalled Z PR needs review/merge/rerun coordination between agents.
+
+Do not use this skill for unrelated feature work or broad refactors.
+
+## Current Gate Order
+
+1. Clear any release-blocking finding with a focused issue and PR.
+2. Require an explicit review comment from another agent or maintainer before
+   merge; do not self-approve.
+3. Merge the blocker fix after all PR checks are green.
+4. Dispatch the exact main-commit Z evidence reruns:
+   - `Fuzzing (LLVM-Stress + CSmith)` with the required CSmith count.
+   - `fuzz-differential`.
+   - `Sanitizer and UB hardening`.
+   - Any exact-commit performance, platform, differential, release-artifact,
+     golden, compatibility, and docs gates required by the RC checklist.
+5. If any rerun fails, download logs/artifacts, create one focused issue, fix
+   it in one PR, and restart this gate order.
+6. Only after all evidence is green, merge the RC evidence tooling/status PRs
+   and publish the #385/#93 go/no-go comment.
+
+## Evidence Handling
+
+- Record run IDs, commit SHAs, artifact IDs, and local artifact paths in the
+  agent memory before pausing or waiting for long CI jobs.
+- Use reminders for CI/review waits instead of leaving a terminal sleep alive.
+- Preserve raw fuzz artifacts before reducing them; reduced inputs are useful
+  only after the raw reproducer is safely stored.
+- Distinguish scheduled burn-in evidence from exact-candidate evidence. A
+  scheduled green run is supportive, but an RC decision must cite the intended
+  pinned commit.
+
+## Validation Before Merge
+
+For docs-only Z tooling changes:
+
+```bash
+bash -n scripts/rc_evidence_bundle.sh
+bash -n scripts/release_candidate_protocol.sh
+scripts/release_candidate_protocol.sh
+git diff --check
+```
+
+For parser/fuzz fixes, at minimum run:
+
+```bash
+cargo test -p llvm-in-rust-ir-parser --test negative_inputs
+cargo fmt --check -p llvm-in-rust-ir-parser
+cargo clippy -p llvm-in-rust-ir-parser -- -D warnings
+cargo +nightly fuzz run parser <raw-or-minimized-reproducer> -- -runs=1
+```
+
+If the fix touches shared crates, broaden to the relevant crate tests and
+workspace tests before review.
+
+## Coordination Rules
+
+- Use the active Slock task thread for status, ownership, and handoffs.
+- Split work explicitly:
+  - one agent owns implementation,
+  - the other owns review or independent evidence verification.
+- Keep #398-style evidence PRs held until all blocker fixes are merged and the
+  exact main-commit reruns are green.
+- After a merge, close the associated issue and update #385/#93 in the same
+  work session.


### PR DESCRIPTION
Refs #93 and #385.
Closes #405.

## Summary
- Add a current `milestone-z-rc-burnin` skill for Milestone Z unblock/review/rerun/evidence work.
- Update `AGENTS.md` to remove references to unavailable slash skills from the development-lifecycle table.
- Mark existing issue-specific skills as completed-milestone references rather than the default path for current roadmap work.
- Replace stale `/loop` auto-resume wording with memory + Slock reminders / agent-native loop guidance.

## Status / Rationale
The active project work is still #385/#93: PR #404 is green and mergeable but unreviewed, and PR #398 remains held until #404 lands and the exact main Z fuzz rerun is green. The repo's skills folder mostly described completed milestone work, so agents did not have a current skill for RC evidence/fuzz triage/sign-off.

## Validation
- `git diff --check`

Docs-only change; no Rust tests required.
