### PR TITLE
docs: mark scoped production readiness after Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A SemVer policy covering the pre-1.0 series, the 1.0 readiness bar, and post-1.0 compatibility rules.
 - Production support-boundary documentation covering constrained pilots, unsupported general LLVM replacement use, unsupported untrusted-input use, backend/platform limits, and the pre-1.0 API stability matrix.
 - Documentation-truth checks for stale README/changelog status markers and release metadata.
+- Scoped production-ready status wording after Milestone Z RC2 burn-in and production-pilot sign-off, with upstream LLVM fallback required by the public support contract.
+
+### Changed
+
+- README and production support boundaries now describe scoped, fallback-backed production readiness after the completed Milestone Z evidence stage.
 
 ### Milestone L — API & documentation polish
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ elimination (`opt_pipeline.rs`) and a full hello-world IR program (`hello_world.
 
 ## Status
 
-LLVM-in-Rust is in a production-readiness stage, not a general drop-in LLVM
-replacement. Milestones A-U in the production roadmap are complete; the
-2026-05-26 audit added release-blocking follow-up Milestones V-Z before any
-general production-ready declaration.
+LLVM-in-Rust is production-ready for scoped, fallback-backed use cases, not a
+general drop-in LLVM replacement. The production-readiness roadmap through
+Milestone Z is complete for the RC2 candidate (`d4a11b2`), with support limited
+to trusted inputs, validated backend/platform combinations, and an upstream LLVM
+fallback for unsupported or divergent programs.
 
 | Use case | Status | Boundary |
 |---|---|---|
-| Constrained production pilots | Supported with controls | Trusted LLVM 15+ opaque-pointer IR, pinned commits/releases, green release-blocking CI, and an explicitly supported backend/object-format combination. |
-| General LLVM replacement | Not supported yet | The project still has open V-Z audit follow-ups, backend contract gaps, and RC burn-in requirements. |
+| Scoped production use | Production-ready with controls | Trusted LLVM 15+ opaque-pointer IR, pinned commits/releases, green release-blocking CI, an explicitly supported backend/object-format combination, and documented upstream LLVM fallback. |
+| General LLVM replacement | Not supported | The Milestone Z pilot showed that fallback remains required; broad parser, backend, runtime, and platform coverage is not complete enough for standalone/drop-in LLVM replacement use. |
 | Untrusted or adversarial input | Not supported without sandboxing | Parser, optimizer, codegen, and JIT paths must run behind external process/container isolation, CPU/memory limits, and JIT disablement where inputs are not trusted. |
 
 The workspace test inventory changes frequently and is intentionally not
@@ -79,7 +80,7 @@ optimization, codegen, object emission, or JIT paths.
 LLVM-in-Rust follows [Semantic Versioning](https://semver.org/) with an explicit pre-1.0 stability policy:
 
 - **`0.x.y` releases:** no public API stability guarantee. Any `0.x` minor-version bump may include breaking public API changes as the IR model, pass interfaces, and backend traits continue to mature.
-- **`1.0.0` readiness:** the project will not declare a stable 1.0 API until the production-readiness roadmap's V-Z follow-up milestones are complete, release-candidate burn-in has passed, and maintainers have signed off at least one constrained production pilot with documented fallback.
+- **`1.0.0` readiness:** scoped `0.x` production readiness does not imply a stable 1.0 API. The project will not declare 1.0 until production-backed API surfaces have operational history, unsupported backend cells are resolved or permanently scoped, and maintainers approve a stable compatibility policy.
 - **Post-1.0 releases:** standard SemVer rules apply. Breaking API changes are reserved for major versions and include a documented deprecation/migration cycle.
 
 The pre-1.0 API stability matrix lives in

--- a/docs/production_support_boundaries.md
+++ b/docs/production_support_boundaries.md
@@ -1,15 +1,15 @@
 # Production Support Boundaries
 
 This document is the public support contract for the pre-1.0 series. It
-distinguishes constrained production pilots from general production readiness
-and from unsupported deployment modes.
+defines the scoped production-ready contract, keeps that contract distinct from
+general LLVM replacement readiness, and records unsupported deployment modes.
 
 ## Production Scope
 
 | Scenario | Status | Requirements and limits |
 |---|---|---|
-| Constrained internal or pilot workload | Supported with controls | Trusted LLVM 15+ opaque-pointer IR; pinned LLVM-in-Rust commit or release; target/backend selected from the matrix below; release-blocking CI green on that commit; fallback to upstream LLVM documented by the embedding project. |
-| General drop-in replacement for LLVM | Not supported | LLVM IR, backend, runtime, and platform coverage are broad but not complete. Milestones V-Z in #93 must complete before a general production-ready declaration. |
+| Scoped fallback-backed production workload | Production-ready with controls | Trusted LLVM 15+ opaque-pointer IR; pinned LLVM-in-Rust commit or release; target/backend selected from the matrix below; release-blocking CI green on that commit; fallback to upstream LLVM documented and exercised by the embedding project. |
+| General drop-in replacement for LLVM | Not supported | LLVM IR, backend, runtime, and platform coverage are broad but not complete. The Milestone Z pilot validated a fallback-backed posture, not standalone compiler replacement readiness. |
 | Untrusted or adversarial IR/object input | Not supported without sandboxing | Run parser, optimizer, codegen, and JIT paths in a separate process/container with CPU, memory, file-system, and wall-clock limits. Disable JIT for hostile input unless the host already has a hardened executable-memory policy. See `docs/sandbox_deployment.md`. |
 | Research, benchmarking, and compiler experiments | Supported | APIs and behavior may change across `0.x` minor releases; pin revisions and record validation commands when publishing results. |
 
@@ -30,10 +30,10 @@ and from unsupported deployment modes.
 | Area | Current production contract | Known limits |
 |---|---|---|
 | x86-64 native backend | Pilot-supported for trusted IR through the tested integer, FP/SIMD, atomics, calls, object emission, debug, unwind, LTO, and JIT paths. SysV and Win64 ABI coverage are both represented in tests. | Not a general LLVM `-O2` quality replacement. Inline asm constraints, exotic relocations, and cross-language EH runtime behavior remain scoped/experimental. |
-| AArch64 backend | Pilot-supported for trusted IR object generation and tested integer, FP/SIMD, atomics, calls, debug, unwind metadata, and LTO payload paths. | Runtime execution coverage is narrower than x86-64. Full platform-linker and language EH interop require the Milestone Y support-contract matrix. |
-| RISC-V RV64GC backend | Experimental pilot support for artifact generation, integer/FP calling convention subsets, atomics, object emission, and backend tests. | Runtime linker/execution coverage and some lowering quality paths remain under Milestone Y. |
+| AArch64 backend | Pilot-supported for trusted IR object generation and tested integer, FP/SIMD, atomics, calls, debug, unwind metadata, and LTO payload paths. | Runtime execution coverage is narrower than x86-64. Full platform-linker and language EH interop remain scoped by the backend support matrix. |
+| RISC-V RV64GC backend | Experimental pilot support for artifact generation, integer/FP calling convention subsets, atomics, object emission, and backend tests. | Runtime linker/execution coverage and lowering quality paths remain pilot/experimental where the backend support matrix marks them so. |
 | WebAssembly backend | Experimental. Can emit wasm modules for simple functions and supported control-flow shapes. | Arbitrary CFG/relooper completeness, stack-frame allocation for `alloca`, loop phi destruction, indirect calls, external imports, FP/vector/atomic breadth, and host execution contracts are not production-supported yet. |
-| JIT execution engine | Experimental x86-64 pilot surface for trusted IR in controlled hosts. | Uses executable memory. Do not expose to untrusted input without process isolation and host-level memory-execution policy. Keep JIT smoke and differential tests green before any pilot sign-off. |
+| JIT execution engine | Experimental x86-64 pilot surface for trusted IR in controlled hosts. | Uses executable memory. Do not expose to untrusted input without process isolation and host-level memory-execution policy. Keep JIT smoke and differential tests green for each scoped production use. |
 | rustc backend | Experimental proof-of-concept/staged backend driver. Stable-compatible shim tests and nightly lanes exist. | Real `rustc_private`/`rustc_codegen_ssa` integration and nightly-driver support are not a general production backend contract. |
 | LTO | Pilot-supported for embedding and recovering LRIR payloads in ELF/COFF (`.llvmbc`, `.llvmcmd`) and Mach-O (`__LLVM,__bitcode`, `__LLVM,__cmdline`) objects. | LRIR is project-specific and not LLVM bitcode. Cross-toolchain LTO compatibility with upstream LLVM is not supported. |
 | Debug and unwind | Pilot-supported metadata/object sections include DWARF line/info/loclist paths, ELF `.eh_frame`, COFF `.pdata`/`.xdata`, and CodeView `.debug$S` where implemented. | Unwind data is not a full language-runtime EH guarantee. Mach-O unwind parity and cross-language throw/catch interop remain experimental. |
@@ -52,8 +52,8 @@ hostile inputs.
 
 ## Documentation Truth Policy
 
-- README status language must stay scoped: "pilot-supported" and "production-ready"
-  are not interchangeable.
+- README status language must stay scoped: "production-ready" means scoped,
+  fallback-backed production use with controls, not general LLVM replacement.
 - Hard-coded test counts are avoided in public status text. CI and the validation
   commands in `docs/production_operations.md` are the current quality signal.
 - Feature tables must distinguish IR parse/round-trip support from backend


### PR DESCRIPTION
## Summary

Refs #93
Refs #385

Updates the public docs after the completed Milestone Z RC2 evidence bundle and maintainer direction to work through the remaining roadmap tasks.

- changes the README status from a pending production-readiness stage to scoped, fallback-backed production readiness
- keeps general/drop-in LLVM replacement and untrusted-input use explicitly unsupported
- updates the production support-boundary contract and changelog to match the Milestone Z outcome

## Scope

This is intentionally docs-only. It does not create a stable 1.0 API promise, remove the upstream LLVM fallback requirement, or broaden support beyond trusted inputs and validated backend/platform combinations.

## Roadmap Evidence

- Final #385 RC2 bundle: https://github.com/yudongusa/LLVM-in-Rust/issues/385#issuecomment-5061187761
- Independent final review: https://github.com/yudongusa/LLVM-in-Rust/issues/385#issuecomment-5061208745
- Consolidated #93 go/no-go checklist: https://github.com/yudongusa/LLVM-in-Rust/issues/93#issuecomment-5073399583

## Validation

- `git diff --check`
- `scripts/production_ops_docs.sh`
- `bash -n scripts/release_candidate_protocol.sh`
- `scripts/release_candidate_protocol.sh`
