### PR TITLE
fix(parser): reject negative align/aggregate-index unsigned literals

### DIFF
--- a/src/llvm-ir-parser/src/parser.rs
+++ b/src/llvm-ir-parser/src/parser.rs
@@ -1160,7 +1160,7 @@ impl<'src> Parser<'src> {
                 let align = if comma_before_align_consumed {
                     // Comma was already consumed; parse `align N` directly.
                     if self.lex.eat_kw(Keyword::Align) {
-                        let a = self.lex.expect_uint_lit()? as u32;
+                        let a = self.lex.expect_nonnegative_uint_lit()? as u32;
                         Some(a)
                     } else {
                         None
@@ -1403,7 +1403,7 @@ impl<'src> Parser<'src> {
                 let (aggregate, agg_ty) = self.parse_typed_value()?;
                 let mut indices = Vec::new();
                 while self.lex.eat(&Token::Comma) {
-                    let idx = self.lex.expect_uint_lit()? as u32;
+                    let idx = self.lex.expect_nonnegative_uint_lit()? as u32;
                     indices.push(idx);
                 }
                 // Walk the index chain to find the actual element type.
@@ -1427,7 +1427,7 @@ impl<'src> Parser<'src> {
                 let (val, _val_ty) = self.parse_typed_value()?;
                 let mut indices = Vec::new();
                 while self.lex.eat(&Token::Comma) {
-                    let idx = self.lex.expect_uint_lit()? as u32;
+                    let idx = self.lex.expect_nonnegative_uint_lit()? as u32;
                     indices.push(idx);
                 }
                 Ok((
@@ -2566,7 +2566,7 @@ impl<'src> Parser<'src> {
     fn parse_optional_align(&mut self) -> Result<Option<u32>, ParseError> {
         if self.lex.eat(&Token::Comma) {
             self.lex.expect_kw(&Keyword::Align)?;
-            let a = self.lex.expect_uint_lit()? as u32;
+            let a = self.lex.expect_nonnegative_uint_lit()? as u32;
             Ok(Some(a))
         } else {
             Ok(None)

--- a/src/llvm-ir-parser/tests/negative_inputs.rs
+++ b/src/llvm-ir-parser/tests/negative_inputs.rs
@@ -388,6 +388,70 @@ entry:
     assert_parse_err_contains(src, "expected unsigned integer literal");
 }
 
+// ───────── 8. Unsigned align / aggregate-index literals ────────────────────
+
+// Follow-up to #404 (issue #409): alignment and aggregate-index operands used
+// the same `expect_uint_lit` + `as` cast that silently wrapped a negative
+// literal to a huge unsigned value. They now route through the nonnegative
+// helper and must reject negative syntax at the source boundary.
+
+/// `align` operands (here on a `load`, via `parse_optional_align`).
+#[test]
+fn negative_load_alignment_is_rejected() {
+    let src = r#"
+define i32 @f(ptr %p) {
+entry:
+  %v = load i32, ptr %p, align -8
+  ret i32 %v
+}
+"#;
+    assert_parse_err_contains(src, "expected unsigned integer literal");
+}
+
+/// `extractvalue` aggregate indices.
+#[test]
+fn negative_extractvalue_index_is_rejected() {
+    let src = r#"
+define i32 @f() {
+entry:
+  %v = extractvalue {i32, i32} undef, -1
+  ret i32 %v
+}
+"#;
+    assert_parse_err_contains(src, "expected unsigned integer literal");
+}
+
+/// `insertvalue` aggregate indices.
+#[test]
+fn negative_insertvalue_index_is_rejected() {
+    let src = r#"
+define void @f() {
+entry:
+  %v = insertvalue {i32, i32} undef, i32 5, -1
+  ret void
+}
+"#;
+    assert_parse_err_contains(src, "expected unsigned integer literal");
+}
+
+/// Guardrail: valid non-negative align/index operands must still parse, so the
+/// hardening above does not over-reject well-formed input.
+#[test]
+fn nonnegative_align_and_indices_still_parse() {
+    let src = r#"
+define i32 @f(ptr %p) {
+entry:
+  %v = load i32, ptr %p, align 8
+  %e = extractvalue {i32, i32} undef, 1
+  %w = insertvalue {i32, i32} undef, i32 5, 0
+  ret i32 %v
+}
+"#;
+    parse(src)
+        .map_err(|e| format!("valid align/index program rejected: {}", e.message))
+        .unwrap();
+}
+
 // ───────── Smoke: depth-checked round-trip ─────────────────────────────────
 
 /// Negative tests above all assert *rejection*; this one pins the positive


### PR DESCRIPTION
## Summary

Follow-up to #404 (issue #409). PR #404 hardened array/vector **type lengths** against negative unsigned literals. This finishes the same class of gap for the two remaining positions I flagged in that review:

- **alignment** operands (`align N` — `parse_optional_align` and the comma-consumed align path)
- **aggregate-index** operands (`extractvalue` / `insertvalue`)

## Root Cause

These four positions still called `expect_uint_lit`, which accepts `Token::IntLit(-n)` and casts via `as` — silently wrapping a negative literal to a huge unsigned value (e.g. `align -8` → a giant `u32`). They now route through the existing `expect_nonnegative_uint_lit` helper introduced in #404, rejecting negatives at the lexer boundary.

Scope kept tight: `as u32` is retained (positive-value behavior unchanged — this PR only closes the negative-wrap). Const-int values (raw bit pattern), attribute-group ids, and metadata node ids intentionally keep `expect_uint_lit` and are out of scope.

## Validation

- `cargo +stable test -p llvm-in-rust-ir-parser --test negative_inputs` — 23 pass (4 new)
- `cargo +stable test -p llvm-in-rust-ir-parser` — full suite green incl. the 74-test LLVM-19 differential round-trip
- `cargo +stable fmt -p llvm-in-rust-ir-parser -- --check` — clean
- `cargo +stable clippy -p llvm-in-rust-ir-parser -- -D warnings` — clean

New tests: `negative_load_alignment_is_rejected`, `negative_extractvalue_index_is_rejected`, `negative_insertvalue_index_is_rejected`, and a `nonnegative_align_and_indices_still_parse` guardrail.

Closes #409. Refs #404, #403, #385.