### PR TITLE
fix: satisfy stable 1.97 clippy

### DIFF
--- a/src/llvm-transforms/src/slp.rs
+++ b/src/llvm-transforms/src/slp.rs
@@ -865,7 +865,7 @@ mod tests {
         let has_vec_fadd = func.blocks[0].body.iter().any(|&id| {
             let instr = &func.instructions[id.0 as usize];
             match &instr.kind {
-                InstrKind::FAdd { lhs, rhs: _, .. } => {
+                InstrKind::FAdd { lhs, .. } => {
                     let lhs_ty = match lhs {
                         ValueRef::Instruction(iid) => func.instructions[iid.0 as usize].ty,
                         _ => return false,


### PR DESCRIPTION
Refs #93, #385.
Closes #407.

## Summary
- Remove a redundant `rhs: _` pattern from the SLP vectorization regression test.
- Restore the stable Rust 1.97.1 Quality Gates clippy job that failed on main-derived PRs.

## Root Cause
Stable Rust 1.97.1 clippy reports `unneeded_wildcard_pattern` for `InstrKind::FAdd { lhs, rhs: _, .. }`. Because Quality Gates run with `-D warnings`, this unrelated lint broke PR #406 even though that PR only changes docs/skills.

## Validation
- `cargo +stable clippy --locked -p llvm-in-rust-transforms --tests -- -D warnings`
- `cargo +stable clippy --locked --all-targets -- -D warnings`
- `git diff --check`
